### PR TITLE
inventory: Crash Bugfix

### DIFF
--- a/Game/ui/inventorymenu.cpp
+++ b/Game/ui/inventorymenu.cpp
@@ -294,12 +294,26 @@ void InventoryMenu::keyDownEvent(KeyEvent &e) {
     lootMode = LootMode::Stack;
     takeTimer.start(200);
     onTakeStuff();
-    }
-  else if(keycodec.tr(e)==KeyCodec::ActionGeneric) {
-    lootMode = LootMode::Normal;
-    takeTimer.start(200);
-    onTakeStuff();
-    }
+    } else if (keycodec.tr(e) == KeyCodec::ActionGeneric) {
+
+      auto &p = activePage();
+      auto &sel = activePageSel();
+      if (sel.sel >= p.size()) {
+          return;
+      }
+      auto &item = p[sel.sel];
+      if (state == State::Equip) {
+          if (item.isEquiped()) {
+              player->unequipItem(item.clsId());
+          } else {
+              player->useItem(item.clsId());
+          }
+      } else if (state == State::Chest || state == State::Trade || state == State::Ransack) {
+          lootMode = LootMode::Normal;
+          takeTimer.start(200);
+          onTakeStuff();
+      }
+  }
   adjustScroll();
   update();
   }

--- a/Game/ui/inventorymenu.h
+++ b/Game/ui/inventorymenu.h
@@ -121,6 +121,7 @@ class InventoryMenu : public Tempest::Widget {
 
     void          onTakeStuff();
     void          adjustScroll();
+    void          onEquip();
     void          drawAll   (Tempest::Painter& p, Npc& player, DrawPass pass);
     void          drawItems (Tempest::Painter& p, DrawPass pass, const Page &inv, const PageLocal &sel, int x, int y, int wcount, int hcount);
     void          drawSlot  (Tempest::Painter& p, DrawPass pass, const Page &inv, const PageLocal &sel, int x, int y, size_t id);


### PR DESCRIPTION
Fixed inventory keyDownEvent to allow for equipping
and using items with ctrl key. Would otherwise may
result in segfault crash because calling loot logic.