### PR TITLE
Add no debug flag to disable FPS counter

### DIFF
--- a/Game/gothic.cpp
+++ b/Game/gothic.cpp
@@ -51,8 +51,8 @@ Gothic::Gothic(const int argc, const char **argv){
     else if(std::strcmp(argv[i],"-nomenu")==0){
       noMenu=true;
       }
-    else if(std::strcmp(argv[i],"-nodebug")==0){
-      noDebug=true;
+    else if(std::strcmp(argv[i],"-nofrate")==0){
+      noFrate=true;
       }
     else if(std::strcmp(argv[i],"-rambo")==0){
       isRambo=true;

--- a/Game/gothic.cpp
+++ b/Game/gothic.cpp
@@ -51,6 +51,9 @@ Gothic::Gothic(const int argc, const char **argv){
     else if(std::strcmp(argv[i],"-nomenu")==0){
       noMenu=true;
       }
+    else if(std::strcmp(argv[i],"-nodebug")==0){
+      noDebug=true;
+      }
     else if(std::strcmp(argv[i],"-rambo")==0){
       isRambo=true;
       }

--- a/Game/gothic.h
+++ b/Game/gothic.h
@@ -42,7 +42,7 @@ class Gothic final {
 
     bool isInGame() const;
     bool doStartMenu() const { return !noMenu; }
-    bool doDebug() const { return !noDebug; }
+    bool doFrate() const { return !noFrate; }
 
     void         setGame(std::unique_ptr<GameSession> &&w);
     auto         clearGame() -> std::unique_ptr<GameSession>;
@@ -150,7 +150,7 @@ class Gothic final {
     std::string                             wdef;
     std::string                             saveDef;
     bool                                    noMenu=false;
-    bool                                    noDebug=false;
+    bool                                    noFrate=false;
     bool                                    isWindow=false;
     uint16_t                                pauseSum=0;
     bool                                    isDebug=false;

--- a/Game/gothic.h
+++ b/Game/gothic.h
@@ -42,6 +42,7 @@ class Gothic final {
 
     bool isInGame() const;
     bool doStartMenu() const { return !noMenu; }
+    bool doDebug() const { return !noDebug; }
 
     void         setGame(std::unique_ptr<GameSession> &&w);
     auto         clearGame() -> std::unique_ptr<GameSession>;
@@ -149,6 +150,7 @@ class Gothic final {
     std::string                             wdef;
     std::string                             saveDef;
     bool                                    noMenu=false;
+    bool                                    noDebug=false;
     bool                                    isWindow=false;
     uint16_t                                pauseSum=0;
     bool                                    isDebug=false;

--- a/Game/mainwindow.cpp
+++ b/Game/mainwindow.cpp
@@ -180,7 +180,7 @@ void MainWindow::paintEvent(PaintEvent& event) {
       }
     }
 
-    if(gothic.doDebug()) {
+    if(gothic.doFrate()) {
       char fpsT[64]={};
       std::snprintf(fpsT,sizeof(fpsT),"fps = %.2f %s",fps.get(),info);
 

--- a/Game/mainwindow.cpp
+++ b/Game/mainwindow.cpp
@@ -180,11 +180,13 @@ void MainWindow::paintEvent(PaintEvent& event) {
       }
     }
 
-  char fpsT[64]={};
-  std::snprintf(fpsT,sizeof(fpsT),"fps = %.2f %s",fps.get(),info);
+    if(gothic.doDebug()) {
+      char fpsT[64]={};
+      std::snprintf(fpsT,sizeof(fpsT),"fps = %.2f %s",fps.get(),info);
 
-  auto& fnt = Resources::font();
-  fnt.drawText(p,5,30,fpsT);
+      auto& fnt = Resources::font();
+      fnt.drawText(p,5,30,fpsT);
+    }
   }
 
 void MainWindow::resizeEvent(SizeEvent&) {

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Don't expect DirectX11 mod to work, since technicaly it's not a mod. But Project
 ##### Command line arguments
 * -g specify gothic game catalog
 * -nomenu - skip main menu
+* -nodebug - Disable FPS debug metrics
 * -w <worldname.zen> - startup world; newworld.zen is default
 * -save \<q> - startup with quick save
 * -save \<number> - startup with specified save-game slot

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Don't expect DirectX11 mod to work, since technicaly it's not a mod. But Project
 ##### Command line arguments
 * -g specify gothic game catalog
 * -nomenu - skip main menu
-* -nodebug - Disable FPS debug metrics
+* -nofrate - Disable FPS display in-game
 * -w <worldname.zen> - startup world; newworld.zen is default
 * -save \<q> - startup with quick save
 * -save \<number> - startup with specified save-game slot


### PR DESCRIPTION
This is mainly an addition to the possible flags to disable the FPS counter (debug mode). Wasn't sure if the best option would be to by default have it on, since this is an in development project, or vice versa. It appears to work well, with and without the flag, tested on Linux.