### PR TITLE
Fixed hero swims with drawn weapons.

### DIFF
--- a/Game/game/movealgo.cpp
+++ b/Game/game/movealgo.cpp
@@ -647,7 +647,7 @@ void MoveAlgo::setInWater(bool f) {
 
 void MoveAlgo::setAsSwim(bool f) {
   if(f)
-    npc.closeWeapon(true);
+    npc.closeWeapon(false);
   if(f)
     flags=Flags(flags|Swim);  else
     flags=Flags(flags&(~Swim));


### PR DESCRIPTION
If the hero starts swimming with a drawn weapon, he won't put it back while starting to swim.
The code somehow states, that the weapon shall be deactivated with no animation.
This doesn't seem to work.

In the original game the weapon magically deactivates without an animation.
This pull request changes the behavior to actually play the put away animations while starting to swim. The animation executes overlayed with the swim animation and it looks pretty good.
In my opinion this is much cleaner than in the original game and I would do it with animation.