### PR TITLE
buildsystem improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 2.8)
 project(Gothic2Notr)
 set (CMAKE_CXX_STANDARD 14)
 
-include_directories("Game")
+option(BUILD_SHARED_LIBS "Build shared libraries." OFF)
+option(BUILD_SHARED_MOLTEN_TEMPEST "Build shared MoltenTempest." ${BUILD_SHARED_LIBS})
 
 set(CMAKE_DEBUG_POSTFIX "")
 
@@ -15,11 +16,11 @@ if(POLICY CMP0015)
   cmake_policy(SET CMP0015 OLD)
 endif()
 
-set(CMAKE_BINARY_DIR ../)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
 
+
+# OpenGothic
 file(GLOB SOURCES
     "Game/*.h"
     "Game/*.cpp"
@@ -31,6 +32,24 @@ file(GLOB SOURCES
     "Game/**/**/**/*.cpp"
   )
 
+add_executable(${PROJECT_NAME} ${SOURCES} icon.rc )
+
+include_directories("Game")
+
+add_subdirectory(lib/edd-dbg)
+include_directories(lib/edd-dbg/include)
+if(WIN32)
+  target_link_libraries(${PROJECT_NAME} edd_dbg)
+endif()
+
+if(WIN32)
+  target_link_libraries(${PROJECT_NAME} shlwapi DbgHelp)
+elseif(UNIX)
+  target_link_libraries(${PROJECT_NAME} -lpthread)
+endif()
+
+
+# Vulkan
 if("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
   link_directories(${PROJECT_NAME} "$ENV{VK_SDK_PATH}/lib")
 else()
@@ -39,22 +58,14 @@ endif()
 
 link_directories(${PROJECT_NAME} "$ENV{VK_SDK_PATH}/lib")
 
-add_executable(${PROJECT_NAME} ${SOURCES} icon.rc )
 
-add_subdirectory(lib/edd-dbg)
-include_directories(lib/edd-dbg/include)
-if(WIN32)
-  target_link_libraries(${PROJECT_NAME} edd_dbg)
-endif()
-
+# ZenLib
 add_subdirectory(lib/ZenLib)
 include_directories(lib/ZenLib)
 target_link_libraries(${PROJECT_NAME} zenload daedalus)
 
-add_subdirectory(lib/MoltenTempest/Engine)
-include_directories(lib/MoltenTempest/Engine/include)
-target_link_libraries(${PROJECT_NAME} MoltenTempest)
 
+# bullet physics
 set(BULLET2_MULTITHREADING ON)
 set(USE_GRAPHICAL_BENCHMARK OFF CACHE STRING "" FORCE)
 set(BUILD_BULLET2_DEMOS OFF CACHE STRING "" FORCE) # No samples
@@ -66,14 +77,33 @@ set(GLFW_BUILD_EXAMPLES OFF CACHE STRING "" FORCE)
 set(GLFW_BUILD_TESTS OFF CACHE STRING "" FORCE)
 set(GLFW_BUILD_DOCS OFF CACHE STRING "" FORCE)
 set(BUILD_BULLET3 OFF CACHE STRING "" FORCE) # Can use bullet2, bullet3 wants to build examples...
+
 add_subdirectory(lib/bullet3)
+
 include_directories(lib/bullet3/src)
-
-if(WIN32)
-  target_link_libraries(${PROJECT_NAME} shlwapi DbgHelp)
-elseif(UNIX)
-  target_link_libraries(${PROJECT_NAME} -lpthread)
-endif()
-
 target_link_libraries(${PROJECT_NAME} BulletDynamics BulletCollision LinearMath)
 
+
+# MoltenTempest
+set(BUILD_SHARED_LIBS ${BUILD_SHARED_MOLTEN_TEMPEST})
+add_subdirectory(lib/MoltenTempest/Engine)
+
+include_directories(lib/MoltenTempest/Engine/include)
+target_link_libraries(${PROJECT_NAME} MoltenTempest)
+
+
+# script for launching in build directory
+if(UNIX)
+    add_custom_command(
+        TARGET ${PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy
+        ${CMAKE_SOURCE_DIR}/scripts/Gothic2Notr.sh
+        ${CMAKE_CURRENT_BINARY_DIR}/bin/Gothic2Notr.sh)
+endif()
+
+
+# installation
+install(
+    TARGETS ${PROJECT_NAME}
+    RUNTIME DESTINATION bin
+    )

--- a/scripts/Gothic2Notr.sh
+++ b/scripts/Gothic2Notr.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export LD_LIBRARY_PATH="$DIR:$LD_LIBRARY_PATH"
+if [[ $DEBUGGER != "" ]]; then
+  exec $DEBUGGER --args "$DIR/Gothic2Notr" "$@"
+else
+  exec "$DIR/Gothic2Notr" "$@"
+fi


### PR DESCRIPTION
* allow building either with shared libraries or static libraries
  (default) with -DBUILD_SHARED_LIBS=on/off
* improve running from within the build directory in linux using a
  wrapper shell script (bin/Gothic2Notr.sh)
* don't set CMAKE_BINARY_DIR so the game can always be run from the
  build directory
* allow installing
* some of the features require a changed MoltenTempest