### PR TITLE
Sneak Implementation

### DIFF
--- a/Game/game/playercontrol.cpp
+++ b/Game/game/playercontrol.cpp
@@ -223,7 +223,7 @@ void PlayerControl::toggleSneakMode() {
   if(w==nullptr || w->player()==nullptr)
     return;
   auto pl = w->player();
-  if(0<pl->canSneak())
+  if(pl->canSneak())
     pl->setWalkMode(WalkBit(pl->walkMode()^WalkBit::WM_Sneak));
   }
 

--- a/Game/game/playercontrol.cpp
+++ b/Game/game/playercontrol.cpp
@@ -103,8 +103,13 @@ void PlayerControl::onKeyPressed(KeyCodec::Action a) {
     return;
     }
 
-  if(a==Action::Walk){
+  if(a==Action::Walk) {
     toogleWalkMode();
+    return;
+    }
+
+  if(a==Action::Sneak) {
+    toggleSneakMode();
     return;
     }
 
@@ -211,6 +216,14 @@ void PlayerControl::toogleWalkMode() {
     return;
   auto pl = w->player();
   pl->setWalkMode(WalkBit(pl->walkMode()^WalkBit::WM_Walk));
+  }
+
+void PlayerControl::toggleSneakMode() {
+  auto w = world();
+  if(w==nullptr || w->player()==nullptr)
+    return;
+  auto pl = w->player();
+  pl->setWalkMode(WalkBit(pl->walkMode()^WalkBit::WM_Sneak));
   }
 
 WeaponState PlayerControl::weaponState() const {

--- a/Game/game/playercontrol.cpp
+++ b/Game/game/playercontrol.cpp
@@ -223,7 +223,8 @@ void PlayerControl::toggleSneakMode() {
   if(w==nullptr || w->player()==nullptr)
     return;
   auto pl = w->player();
-  pl->setWalkMode(WalkBit(pl->walkMode()^WalkBit::WM_Sneak));
+  if(0<pl->canSneak())
+    pl->setWalkMode(WalkBit(pl->walkMode()^WalkBit::WM_Sneak));
   }
 
 WeaponState PlayerControl::weaponState() const {

--- a/Game/game/playercontrol.h
+++ b/Game/game/playercontrol.h
@@ -81,6 +81,7 @@ class PlayerControl final {
 
     void           marvinF8();
     void           toogleWalkMode();
+    void           toggleSneakMode();
     Focus          findFocus(Focus *prev);
 
     World*         world() const;

--- a/Game/graphics/animationsolver.cpp
+++ b/Game/graphics/animationsolver.cpp
@@ -144,6 +144,8 @@ const Animation::Sequence* AnimationSolver::solveAnim(AnimationSolver::Anim a, W
   if(a==Idle) {
     if(bool(wlkMode & WalkBit::WM_Swim))
       return solveFrm("S_SWIM");
+    if(bool(wlkMode&WalkBit::WM_Sneak))
+      return solveFrm("S_%sSNEAK",st);
     if(bool(wlkMode&WalkBit::WM_Walk))
       return solveFrm("S_%sWALK",st);
     return solveFrm("S_%sRUN",st);
@@ -151,6 +153,8 @@ const Animation::Sequence* AnimationSolver::solveAnim(AnimationSolver::Anim a, W
   if(a==Move)  {
     if(bool(wlkMode & WalkBit::WM_Swim))
       return solveFrm("S_SWIMF",st);
+    if(bool(wlkMode & WalkBit::WM_Sneak))
+      return solveFrm("S_%sSNEAKL",st);
     if(bool(wlkMode & WalkBit::WM_Walk))
       return solveFrm("S_%sWALKL",st);
     if(bool(wlkMode & WalkBit::WM_Water))
@@ -160,6 +164,8 @@ const Animation::Sequence* AnimationSolver::solveAnim(AnimationSolver::Anim a, W
   if(a==MoveL) {
     if(bool(wlkMode & WalkBit::WM_Swim))
       return solveFrm("S_SWIM"); // ???
+    if(bool(wlkMode & WalkBit::WM_Sneak))
+      return solveFrm("T_%sSNEAKSTRAFEL",st);
     if(bool(wlkMode & WalkBit::WM_Walk))
       return solveFrm("T_%sWALKWSTRAFEL",st);
     if(bool(wlkMode & WalkBit::WM_Water))
@@ -169,6 +175,8 @@ const Animation::Sequence* AnimationSolver::solveAnim(AnimationSolver::Anim a, W
   if(a==MoveR) {
     if(bool(wlkMode & WalkBit::WM_Swim))
       return solveFrm("S_SWIM"); // ???
+    if(bool(wlkMode & WalkBit::WM_Sneak))
+      return solveFrm("T_%sSNEAKSTRAFER",st);
     if(bool(wlkMode & WalkBit::WM_Walk))
       return solveFrm("T_%sWALKWSTRAFER",st);
     if(bool(wlkMode & WalkBit::WM_Water))
@@ -178,12 +186,16 @@ const Animation::Sequence* AnimationSolver::solveAnim(AnimationSolver::Anim a, W
   if(a==Anim::MoveBack) {
     if(bool(wlkMode & WalkBit::WM_Swim))
       return solveFrm("S_SWIMB");
+    if(bool(wlkMode & WalkBit::WM_Sneak))
+      return solveFrm("S_%sSNEAKBL",st);
     return solveFrm("T_%sJUMPB",st);
     }
   // Rotation
   if(a==RotL) {
     if(bool(wlkMode & WalkBit::WM_Swim))
       return solveFrm("T_SWIMTURNL");
+    if(bool(wlkMode & WalkBit::WM_Sneak))
+      return solveFrm("T_SNEAKTURNL");
     if(bool(wlkMode & WalkBit::WM_Walk))
       return solveFrm("T_%sWALKTURNL",st);
     if(bool(wlkMode & WalkBit::WM_Water))
@@ -193,6 +205,8 @@ const Animation::Sequence* AnimationSolver::solveAnim(AnimationSolver::Anim a, W
   if(a==RotR) {
     if(bool(wlkMode & WalkBit::WM_Swim))
       return solveFrm("T_SWIMTURNR");
+    if(bool(wlkMode & WalkBit::WM_Sneak))
+      return solveFrm("T_SNEAKTURNR");
     if(bool(wlkMode & WalkBit::WM_Walk))
       return solveFrm("T_%sWALKTURNR",st);
     if(bool(wlkMode & WalkBit::WM_Water))

--- a/Game/graphics/mdlvisual.cpp
+++ b/Game/graphics/mdlvisual.cpp
@@ -454,6 +454,8 @@ const Animation::Sequence* MdlVisual::startAnimAndGet(Npc& npc, AnimationSolver:
 
   if(bool(wlk & WalkBit::WM_Swim))
     bs = BS_SWIM;
+  if(bool(wlk & WalkBit::WM_Sneak))
+    bs = BS_SNEAK;
 
   Pose::StartHint hint = Pose::StartHint((forceAnim  ? Pose::Force : Pose::NoHint) |
                                          (noInterupt ? Pose::NoInterupt : Pose::NoHint));

--- a/Game/utils/keycodec.cpp
+++ b/Game/utils/keycodec.cpp
@@ -122,7 +122,7 @@ KeyCodec::Action KeyCodec::implTr(int32_t code) {
   if(keyWeapon.is(code))
     return Weapon;
   if(keySneak.is(code))
-    return Idle; //TODO
+    return Sneak;
 
   if(keyLook.is(code))
     return Idle; // ?

--- a/Game/utils/keycodec.h
+++ b/Game/utils/keycodec.h
@@ -29,6 +29,7 @@ class KeyCodec final {
 
       ActionGeneric,
       Walk,
+      Sneak,
 
       Weapon,
       WeaponMele,

--- a/Game/world/npc.cpp
+++ b/Game/world/npc.cpp
@@ -931,9 +931,9 @@ int32_t Npc::mageCycle() const {
   return talentSkill(TALENT_MAGE);
   }
 
-int32_t Npc::canSneak() const {
+bool Npc::canSneak() const {
   return talentSkill(TALENT_SNEAK);
-}
+  }
 
 void Npc::setRefuseTalk(uint64_t milis) {
   refuseTalkMilis = owner.tickCount()+milis;

--- a/Game/world/npc.cpp
+++ b/Game/world/npc.cpp
@@ -932,7 +932,7 @@ int32_t Npc::mageCycle() const {
   }
 
 bool Npc::canSneak() const {
-  return talentSkill(TALENT_SNEAK);
+  return talentSkill(TALENT_SNEAK)!=0;
   }
 
 void Npc::setRefuseTalk(uint64_t milis) {

--- a/Game/world/npc.cpp
+++ b/Game/world/npc.cpp
@@ -931,6 +931,10 @@ int32_t Npc::mageCycle() const {
   return talentSkill(TALENT_MAGE);
   }
 
+int32_t Npc::canSneak() const {
+  return talentSkill(TALENT_SNEAK);
+}
+
 void Npc::setRefuseTalk(uint64_t milis) {
   refuseTalkMilis = owner.tickCount()+milis;
   }

--- a/Game/world/npc.cpp
+++ b/Game/world/npc.cpp
@@ -2551,7 +2551,7 @@ bool Npc::perceptionProcess(Npc &pl) {
 
   const float quadDist = pl.qDistTo(*this);
 
-  if(hasPerc(PERC_ASSESSPLAYER) && canSenseNpc(pl,true)!=SensesBit::SENSE_NONE) {
+  if(hasPerc(PERC_ASSESSPLAYER) && canSenseNpc(pl,false)!=SensesBit::SENSE_NONE) {
     if(perceptionProcess(pl,nullptr,quadDist,PERC_ASSESSPLAYER)) {
       ret = true;
       }

--- a/Game/world/npc.cpp
+++ b/Game/world/npc.cpp
@@ -3063,15 +3063,16 @@ bool Npc::canSeeNpc(const Npc &oth, bool freeLos) const {
   }
 
 bool Npc::canSeeNpc(float tx, float ty, float tz, bool freeLos) const {
-  SensesBit s = canSenseNpc(tx,ty,tz,freeLos);
+  SensesBit s = canSenseNpc(tx,ty,tz,freeLos,false);
   return int32_t(s&SensesBit::SENSE_SEE)!=0;
   }
 
 SensesBit Npc::canSenseNpc(const Npc &oth, bool freeLos, float extRange) const {
-  return canSenseNpc(oth.x,oth.y+180,oth.z,freeLos,extRange);
+  const bool isNoisy = (oth.bodyState()&BodyState::BS_SNEAK)==0;
+  return canSenseNpc(oth.x,oth.y+180,oth.z,freeLos,isNoisy,extRange);
   }
 
-SensesBit Npc::canSenseNpc(float tx, float ty, float tz, bool freeLos, float extRange) const {
+SensesBit Npc::canSenseNpc(float tx, float ty, float tz, bool freeLos, bool isNoisy, float extRange) const {
   DynamicWorld* w = owner.physic();
   static const double ref = std::cos(100*M_PI/180.0); // spec requires +-100 view angle range
 
@@ -3082,7 +3083,8 @@ SensesBit Npc::canSenseNpc(float tx, float ty, float tz, bool freeLos, float ext
   SensesBit ret=SensesBit::SENSE_NONE;
   if(owner.roomAt({tx,ty,tz})==owner.roomAt({x,y,z})) {
     ret = ret | SensesBit::SENSE_SMELL;
-    ret = ret | SensesBit::SENSE_HEAR; // TODO:sneaking
+    if(isNoisy)
+      ret = ret | SensesBit::SENSE_HEAR;
     }
 
   if(!freeLos){

--- a/Game/world/npc.h
+++ b/Game/world/npc.h
@@ -260,7 +260,7 @@ class Npc final {
     bool       isRefuseTalk() const;
 
     int32_t    mageCycle() const;
-    int32_t    canSneak() const;
+    bool       canSneak() const;
     int32_t    attribute (Attribute a) const;
     void       changeAttribute(Attribute a, int32_t val, bool allowUnconscious);
     int32_t    protection(Protection p) const;

--- a/Game/world/npc.h
+++ b/Game/world/npc.h
@@ -260,6 +260,7 @@ class Npc final {
     bool       isRefuseTalk() const;
 
     int32_t    mageCycle() const;
+    int32_t    canSneak() const;
     int32_t    attribute (Attribute a) const;
     void       changeAttribute(Attribute a, int32_t val, bool allowUnconscious);
     int32_t    protection(Protection p) const;

--- a/Game/world/npc.h
+++ b/Game/world/npc.h
@@ -435,7 +435,7 @@ class Npc final {
     bool      canSeeNpc(const Npc& oth,bool freeLos) const;
     bool      canSeeNpc(float x,float y,float z,bool freeLos) const;
     auto      canSenseNpc(const Npc& oth,bool freeLos, float extRange=0.f) const -> SensesBit;
-    auto      canSenseNpc(float x,float y,float z,bool freeLos, float extRange=0.f) const -> SensesBit;
+    auto      canSenseNpc(float x,float y,float z,bool freeLos,bool isNoisy,float extRange=0.f) const -> SensesBit;
 
     void      setTarget(Npc* t);
     Npc*      target();


### PR DESCRIPTION
- [x] Added sneak key codec reading and added action for playercontroler
- [x] Added toggleSneakMode function to playercontroller.
- [x] Added animation solving for sneak animations.
- [x] Added Bodystate BS_SNEAK, so script NPCs can react to.
- [x] Added canSenseNpc feature to use npcs bodystate sneak for sense_hear detection.
- [x] Allow activation of sneak mode only, if the hero has learned it.
- [x] Fix bug: NPCs react to sneaking, even if CanSee returns false.

I actually created the pull request to ask, if someone has an idea, why NPCs react to sneaking, even if they definitely can't see me. NPCs that are occupied on mobsis cancle their tasks to turn around and react to the sneaking.
I read though the deadalous scripts and maybe I'm blind, but I cant see whats missing here.
