### PR TITLE
UI improvements

### DIFF
--- a/Game/ui/dialogmenu.cpp
+++ b/Game/ui/dialogmenu.cpp
@@ -345,6 +345,13 @@ void DialogMenu::startTrade() {
   dlgTrade=false;
   }
 
+void DialogMenu::skipPhrase() {
+  if(current.time>0) {
+    currentSnd   = SoundEffect();
+    current.time = 1;
+    }
+  }
+
 void DialogMenu::onEntry(const GameScript::DlgChoise &e) {
   if(pl && other) {
     selected = e;
@@ -481,7 +488,12 @@ void DialogMenu::mouseDownEvent(MouseEvent &event) {
     return;
     }
 
-  onSelect();
+  if(event.button==MouseEvent::ButtonLeft) {
+    onSelect();
+    }
+  if(event.button==MouseEvent::ButtonRight) {
+    skipPhrase();
+    }
   }
 
 void DialogMenu::mouseWheelEvent(MouseEvent &e) {
@@ -499,12 +511,7 @@ void DialogMenu::mouseWheelEvent(MouseEvent &e) {
   }
 
 void DialogMenu::keyDownEvent(KeyEvent &e) {
-  if(state==State::Idle){
-    e.ignore();
-    return;
-    }
-
-  if(e.key!=Event::K_ESCAPE && trade.isOpen()!=InventoryMenu::State::Closed){
+  if(state==State::Idle || trade.isOpen()!=InventoryMenu::State::Closed){
     e.ignore();
     return;
     }
@@ -520,6 +527,9 @@ void DialogMenu::keyDownEvent(KeyEvent &e) {
     if(e.key==Event::K_S || e.key==Event::K_Down){
       dlgSel++;
       }
+    if(e.key==Event::K_ESCAPE){
+      skipPhrase();
+      }
     dlgSel = (dlgSel+choise.size())%std::max<size_t>(choise.size(),1);
     update();
     return;
@@ -532,22 +542,5 @@ void DialogMenu::keyUpEvent(KeyEvent &event) {
     event.ignore();
     return;
     }
-
-  if(event.key==Event::K_ESCAPE) {
-    if(trade.isOpen()!=InventoryMenu::State::Closed) {
-      trade.close();
-      } else {
-      if(current.time>0) {
-        currentSnd   = SoundEffect();
-        if(dlgAnimation) {
-          current.time = std::min<uint64_t>(current.time,ANIM_TIME);
-          } else {
-          current.time = 1;
-          }
-        }
-      }
-    update();
-    }
   }
-
 

--- a/Game/ui/dialogmenu.h
+++ b/Game/ui/dialogmenu.h
@@ -111,6 +111,7 @@ class DialogMenu : public Tempest::Widget {
     Tempest::Size processTextMultiline(Tempest::Painter* p, int x, int y, int w, int h, const std::string& txt, bool isPl);
 
     void startTrade();
+    void skipPhrase();
 
     Gothic&                             gothic;
     InventoryMenu&                      trade;

--- a/Game/ui/inventorymenu.cpp
+++ b/Game/ui/inventorymenu.cpp
@@ -598,14 +598,24 @@ void InventoryMenu::drawSlot(Painter &p, DrawPass pass, const Page &inv, const P
   if(!slot)
     return;
 
-  p.setBrush(*slot);
-  p.drawRect(x,y,slotSize().w,slotSize().h,
-             0,0,slot->w(),slot->h());
+  auto& page = activePage();
+
+  if(pass==DrawPass::Back){
+    p.setBrush(*slot);
+    p.drawRect(x,y,slotSize().w,slotSize().h,
+               0,0,slot->w(),slot->h());
+
+    if(inv.size()==0 && id==0 && &page==&inv){
+      p.setBrush(*selT);
+      p.drawRect(x,y,slotSize().w,slotSize().h,
+                 0,0,selT->w(),selT->h());
+      }
+    }
 
   if(id>=inv.size())
     return;
-  auto& r    = inv[id];
-  auto& page = activePage();
+
+  auto& r = inv[id];
 
   if(pass==DrawPass::Back) {
     if(id==sel.sel && &page==&inv && selT!=nullptr){

--- a/Game/ui/inventorymenu.cpp
+++ b/Game/ui/inventorymenu.cpp
@@ -192,10 +192,6 @@ void InventoryMenu::tick(uint64_t /*dt*/) {
   }
 
 void InventoryMenu::processMove(KeyEvent& e) {
-  auto&        pg     = activePage();
-  auto&        sel    = activePageSel();
-  const size_t pCount = pagesCount();
-
   auto key = keycodec.tr(e);
   if(key==KeyCodec::Forward)
     moveUp();
@@ -252,9 +248,7 @@ void InventoryMenu::processPickLock(KeyEvent& e) {
   }
 
 void InventoryMenu::moveLeft(bool usePage) {
-  auto&        pg     = activePage();
-  auto&        sel    = activePageSel();
-  const size_t pCount = pagesCount();
+  auto& sel = activePageSel();
 
   if(usePage && sel.sel%columsCount==0 && page>0)
     page--;
@@ -274,7 +268,6 @@ void InventoryMenu::moveRight(bool usePage) {
   }
 
 void InventoryMenu::moveUp() {
-  auto& pg  = activePage();
   auto& sel = activePageSel();
 
   if(sel.sel>=columsCount)
@@ -381,8 +374,6 @@ void InventoryMenu::mouseWheelEvent(MouseEvent &e) {
   if(state==State::LockPicking)
     return;
 
-  auto& pg  = activePage();
-  auto& sel = activePageSel();
   if(e.delta>0)
     for(int i=0;i<e.delta/120;++i){
       moveUp();

--- a/Game/ui/inventorymenu.h
+++ b/Game/ui/inventorymenu.h
@@ -118,6 +118,10 @@ class InventoryMenu : public Tempest::Widget {
 
     void          processMove(Tempest::KeyEvent& e);
     void          processPickLock(Tempest::KeyEvent& e);
+    void          moveLeft(bool usePage);
+    void          moveRight(bool usePage);
+    void          moveUp();
+    void          moveDown();
 
     void          onItemAction();
     void          onTakeStuff();


### PR DESCRIPTION
* Dialogues
  - [x] RMB to skip phrase
  - [x] Esc down (instead of up) to skip phrase
  - [x] Skip fade out animation when phrase is skipped
* Inventory
  - [x] RMB to close
  - [x] Esc down (instead of up) to close inventory (or trade)
  - [x] Move selection left when there is no space to move up
  - [x] Move selection right when there is no space to move down
  - [x] Maintain selection when switching pages
  - [x] Show selection even if inventory is empty

I checked all the changes in the original game.