### PR TITLE
Update Gothic2Notr.sh

### DIFF
--- a/scripts/Gothic2Notr.sh
+++ b/scripts/Gothic2Notr.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
+
+function cdroot()
+{
+    while [[ $PWD != '/' && ${PWD##*/} != 'OpenGothic' ]]; do cd ..; done
+    echo ${PWD}
+}
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-export LD_LIBRARY_PATH="$DIR/lib:$LD_LIBRARY_PATH"
+
+export LD_LIBRARY_PATH=(cdroot)+"/lib:$LD_LIBRARY_PATH"
 if [[ $DEBUGGER != "" ]]; then
-  exec $DEBUGGER --args "$DIR/bin/Gothic2Notr" "$@"
+  exec $DEBUGGER --args "$DIR/Gothic2Notr" "$@"
 else
-  exec "$DIR/bin/Gothic2Notr" "$@"
+  exec "$DIR/Gothic2Notr" "$@"
 fi


### PR DESCRIPTION
The lib can now be reached (and game started) even when running from e.g. /build/openGothic instead of /bin.