### PR TITLE
Implemented playercontrol weapon.

### DIFF
--- a/Game/game/playercontrol.h
+++ b/Game/game/playercontrol.h
@@ -69,6 +69,7 @@ class PlayerControl final {
 
     bool           ctrl[Action::Last]={};
     bool           wctrl[WeponAction::Last]={};
+    WeponAction    wctrl_last = WeponAction::WeaponMele; //!< Reminder for weapon toggle.
     bool           actrl[5]={};
 
     bool           cacheFocus=false;

--- a/Game/world/npc.cpp
+++ b/Game/world/npc.cpp
@@ -833,6 +833,10 @@ bool Npc::isInAir() const {
   return mvAlgo.isInAir();
   }
 
+bool Npc::isSwim() const {
+  return mvAlgo.isSwim();
+}
+
 void Npc::setTalentSkill(Npc::Talent t, int32_t lvl) {
   if(t<TALENT_MAX_G2) {
     talentsSk[t] = lvl;

--- a/Game/world/npc.h
+++ b/Game/world/npc.h
@@ -247,6 +247,7 @@ class Npc final {
     bool       isFaling() const;
     bool       isSlide() const;
     bool       isInAir() const;
+    bool       isSwim() const;
     bool       isStanding() const;
 
     void       setTalentSkill(Talent t,int32_t lvl);


### PR DESCRIPTION
* Implementation of playercontrol weapon, which toggles between last active weapon and no weapon.
  If the last active weapon is no longer available, a fallback weapon is chosen (Spell -> Range -> Melee)

* Fixed Bug: [FIXME]: Player got freezed, if he was swimming and a weapon shall be drawn.
  movealgo.cpp seems to cover this case. Investigation needed why the player freezes anyway.
  Current workaround: check in playercontrol, if the player is swimming and prevent WeponAction changes in that case.