### PR TITLE
allow usage of mouse 4 and 5

### DIFF
--- a/game/utils/keycodec.cpp
+++ b/game/utils/keycodec.cpp
@@ -64,9 +64,11 @@ std::initializer_list<KeyCodec::K_Key> KeyCodec::keys = {
   };
 
 std::initializer_list<KeyCodec::M_Key> KeyCodec::mkeys = {
-  {Tempest::Event::ButtonLeft,  0x0c02},
-  {Tempest::Event::ButtonMid,   0x0e02},
-  {Tempest::Event::ButtonRight, 0x0d02},
+  {Tempest::Event::ButtonLeft,    0x0c02},
+  {Tempest::Event::ButtonMid,     0x0e02},
+  {Tempest::Event::ButtonRight,   0x0d02},
+  {Tempest::Event::ButtonForward, 0x0e12},
+  {Tempest::Event::ButtonBack,    0x0e22},
   };
 
 KeyCodec::KeyCodec() {
@@ -335,6 +337,14 @@ void KeyCodec::keyToStr(Tempest::Event::MouseButton k, char* buf, size_t bufSz) 
     }
   if(k==Tempest::Event::ButtonRight) {
     std::strncpy(buf,"MOUSE RIGHT",bufSz);
+    return;
+    }
+  if(k==Tempest::Event::ButtonForward) {
+    std::strncpy(buf,"MOUSE 5",bufSz);
+    return;
+    }
+  if(k==Tempest::Event::ButtonBack) {
+    std::strncpy(buf,"MOUSE 4",bufSz);
     return;
     }
 


### PR DESCRIPTION
A small change that allows to set mouse 4 and 5 as bindings.
I wasn't sure about the hex numbers so I just incremented the second 0.

Seems to work fine.