### PR TITLE
enable CrashLog::dumpStack outside Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 if(WIN32)
   target_link_libraries(${PROJECT_NAME} shlwapi DbgHelp)
 elseif(UNIX)
-  target_link_libraries(${PROJECT_NAME} -lpthread)
+  target_link_libraries(${PROJECT_NAME} -lpthread -ldl)
 endif()
 
 # ZenLib
@@ -103,6 +103,8 @@ target_link_libraries(${PROJECT_NAME} GothicShaders)
 
 if(NOT MSVC)
   target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wconversion -Wno-strict-aliasing -Werror)
+  # -rdynamic is needed to allow obtaining meaningful backtraces
+  target_link_options(${PROJECT_NAME} PRIVATE -rdynamic)
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,10 @@ target_link_libraries(${PROJECT_NAME} GothicShaders)
 
 if(NOT MSVC)
   target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wconversion -Wno-strict-aliasing -Werror)
-  # -rdynamic is needed to allow obtaining meaningful backtraces
-  target_link_options(${PROJECT_NAME} PRIVATE -rdynamic)
+  if(UNIX)
+    # -rdynamic is needed to allow obtaining meaningful backtraces
+    target_link_options(${PROJECT_NAME} PRIVATE -rdynamic)
+  endif()
 endif()
 
 if(WIN32)

--- a/Game/utils/crashlog.cpp
+++ b/Game/utils/crashlog.cpp
@@ -136,10 +136,13 @@ std::string CrashLog::demangle(const void* frame, const char* symbol) {
     }
   // couldn't demangle, return the unchanged symbol
   return symbol;
+  #else
+  return "";
   #endif
   }
 
 void CrashLog::tracebackLinux(std::ostream &out) {
+  #ifdef __LINUX__
   // inspired by https://gist.github.com/fmela/591333 (BSD)
   void *callstack[64];
   char **symbols = NULL;
@@ -163,6 +166,7 @@ void CrashLog::tracebackLinux(std::ostream &out) {
       }
     }
     free(symbols);
+  #endif
   }
 
 void CrashLog::writeSysInfo(std::ostream &fout) {

--- a/Game/utils/crashlog.cpp
+++ b/Game/utils/crashlog.cpp
@@ -140,10 +140,11 @@ std::string CrashLog::demangle(const void* frame, const char* symbol) {
   }
 
 void CrashLog::tracebackLinux(std::ostream &out) {
+  // inspired by https://gist.github.com/fmela/591333 (BSD)
   void *callstack[64];
   char **symbols = NULL;
   int framesNum = 0;
-  framesNum = backtrace(callstack, 50);
+  framesNum = backtrace(callstack, 64);
   symbols = backtrace_symbols(callstack, framesNum);
   if(symbols != NULL)
   {
@@ -158,7 +159,7 @@ void CrashLog::tracebackLinux(std::ostream &out) {
       if (frame != symbols[i]) {
         frame = frame + " - " + symbols[i];
         }
-      out << "#" << i-skip << ": " << frame << std::endl;
+      out << "#" << i-skip+1 << ": " << frame << std::endl;
       }
     }
     free(symbols);

--- a/Game/utils/crashlog.cpp
+++ b/Game/utils/crashlog.cpp
@@ -126,13 +126,12 @@ void CrashLog::dumpStack(const char *sig) {
 void CrashLog::tracebackLinux(std::ostream &out) {
   #ifdef __LINUX__
   // inspired by https://gist.github.com/fmela/591333/36faca4c2f68f7483cd0d3a357e8a8dd5f807edf (BSD)
-  void *callstack[64];
-  char **symbols = NULL;
+  void *callstack[64] = {};
+  char **symbols = nullptr;
   int framesNum = 0;
   framesNum = backtrace(callstack, 64);
   symbols = backtrace_symbols(callstack, framesNum);
-  if(symbols != NULL)
-  {
+  if(symbols != nullptr) {
     int skip = 4; // skip the signal handler frames
     bool loop = true;
     Dl_info info;
@@ -140,8 +139,8 @@ void CrashLog::tracebackLinux(std::ostream &out) {
     for(int i = skip; i < framesNum && loop; i++) {
       if(dladdr(callstack[i], &info) && info.dli_sname) {
         int status = -1;
-        if (info.dli_sname[0] == '_')
-            frame = abi::__cxa_demangle(info.dli_sname, NULL, 0, &status);
+        if(info.dli_sname[0] == '_')
+          frame = abi::__cxa_demangle(info.dli_sname, NULL, 0, &status);
         frame = status == 0 ? frame : info.dli_sname == 0 ? symbols[i] : info.dli_sname;
         }
       if(!strcmp("main", frame)) {
@@ -153,8 +152,8 @@ void CrashLog::tracebackLinux(std::ostream &out) {
       else
         out << "#" << i-skip+1 << ": " << frame << std::endl;
       }
-    }
     free(symbols);
+    }
   #endif
   }
 

--- a/Game/utils/crashlog.h
+++ b/Game/utils/crashlog.h
@@ -11,7 +11,6 @@ class CrashLog final {
     static void dumpStack(const char* sig);
 
   private:
-    static std::string demangle(const void* frame, const char* symbol);
     static void tracebackLinux(std::ostream &out);
     static void writeSysInfo(std::ostream& fout);
   };

--- a/Game/utils/crashlog.h
+++ b/Game/utils/crashlog.h
@@ -11,6 +11,8 @@ class CrashLog final {
     static void dumpStack(const char* sig);
 
   private:
+    static std::string demangle(const void* frame, const char* symbol);
+    static void tracebackLinux(std::ostream &out);
     static void writeSysInfo(std::ostream& fout);
   };
 


### PR DESCRIPTION
This seems like the cleanest diff right now.