### PR TITLE
feat: original buttons

### DIFF
--- a/Game/game/playercontrol.cpp
+++ b/Game/game/playercontrol.cpp
@@ -89,9 +89,9 @@ void PlayerControl::onKeyPressed(KeyCodec::Action a, Tempest::KeyEvent::KeyType 
     if(ws==WeaponState::W1H || ws==WeaponState::W2H) {
       if(a==Action::Back)
         fk = ActBack;
-      if(a==Action::Left)
+      if(a==Action::Left || a==Action::RotateL)
         fk = ActLeft;
-      if(a==Action::Right)
+      if(a==Action::Right || a==Action::RotateR)
         fk = ActRight;
       }
     if(fk>=0) {
@@ -544,6 +544,27 @@ void PlayerControl::implMove(uint64_t dt) {
       }
     }
 
+  if(ctrl[Action::Forward]) {
+    if((pl.walkMode()&WalkBit::WM_Dive)!=WalkBit::WM_Dive) {
+      ani = Npc::Anim::Move;
+      } else if(pl.isDive()) {
+      pl.setDirectionY(rotY - 1);
+      return;
+      }
+    }
+  else if(ctrl[Action::Back]) {
+    if((pl.walkMode()&WalkBit::WM_Dive)!=WalkBit::WM_Dive) {
+      ani = Npc::Anim::MoveBack;
+      } else if(pl.isDive()) {
+      pl.setDirectionY(rotY + 1);
+      return;
+      }
+    }
+  else if(ctrl[Action::Left])
+    ani = Npc::Anim::MoveL;
+  else if(ctrl[Action::Right])
+    ani = Npc::Anim::MoveR;
+
   if(ctrl[Action::Jump]) {
     if(pl.isDive()) {
       ani = Npc::Anim::Move;
@@ -563,16 +584,6 @@ void PlayerControl::implMove(uint64_t dt) {
       ani = Npc::Anim::Jump;
       }
     }
-  else if(ctrl[Action::Forward]) {
-    if((pl.walkMode()&WalkBit::WM_Dive)!=WalkBit::WM_Dive)
-      ani = Npc::Anim::Move;
-    }
-  else if(ctrl[Action::Back])
-    ani = Npc::Anim::MoveBack;
-  else if(ctrl[Action::Left])
-    ani = Npc::Anim::MoveL;
-  else if(ctrl[Action::Right])
-    ani = Npc::Anim::MoveR;
 
   if(!pl.isCasting()) {
     if(ani==Npc::Anim::Jump) {

--- a/Game/mainwindow.cpp
+++ b/Game/mainwindow.cpp
@@ -27,7 +27,7 @@ MainWindow::MainWindow(Gothic &gothic, Device& device)
   : Window(Maximized),device(device),swapchain(device,hwnd()),
     atlas(device),renderer(device,swapchain,gothic),
     gothic(gothic),keycodec(gothic),
-    rootMenu(gothic),video(gothic),inventory(gothic,keycodec,renderer.storage()),dialogs(gothic,inventory),document(gothic),chapter(gothic),
+    rootMenu(gothic),video(gothic),inventory(gothic,keycodec,renderer.storage()),dialogs(gothic,inventory),document(gothic,keycodec),chapter(gothic),
     player(gothic,dialogs,inventory) {
   CrashLog::setGpu(device.renderer());
   if(!gothic.isWindowMode())

--- a/Game/ui/dialogmenu.h
+++ b/Game/ui/dialogmenu.h
@@ -17,7 +17,7 @@ class GthFont;
 
 class DialogMenu : public Tempest::Widget {
   public:
-    DialogMenu(Gothic& gothic,InventoryMenu& trade);
+    DialogMenu(Gothic& gothic, InventoryMenu& trade);
     ~DialogMenu();
 
     void tick(uint64_t dt);

--- a/Game/ui/documentmenu.cpp
+++ b/Game/ui/documentmenu.cpp
@@ -1,14 +1,15 @@
 #include "documentmenu.h"
 
 #include "utils/gthfont.h"
+#include "utils/keycodec.h"
 #include "world/interactive.h"
 #include "world/npc.h"
 #include "gothic.h"
 
 using namespace Tempest;
 
-DocumentMenu::DocumentMenu(Gothic& gothic)
-  :gothic(gothic) {
+DocumentMenu::DocumentMenu(Gothic& gothic, const KeyCodec& key)
+  :gothic(gothic), keycodec(key) {
   cursor = Resources::loadTexture("U.TGA");
   }
 
@@ -33,7 +34,7 @@ void DocumentMenu::keyDownEvent(KeyEvent &e) {
     return;
     }
 
-  if(e.key!=Event::K_ESCAPE){
+  if(e.key!=Event::K_ESCAPE && keycodec.tr(e)!=KeyCodec::Inventory){
     e.ignore();
     return;
     }

--- a/Game/ui/documentmenu.h
+++ b/Game/ui/documentmenu.h
@@ -5,10 +5,11 @@
 #include <Tempest/Timer>
 
 class Gothic;
+class KeyCodec;
 
 class DocumentMenu : public Tempest::Widget {
   public:
-    DocumentMenu(Gothic& gothic);
+    DocumentMenu(Gothic& gothic, const KeyCodec& key);
 
     enum Flags : uint8_t {
       F_None,
@@ -49,6 +50,7 @@ class DocumentMenu : public Tempest::Widget {
   private:
     Gothic&                   gothic;
     DocumentMenu::Show        document;
+    const KeyCodec&           keycodec;
     const Tempest::Texture2d* cursor = nullptr;
     bool                      active = false;
   };

--- a/Game/ui/inventorymenu.cpp
+++ b/Game/ui/inventorymenu.cpp
@@ -205,7 +205,7 @@ void InventoryMenu::processMove(KeyEvent& e) {
     if(sel.sel+columsCount<pg.size())
       sel.sel += columsCount;
     }
-  else if(key==KeyCodec::Left){
+  else if(key==KeyCodec::Left || key==KeyCodec::RotateL){
     if(sel.sel%columsCount==0 && page>0){
       page--;
       sel.sel += (columsCount-1);
@@ -213,7 +213,7 @@ void InventoryMenu::processMove(KeyEvent& e) {
     else if(sel.sel>0)
       sel.sel--;
     }
-  else if(key==KeyCodec::Right) {
+  else if(key==KeyCodec::Right || key==KeyCodec::RotateR) {
     if(((sel.sel+1u)%columsCount==0 || sel.sel+1u==pg.size() || pg.size()==0) && page+1u<pCount) {
       page++;
       sel.sel -= sel.sel%columsCount;
@@ -229,9 +229,9 @@ void InventoryMenu::processPickLock(KeyEvent& e) {
 
   auto k  = keycodec.tr(e);
   char ch = '\0';
-  if(k==KeyCodec::Left)
+  if(k==KeyCodec::Left || k==KeyCodec::RotateL)
     ch = 'L';
-  else if(k==KeyCodec::Right)
+  else if(k==KeyCodec::Right || k==KeyCodec::RotateR)
     ch = 'R';
   else if(k==KeyCodec::Back) {
     close();
@@ -318,7 +318,7 @@ void InventoryMenu::keyRepeatEvent(KeyEvent& e) {
 void InventoryMenu::keyUpEvent(KeyEvent &e) {
   takeTimer.stop();
   lootMode = LootMode::Normal;
-  if(e.key==KeyEvent::K_ESCAPE || (keycodec.tr(e)==KeyCodec::Inventory && state!=State::Trade)){
+  if(e.key==KeyEvent::K_ESCAPE || keycodec.tr(e)==KeyCodec::Inventory){
     close();
     }
   }


### PR DESCRIPTION
I think I looked at all the gothic controls and its implementation in the engine. I corrected all the changes I noticed, to match the original. A list of changes:

- in the inventory you can use rotating buttons to go left / right in the items table
- lockpicking can by provided with rotating buttons
- swinging the sword left and right should be possible after holding down the action button and rotating buttons
- the Y rotation of the player during the dive is possible using the forward and backward buttons
- closing documents (stone plates, letters) should be possible with the inventory button, otherwise you can close the inventory with the document remaining on the screen
- closing the trade screen with the inventory key