### PR TITLE
Add CLI option to force the game version

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,5 @@ make -C build -j <number_of_cpucores>
 * -window - window mode
 * -rambo - reduce damage to player to 1hp
 * -v -validation - enable Vulkan validation mode
+* -g1 - assume a Gothic 1 installation
+* -g2 - assume a Gothic 2 installation

--- a/game/commandline.cpp
+++ b/game/commandline.cpp
@@ -59,6 +59,12 @@ CommandLine::CommandLine(int argc, const char** argv) {
     else if(arg=="-rambo") {
       isRambo  = true;
       }
+    else if(arg=="-g1") {
+      forceG1 = true;
+      }
+    else if(arg=="-g2") {
+      forceG2 = true;
+      }
     else if(arg=="-dx12") {
       graphics = GraphicBackend::DirectX12;
       }

--- a/game/commandline.h
+++ b/game/commandline.h
@@ -27,6 +27,8 @@ class CommandLine {
     bool                isWindowMode() const { return isWindow; }
     bool                isRayQuery()   const { return isRQuery; }
     bool                doStartMenu()  const { return !noMenu;  }
+    bool                doForceG1()    const { return forceG1;  }
+    bool                doForceG2()    const { return forceG2;  }
     std::string_view    defaultSave()  const { return saveDef;  }
 
     std::string         wrldDef;
@@ -43,5 +45,7 @@ class CommandLine {
     bool                isDebug  = false;
     bool                isRambo  = false;
     bool                isRQuery = false;
+    bool                forceG1  = false;
+    bool                forceG2  = false;
   };
 

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -665,6 +665,11 @@ void Gothic::detectGothicVersion() {
     vinfo.game = 1; else
     vinfo.game = 2;
 
+  if (CommandLine::inst().doForceG1())
+    vinfo.game = 1;
+  else if (CommandLine::inst().doForceG2())
+    vinfo.game = 2;
+
   if(vinfo.game==2) {
     vinfo.patch = baseIniFile->getI("GAME","PATCHVERSION");
     }

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -665,9 +665,9 @@ void Gothic::detectGothicVersion() {
     vinfo.game = 1; else
     vinfo.game = 2;
 
-  if (CommandLine::inst().doForceG1())
+  if(CommandLine::inst().doForceG1())
     vinfo.game = 1;
-  else if (CommandLine::inst().doForceG2())
+  else if(CommandLine::inst().doForceG2())
     vinfo.game = 2;
 
   if(vinfo.game==2) {


### PR DESCRIPTION
In some circumstances OpenGothic might not detect whether Gothic 1 or Gothic 2 is being started. This can happen due to a multitude of reasons: 
- The game path has "Gothic/" in it (this is an issue if you keep your installations in a common folder named "Gothic")
- `GOTHIC.INI` missing from `<install-path>/System` (this happens when using the GOG version of G2 NotR)
- Running on an OS with a case-sensitive file system (like Linux; can be circumvented using [ciopfs](https://www.brain-dump.org/projects/ciopfs/))
- Running the German version of G 2NotR (it has a `OU.BIN` file instead of an `OU.DAT`)

This PR adds two command-line parameters which allow the user to force OpenGothic to disregard the version detection logic and force it to assume either G1 or G2.