### PR TITLE
fix 'class-memaccess' error

### DIFF
--- a/Game/graphics/skeletalstorage.cpp
+++ b/Game/graphics/skeletalstorage.cpp
@@ -110,7 +110,9 @@ struct SkeletalStorage::TImpl : Impl {
   void   free(const size_t objId, const size_t bonesCount) override {
     freeList.free(objId, bonesCount);
     auto m = &obj[objId];
-    std::memset(m,0,sizeof(Matrix4x4)*bonesCount);
+    for (size_t i=0; i<bonesCount; i++) {
+      m[i] = Block();
+    }
     }
 
   void   bind(Uniforms& ubo, uint8_t bind, uint8_t fId, size_t id) override {


### PR DESCRIPTION
fixes the compiler error:
```
[...]/OpenGothic/Game/graphics/skeletalstorage.cpp:113:16: error: \u2018void* memset(void*, int, size_t)\u2019 clearing an object of non-trivial type \u2018struct SkeletalStorage::TImpl<48>::Block\u2019; use assignment or value-initialization instead [-Werror=class-memaccess]
  113 |     std::memset(m,0,sizeof(Matrix4x4)*bonesCount);
      |     ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```