### PR TITLE
Fixed type missmatch to prevent possible linker error

### DIFF
--- a/Game/gamemusic.h
+++ b/Game/gamemusic.h
@@ -4,7 +4,7 @@
 
 namespace Daedalus {
 namespace GEngineClasses {
-class C_MusicTheme;
+struct C_MusicTheme;
 }
 }
 


### PR DESCRIPTION
C_MusicTheme is originally defined as a struct. Clang warned that changing it may cause problems with windows ABI.