### PR TITLE
implemented gothic 2 controls

### DIFF
--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -128,7 +128,7 @@ void PlayerControl::onKeyPressed(KeyCodec::Action a, Tempest::KeyEvent::KeyType 
 
   if(fk>=0) {
     std::memset(actrl,0,sizeof(actrl));
-    actrl[ActGeneric] = true;
+    actrl[ActGeneric] = ctrl[KeyCodec::ActionGeneric];
     actrl[fk]         = true;
 
     ctrl[a] = true;

--- a/game/utils/keycodec.cpp
+++ b/game/utils/keycodec.cpp
@@ -184,6 +184,13 @@ KeyCodec::Action KeyCodec::implTr(int32_t code) const {
 
   if(keyAction.is(code))
     return ActionGeneric;
+  if(keyActionLeft.is(code))
+    return ActionLeft;
+  if(keyActionRight.is(code))
+    return ActionRight;
+  if(keyParade.is(code))
+    return Parade;
+
   if(keySlow.is(code))
     return Walk;
   if(keySMove.is(code))

--- a/game/utils/keycodec.h
+++ b/game/utils/keycodec.h
@@ -30,6 +30,10 @@ class KeyCodec final {
       Jump,
 
       ActionGeneric,
+      ActionLeft,
+      ActionRight,
+      Parade,
+
       Walk,
       Sneak,
 


### PR DESCRIPTION
Merge for [#214](https://github.com/Try/OpenGothic/issues/214)

I noticed that the running attack seems to have a bug (even without this change).
In the gothic 1 control scheme the running attack sometimes doesn't work properly. Especially if you already did a normal attack.
In the gothic 2 control scheme the running attack always doesn't work properly.

When you try to initiate the running attack, the hero stops and does a normal attack which seems to hit twice.

I tried to find the issue in `npc.cpp doAttack`, but couldn't find anything related to the differentiation between a running and a normal attack.

Maybe it would be best to fix this problem in this branch, but I'm a bit lost right now.

The other attacks seem to work like vanilla gothic 2 with gothic 2 controls.