### PR TITLE
close inventory also with backspace

### DIFF
--- a/Game/ui/inventorymenu.cpp
+++ b/Game/ui/inventorymenu.cpp
@@ -315,7 +315,7 @@ void InventoryMenu::keyRepeatEvent(KeyEvent& e) {
 void InventoryMenu::keyUpEvent(KeyEvent &e) {
   takeTimer.stop();
   lootMode = LootMode::Normal;
-  if(e.key==KeyEvent::K_ESCAPE || (e.key==KeyEvent::K_Tab && state!=State::Trade)){
+  if(e.key==KeyEvent::K_ESCAPE || (keycodec.tr(e)==KeyCodec::Inventory && state!=State::Trade)){
     close();
     }
   }


### PR DESCRIPTION
Currently, the inventory can be opened with Tab and Backspace, but can be closed only with Tab. This adds support for Backspace too.