### PR TITLE
Fix broken sit ani at vectors.

### DIFF
--- a/Game/graphics/mdlvisual.cpp
+++ b/Game/graphics/mdlvisual.cpp
@@ -491,15 +491,24 @@ Tempest::Vec3 MdlVisual::displayPosition() const {
   return {0.f,0.f,0.f};
   }
 
-Vec3 MdlVisual::lookAtVector(const char *nodeName) const
+bool MdlVisual::boneRotationY(const char *nodeName, float& deg) const
 {
-  if(nullptr==skeleton) {
-    return Vec3(0.f, 0.f, 0.f);
-  }
-  size_t nodeId = skeleton->findNode(nodeName);
-  Matrix4x4 trafo = skInst->tr[nodeId];
-  Vec3 atVector = Vec3(trafo.at(0,0),trafo.at(0,1),trafo.at(0,2));
-  return atVector;
+  size_t nodeId = size_t(-1);
+
+  if(nullptr!=skeleton)
+    nodeId = skeleton->findNode(nodeName);
+
+  if(size_t(-1)!=nodeId) {
+    auto p = pos;
+    p.mul(pose().tr[nodeId]);
+    float atVecX = p.at(2,0);
+    float atVecZ = p.at(2,2);
+    if(0.f!=atVecX) {
+      deg = static_cast<float>(atan(atVecZ / atVecX)) * 180.f / static_cast<float>(M_PI);
+      return true;
+      }
+    }
+  return false;
 }
 
 const Animation::Sequence* MdlVisual::continueCombo(Npc& npc, AnimationSolver::Anim a,

--- a/Game/graphics/mdlvisual.cpp
+++ b/Game/graphics/mdlvisual.cpp
@@ -491,8 +491,7 @@ Tempest::Vec3 MdlVisual::displayPosition() const {
   return {0.f,0.f,0.f};
   }
 
-float MdlVisual::viewDirection() const
-{
+float MdlVisual::viewDirection() const {
   auto p = pos;
   if(nullptr!=skeleton) {
     size_t nodeId = skeleton->findNode("BIP01");
@@ -501,8 +500,8 @@ float MdlVisual::viewDirection() const
     }
   float rx = p.at(2,0);
   float rz = p.at(2,2);
-  return static_cast<float>(atan2(rz,rx)) * 180.f / static_cast<float>(M_PI);
-}
+  return float(std::atan2(rz,rx)) * 180.f / float(M_PI);
+  }
 
 const Animation::Sequence* MdlVisual::continueCombo(Npc& npc, AnimationSolver::Anim a,
                                                     WeaponState st, WalkBit wlk)  {

--- a/Game/graphics/mdlvisual.cpp
+++ b/Game/graphics/mdlvisual.cpp
@@ -491,24 +491,17 @@ Tempest::Vec3 MdlVisual::displayPosition() const {
   return {0.f,0.f,0.f};
   }
 
-bool MdlVisual::boneRotationY(const char *nodeName, float& deg) const
+float MdlVisual::viewDirection() const
 {
-  size_t nodeId = size_t(-1);
-
-  if(nullptr!=skeleton)
-    nodeId = skeleton->findNode(nodeName);
-
-  if(size_t(-1)!=nodeId) {
-    auto p = pos;
-    p.mul(pose().tr[nodeId]);
-
-    float rx = p.at(2,0);
-    float rz = p.at(2,2);
-
-    deg = static_cast<float>(atan2(rz,rx)) * 180.f / static_cast<float>(M_PI);
-    return true;
+  auto p = pos;
+  if(nullptr!=skeleton) {
+    size_t nodeId = skeleton->findNode("BIP01");
+    if(nodeId!=size_t(-1))
+      p.mul(pose().tr[nodeId]);
     }
-  return false;
+  float rx = p.at(2,0);
+  float rz = p.at(2,2);
+  return static_cast<float>(atan2(rz,rx)) * 180.f / static_cast<float>(M_PI);
 }
 
 const Animation::Sequence* MdlVisual::continueCombo(Npc& npc, AnimationSolver::Anim a,

--- a/Game/graphics/mdlvisual.cpp
+++ b/Game/graphics/mdlvisual.cpp
@@ -491,6 +491,17 @@ Tempest::Vec3 MdlVisual::displayPosition() const {
   return {0.f,0.f,0.f};
   }
 
+Vec3 MdlVisual::lookAtVector(const char *nodeName) const
+{
+  if(nullptr==skeleton) {
+    return Vec3(0.f, 0.f, 0.f);
+  }
+  size_t nodeId = skeleton->findNode(nodeName);
+  Matrix4x4 trafo = skInst->tr[nodeId];
+  Vec3 atVector = Vec3(trafo.at(0,0),trafo.at(0,1),trafo.at(0,2));
+  return atVector;
+}
+
 const Animation::Sequence* MdlVisual::continueCombo(Npc& npc, AnimationSolver::Anim a,
                                                     WeaponState st, WalkBit wlk)  {
   if(st==WeaponState::Fist || st==WeaponState::W1H || st==WeaponState::W2H) {

--- a/Game/graphics/mdlvisual.cpp
+++ b/Game/graphics/mdlvisual.cpp
@@ -501,12 +501,12 @@ bool MdlVisual::boneRotationY(const char *nodeName, float& deg) const
   if(size_t(-1)!=nodeId) {
     auto p = pos;
     p.mul(pose().tr[nodeId]);
-    float atVecX = p.at(2,0);
-    float atVecZ = p.at(2,2);
-    if(0.f!=atVecX) {
-      deg = static_cast<float>(atan(atVecZ / atVecX)) * 180.f / static_cast<float>(M_PI);
-      return true;
-      }
+
+    float rx = p.at(2,0);
+    float rz = p.at(2,2);
+
+    deg = static_cast<float>(atan2(rz,rx)) * 180.f / static_cast<float>(M_PI);
+    return true;
     }
   return false;
 }

--- a/Game/graphics/mdlvisual.h
+++ b/Game/graphics/mdlvisual.h
@@ -71,7 +71,7 @@ class MdlVisual final {
     WeaponState                    fightMode() const { return fgtMode; }
     Tempest::Vec3                  displayPosition() const;
     const Tempest::Matrix4x4&      position() const { return pos; }
-    bool                           boneRotationY(const char* nodeName, float& deg) const;
+    float                          viewDirection() const;
 
     const Animation::Sequence*     continueCombo(Npc& npc, AnimationSolver::Anim a, WeaponState st, WalkBit wlk);
     uint32_t                       comboLength() const;

--- a/Game/graphics/mdlvisual.h
+++ b/Game/graphics/mdlvisual.h
@@ -71,6 +71,7 @@ class MdlVisual final {
     WeaponState                    fightMode() const { return fgtMode; }
     Tempest::Vec3                  displayPosition() const;
     const Tempest::Matrix4x4&      position() const { return pos; }
+    Tempest::Vec3                  lookAtVector(const char* nodeName) const;
 
     const Animation::Sequence*     continueCombo(Npc& npc, AnimationSolver::Anim a, WeaponState st, WalkBit wlk);
     uint32_t                       comboLength() const;

--- a/Game/graphics/mdlvisual.h
+++ b/Game/graphics/mdlvisual.h
@@ -71,7 +71,7 @@ class MdlVisual final {
     WeaponState                    fightMode() const { return fgtMode; }
     Tempest::Vec3                  displayPosition() const;
     const Tempest::Matrix4x4&      position() const { return pos; }
-    Tempest::Vec3                  lookAtVector(const char* nodeName) const;
+    bool                           boneRotationY(const char* nodeName, float& deg) const;
 
     const Animation::Sequence*     continueCombo(Npc& npc, AnimationSolver::Anim a, WeaponState st, WalkBit wlk);
     uint32_t                       comboLength() const;

--- a/Game/world/npc.cpp
+++ b/Game/world/npc.cpp
@@ -507,11 +507,6 @@ float Npc::rotationRad() const {
   return angle*float(M_PI)/180.f;
   }
 
-float Npc::rotationLook() const {
-  Vec3 lookAt = visual.lookAtVector("BIP01");
-  return 180.f * static_cast<float>(atan(lookAt.z / lookAt.x)) / static_cast<float>(M_PI);
-}
-
 float Npc::translateY() const {
   return visual.pose().translateY();
   }
@@ -3092,8 +3087,13 @@ SensesBit Npc::canSenseNpc(float tx, float ty, float tz, bool freeLos, float ext
 
   if(!freeLos){
     float dx  = x-tx, dz=z-tz;
-    float dir = angleDir(dx,dz);   
-    float da  = float(M_PI)*(rotationLook()-dir)/180.f;
+    float dir = angleDir(dx,dz);
+    float boneRotation = 0.f;
+    if(visual.boneRotationY("BIP01", boneRotation))
+      LogInfo() << "Bone rotation diff: " << std::fabs(boneRotation-rotation());
+    else
+      LogInfo() << "Bone rotation: FAIL.";
+    float da  = float(M_PI)*(boneRotation-dir)/180.f;
     if(double(std::cos(da))<=ref)
       if(!w->ray(x,y+180,z, tx,ty,tz).hasCol)
         ret = ret | SensesBit::SENSE_SEE;

--- a/Game/world/npc.cpp
+++ b/Game/world/npc.cpp
@@ -3088,9 +3088,7 @@ SensesBit Npc::canSenseNpc(float tx, float ty, float tz, bool freeLos, float ext
   if(!freeLos){
     float dx  = x-tx, dz=z-tz;
     float dir = angleDir(dx,dz);
-    float boneRotation = rotation(); //Fallback is NPC rotation.
-    (void)visual.boneRotationY("BIP01", boneRotation);
-    float da  = float(M_PI)*(boneRotation-dir)/180.f;
+    float da  = float(M_PI)*(visual.viewDirection()-dir)/180.f;
     if(double(std::cos(da))<=ref)
       if(!w->ray(x,y+180,z, tx,ty,tz).hasCol)
         ret = ret | SensesBit::SENSE_SEE;

--- a/Game/world/npc.cpp
+++ b/Game/world/npc.cpp
@@ -507,6 +507,11 @@ float Npc::rotationRad() const {
   return angle*float(M_PI)/180.f;
   }
 
+float Npc::rotationLook() const {
+  Vec3 lookAt = visual.lookAtVector("BIP01");
+  return 180.f * static_cast<float>(atan(lookAt.z / lookAt.x)) / static_cast<float>(M_PI);
+}
+
 float Npc::translateY() const {
   return visual.pose().translateY();
   }
@@ -3087,12 +3092,8 @@ SensesBit Npc::canSenseNpc(float tx, float ty, float tz, bool freeLos, float ext
 
   if(!freeLos){
     float dx  = x-tx, dz=z-tz;
-    float dir = angleDir(dx,dz);
-    if((bodyState()&BodyState::BS_SIT)!=0 &&    //If we are sitting with
-       (visual.pose().isInAnim("S_BENCH_S1") || //this ani on a bench or
-        visual.pose().isInAnim("S_THRONE_S1"))) //that ani on a throne,
-       dir+=180.f; //the atVector of the animations points in the opposite direction.
-    float da  = float(M_PI)*(angle-dir)/180.f;
+    float dir = angleDir(dx,dz);   
+    float da  = float(M_PI)*(rotationLook()-dir)/180.f;
     if(double(std::cos(da))<=ref)
       if(!w->ray(x,y+180,z, tx,ty,tz).hasCol)
         ret = ret | SensesBit::SENSE_SEE;

--- a/Game/world/npc.cpp
+++ b/Game/world/npc.cpp
@@ -3088,11 +3088,8 @@ SensesBit Npc::canSenseNpc(float tx, float ty, float tz, bool freeLos, float ext
   if(!freeLos){
     float dx  = x-tx, dz=z-tz;
     float dir = angleDir(dx,dz);
-    float boneRotation = 0.f;
-    if(visual.boneRotationY("BIP01", boneRotation))
-      LogInfo() << "Bone rotation diff: " << std::fabs(boneRotation-rotation());
-    else
-      LogInfo() << "Bone rotation: FAIL.";
+    float boneRotation = rotation(); //Fallback is NPC rotation.
+    (void)visual.boneRotationY("BIP01", boneRotation);
     float da  = float(M_PI)*(boneRotation-dir)/180.f;
     if(double(std::cos(da))<=ref)
       if(!w->ray(x,y+180,z, tx,ty,tz).hasCol)

--- a/Game/world/npc.cpp
+++ b/Game/world/npc.cpp
@@ -3088,6 +3088,10 @@ SensesBit Npc::canSenseNpc(float tx, float ty, float tz, bool freeLos, float ext
   if(!freeLos){
     float dx  = x-tx, dz=z-tz;
     float dir = angleDir(dx,dz);
+    if((bodyState()&BodyState::BS_SIT)!=0 &&    //If we are sitting with
+       (visual.pose().isInAnim("S_BENCH_S1") || //this ani on a bench or
+        visual.pose().isInAnim("S_THRONE_S1"))) //that ani on a throne,
+       dir+=180.f; //the atVector of the animations points in the opposite direction.
     float da  = float(M_PI)*(angle-dir)/180.f;
     if(double(std::cos(da))<=ref)
       if(!w->ray(x,y+180,z, tx,ty,tz).hasCol)

--- a/Game/world/npc.h
+++ b/Game/world/npc.h
@@ -194,7 +194,6 @@ class Npc final {
     float      collisionRadius() const;
     float      rotation() const;
     float      rotationRad() const;
-    float      rotationLook() const;
     float      translateY() const;
     float      centerY() const;
     Npc*       lookAtTarget() const;

--- a/Game/world/npc.h
+++ b/Game/world/npc.h
@@ -194,6 +194,7 @@ class Npc final {
     float      collisionRadius() const;
     float      rotation() const;
     float      rotationRad() const;
+    float      rotationLook() const;
     float      translateY() const;
     float      centerY() const;
     Npc*       lookAtTarget() const;

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Core gameplay is done, you can complete first chapter, as well as all addon cont
 2. [Download latest stable build](https://github.com/Try/opengothic/releases/latest)
 3. run '/OpenGothic/bin/Gothic2Notr.exe -g "C:\Program Files (x86)\Path\To\Gothic II"'
 
+Common Gothic installation paths:
+
+- "C:\Program Files (x86)\JoWooD\Gothic II"
+- "C:\Gothic II"
+- "C:\Program Files (x86)\Steam\steamapps\common\Gothic II"
+- "~/PlayOnLinux's virtual drives/Gothic2_gog/drive_c/Gothic II"
+
 #### Gameplay video
 [![Video](https://img.youtube.com/vi/21OTvuMdwb4/0.jpg)](https://www.youtube.com/watch?v=21OTvuMdwb4) [![Video](https://img.youtube.com/vi/MUVd-ZWliKY/0.jpg)](https://www.youtube.com/watch?v=MUVd-ZWliKY)
 
@@ -24,7 +31,7 @@ Core gameplay is done, you can complete first chapter, as well as all addon cont
     * Walk - Done
     * Walk(in water) - Done
     * Run - Done
-    * Sneak - Not Implemented
+    * Sneak - Done
     * Jump - Done
     * Jump(pull-up) - Not Implemented
     * Swimming - Partial


### PR DESCRIPTION
Fixes #43.
Update of the readme file (hints for common Gothic installation paths and 
changed sneak implementation status: Done.

There are two animations with broken atVectors (pointing in the opposite direction).

Affected animations:
- S_BENCH_S1
- S_THRONE_S1

All other animations aren't affected by this.