### PR TITLE
Fixed paths Gothic2Notr.sh

### DIFF
--- a/scripts/Gothic2Notr.sh
+++ b/scripts/Gothic2Notr.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-export LD_LIBRARY_PATH="$DIR/lib:$LD_LIBRARY_PATH"
+export LD_LIBRARY_PATH="$DIR:$LD_LIBRARY_PATH"
 if [[ $DEBUGGER != "" ]]; then
-  exec $DEBUGGER --args "$DIR/bin/Gothic2Notr" "$@"
+  exec $DEBUGGER --args "$DIR/Gothic2Notr" "$@"
 else
-  exec "$DIR/bin/Gothic2Notr" "$@"
+  exec "$DIR/Gothic2Notr" "$@"
 fi


### PR DESCRIPTION
Output directory does not have subdirectories; removed `/bin` and `/lib` as all libraires are in current `$DIR`