### PR TITLE
Fix build on case-sensitive filesystems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ add_executable(${PROJECT_NAME}
     ${OPENGOTHIC_SOURCES}
     icon.rc)
 
-include_directories("Game")
+include_directories("game")
 
 # edd-dbg
 include_directories(lib/edd-dbg/include)


### PR DESCRIPTION
This reference to the game directory was not made lowercase when the directory was renamed in 1399b1157dd4d754a41698bc210490b0407fb26c. Fixes https://github.com/Try/OpenGothic/issues/148