### PR TITLE
linux: fix building with gcc9

### DIFF
--- a/Game/graphics/pfxobjects.cpp
+++ b/Game/graphics/pfxobjects.cpp
@@ -324,7 +324,7 @@ void PfxObjects::Bucket::finalize(size_t particle) {
   Vertex* v = &vbo[particle*6];
   std::memset(v,0,sizeof(*v)*6);
   auto& p = particles[particle];
-  std::memset(&p,0,sizeof(p));
+  p = {};
   }
 
 void PfxObjects::Bucket::tick(Block& sys, size_t particle, uint64_t dt) {

--- a/Game/world/interactive.cpp
+++ b/Game/world/interactive.cpp
@@ -611,7 +611,7 @@ Tempest::Vec3 Interactive::nodePosition(const Npc &npc, const Pos &p) const {
 
 const Animation::Sequence* Interactive::setAnim(Interactive::Anim t) {
   int  st[]     = {state,state+(reverseState ? -t : t)};
-  char ss[2][8] = {};
+  char ss[2][12] = {};
 
   st[1] = std::max(0,std::min(st[1],stateNum));
 
@@ -659,7 +659,7 @@ bool Interactive::setAnim(Npc* npc,Anim dir) {
 const Animation::Sequence* Interactive::animNpc(const AnimationSolver &solver, Anim t) {
   const char* tag      = schemeName();
   int         st[]     = {state,state+(reverseState ? -t : t)};
-  char        ss[2][8] = {};
+  char        ss[2][12] = {};
   const char* point    = "";
 
   if(t==Anim::FromStand) {


### PR DESCRIPTION
It will fix 2 errors:
```
/home/1/git/OpenGothic/Game/graphics/pfxobjects.cpp: In member function ‘void PfxObjects::Bucket::finalize(size_t)’:
/home/1/git/OpenGothic/Game/graphics/pfxobjects.cpp:327:29: error: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct PfxObjects::ParState’; use assignment or value-initialization instead [-Werror=class-memaccess]
  327 |   std::memset(&p,0,sizeof(p));
      |                             ^
In file included from /home/1/git/OpenGothic/Game/graphics/pfxobjects.cpp:1:
/home/1/git/OpenGothic/Game/graphics/pfxobjects.h:107:12: note: ‘struct PfxObjects::ParState’ declared here
  107 |     struct ParState final {
      |            ^~~~~~~~
```
And this one:
```
/home/1/git/OpenGothic/Game/world/interactive.cpp: In member function ‘const Animation::Sequence* Interactive::setAnim(Interactive::Anim)’:
/home/1/git/OpenGothic/Game/world/interactive.cpp:622:43: error: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 7 [-Werror=format-truncation=]
  622 |       std::snprintf(ss[i],sizeof(ss[i]),"S%d",st[i]);
      |                                           ^~
/home/1/git/OpenGothic/Game/world/interactive.cpp:622:41: note: directive argument in the range [0, 2147483647]
  622 |       std::snprintf(ss[i],sizeof(ss[i]),"S%d",st[i]);
      |                                         ^~~~~
In file included from /usr/include/stdio.h:867,
                 from /usr/include/c++/9/cstdio:42,
                 from /usr/include/c++/9/ext/string_conversions.h:43,
                 from /usr/include/c++/9/bits/basic_string.h:6493,
                 from /usr/include/c++/9/string:55,
                 from /home/1/git/OpenGothic/lib/ZenLib/zenload/zTypes.h:2,
                 from /home/1/git/OpenGothic/lib/ZenLib/zenload/zCMesh.h:3,
                 from /home/1/git/OpenGothic/Game/physics/dynamicworld.h:3,
                 from /home/1/git/OpenGothic/Game/physics/physicmesh.h:3,
                 from /home/1/git/OpenGothic/Game/world/interactive.h:4,
                 from /home/1/git/OpenGothic/Game/world/interactive.cpp:1:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:35: note: ‘__builtin___snprintf_chk’ output between 3 and 12 bytes into a destination of size 8
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/c/git/OpenGothic/Game/world/interactive.cpp:622:43: error: ‘%d’ directive output may be truncated writing between 1 and 10 bytes into a region of size 7 [-Werror=format-truncation=]
  622 |       std::snprintf(ss[i],sizeof(ss[i]),"S%d",st[i]);
      |                                           ^~
/mnt/c/git/OpenGothic/Game/world/interactive.cpp:622:41: note: directive argument in the range [0, 2147483647]
  622 |       std::snprintf(ss[i],sizeof(ss[i]),"S%d",st[i]);
      |                                         ^~~~~
In file included from /usr/include/stdio.h:867,
                 from /usr/include/c++/9/cstdio:42,
                 from /usr/include/c++/9/ext/string_conversions.h:43,
                 from /usr/include/c++/9/bits/basic_string.h:6493,
                 from /usr/include/c++/9/string:55,
                 from /mnt/c/git/OpenGothic/lib/ZenLib/zenload/zTypes.h:2,
                 from /mnt/c/git/OpenGothic/lib/ZenLib/zenload/zCMesh.h:3,
                 from /mnt/c/git/OpenGothic/Game/physics/dynamicworld.h:3,
                 from /mnt/c/git/OpenGothic/Game/physics/physicmesh.h:3,
                 from /mnt/c/git/OpenGothic/Game/world/interactive.h:4,
                 from /mnt/c/git/OpenGothic/Game/world/interactive.cpp:1:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:35: note: ‘__builtin___snprintf_chk’ output between 3 and 12 bytes into a destination of size 8
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```