### PR TITLE
Update Gothic2Notr.sh

### DIFF
--- a/scripts/Gothic2Notr.sh
+++ b/scripts/Gothic2Notr.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
+
+function cdroot()
+{
+  cd ..; 
+  echo ${PWD}
+}
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-export LD_LIBRARY_PATH="$DIR/lib:$LD_LIBRARY_PATH"
+
+
+export LD_LIBRARY_PATH=(cdroot)+"/lib:$LD_LIBRARY_PATH"
 if [[ $DEBUGGER != "" ]]; then
-  exec $DEBUGGER --args "$DIR/bin/Gothic2Notr" "$@"
+  exec $DEBUGGER --args "$DIR/Gothic2Notr" "$@"
 else
-  exec "$DIR/bin/Gothic2Notr" "$@"
+  exec "$DIR/Gothic2Notr" "$@"
 fi


### PR DESCRIPTION
A simpler version that do not require an unchanged project name. This works when testing to start the game directly from build folder in Linux.