### PR TITLE
[Fix] Bug fixes for UI

### DIFF
--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -372,6 +372,11 @@ void MainWindow::keyRepeatEvent(KeyEvent& event) {
   }
 
 void MainWindow::keyUpEvent(KeyEvent &event) {
+  // Don't process any key up events if the game is loading!
+  if (Gothic::inst().checkLoading()!=Gothic::LoadState::Idle) {
+    return;
+    }
+
   if(uiKeyUp==&video){
     video.keyUpEvent(event);
     if(event.isAccepted())

--- a/game/ui/dialogmenu.cpp
+++ b/game/ui/dialogmenu.cpp
@@ -520,6 +520,13 @@ void DialogMenu::mouseWheelEvent(MouseEvent &e) {
   }
 
 void DialogMenu::keyDownEvent(KeyEvent &e) {
+  // Explicitly accept this even so inventory won't open
+  // as long as dialog menu is active.
+  if(e.key==Event::K_Back) {
+    e.accept();
+    return;
+    }
+
   if(state==State::Idle || trade.isOpen()!=InventoryMenu::State::Closed){
     e.ignore();
     return;


### PR DESCRIPTION
Description
A little patch for a couple of UI bugs I've found.

- It's no longer possible to open any menu type (MENU_MAIN, MENU_LOG etc.)
  while the game is loading or saving.
- Removed possibility to open the inventory while the dialog menu is active.