### PR TITLE
Allow specifying Gothic catalog interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Don't expect DirectX11 mod to work, since technicaly it's not a mod. But Project
 
 ##### Command line arguments
 * -g specify gothic game catalog
+* -i specify gothic game catelog interactively
 * -nomenu - skip main menu
 * -nofrate - disable FPS display in-game
 * -w <worldname.zen> - startup world; newworld.zen is default

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -6,6 +6,8 @@
 #include <zenload/zCMesh.h>
 #include <cstring>
 #include <cctype>
+#include <codecvt>
+#include <locale>
 
 #include "game/definitions/visualfxdefinitions.h"
 #include "game/definitions/sounddefinitions.h"
@@ -31,6 +33,14 @@ Gothic::Gothic(const int argc, const char **argv) {
       ++i;
       if(i<argc)
         gpath.assign(argv[i],argv[i]+std::strlen(argv[i]));
+      }
+    else if(std::strcmp(argv[i],"-i")==0) {
+      ++i;
+      std::cout << "Enter the path to your Gothic installation:\n";
+      std::wstring_convert<std::codecvt_utf8_utf16<char16_t>,char16_t> convert;
+      std::string gothicPath;
+      std::cin >> gothicPath;
+      gpath.assign(convert.from_bytes(gothicPath));
       }
     else if(std::strcmp(argv[i],"-save")==0){
       ++i;


### PR DESCRIPTION
This is useful for environments where it's not feasible to expect users to invoke the game from a command line in such a way that they can specify the parameters they want, e.g. Flatpaks from Flathub.

I can't get latest master to build at all so I haven't tested this there, but it does build against v0.37. Also worth noting is that I've only tested this on Linux, and there are some encoding conversions that may be problematic on Windows?