### PR TITLE
Add Clang compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,8 @@ endif()
 
 if(NOT MSVC)
   target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wconversion -Wno-strict-aliasing -Werror)
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "7.1" AND NOT APPLE)
+
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "7.1" AND NOT APPLE AND NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     target_compile_options(${PROJECT_NAME} PRIVATE -Wno-format-truncation)
   endif()
   if(UNIX)

--- a/game/game/damagecalculator.cpp
+++ b/game/game/damagecalculator.cpp
@@ -55,7 +55,7 @@ DamageCalculator::Val DamageCalculator::damageFall(Npc& npc, float speed) {
 
 DamageCalculator::Val DamageCalculator::rangeDamage(Npc& nsrc, Npc& nother, const Bullet& b, const CollideMask bMsk) {
   bool invinsible = !checkDamageMask(nsrc,nother,&b);
-  if(b.pathLength()>MaxBowRange*b.hitChance() && b.hitChance()<1.f)
+  if(b.pathLength() > static_cast<float>(MaxBowRange) * b.hitChance() && b.hitChance()<1.f)
     return Val(0,false,invinsible);
 
   if(invinsible)

--- a/game/game/damagecalculator.cpp
+++ b/game/game/damagecalculator.cpp
@@ -55,7 +55,7 @@ DamageCalculator::Val DamageCalculator::damageFall(Npc& npc, float speed) {
 
 DamageCalculator::Val DamageCalculator::rangeDamage(Npc& nsrc, Npc& nother, const Bullet& b, const CollideMask bMsk) {
   bool invinsible = !checkDamageMask(nsrc,nother,&b);
-  if(b.pathLength() > static_cast<float>(MaxBowRange) * b.hitChance() && b.hitChance()<1.f)
+  if(b.pathLength() > float(MaxBowRange) * b.hitChance() && b.hitChance()<1.f)
     return Val(0,false,invinsible);
 
   if(invinsible)


### PR DESCRIPTION
This PR adds support for the Clang compiler. The build mostly works out-of-the box, however the `-Wno-format-truncation` is not supported by Clang and an additional error was being generated by `DamageCalculator::rangeDamage(Npc&, Npc& const Bullet&, const CollideMask)` where an integer enum value was multiplied with a floating point value.

I have fixed both of these issues. There is another [issue](https://github.com/Try/Tempest/pull/28) related to Clang compatibility in Tempest however, which needs to be merged too in order to properly support Clang.