### PR TITLE
Read enabled .mod files from ini file

### DIFF
--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -116,7 +116,7 @@ Gothic::Gothic() {
         modvdfs.push_back(mod);
       }
     }
-  Resources::loadAssets(modvdfs);
+  Resources::loadVdfs(modvdfs);
 
   if(wrldDef.empty()) {
     if(version().game==2)

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -6,6 +6,8 @@
 #include <zenload/zCMesh.h>
 #include <cstring>
 #include <cctype>
+#include <vector>
+#include <sstream>
 
 #include "game/definitions/visualfxdefinitions.h"
 #include "game/definitions/sounddefinitions.h"

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -6,9 +6,6 @@
 #include <zenload/zCMesh.h>
 #include <cstring>
 #include <cctype>
-#include <locale>
-#include <sstream>
-#include <vector>
 
 #include "game/definitions/visualfxdefinitions.h"
 #include "game/definitions/sounddefinitions.h"
@@ -112,10 +109,11 @@ Gothic::Gothic() {
     plDef = modFile->getS("SETTINGS","PLAYER");
 
     std::u16string vdf = TextCodec::toUtf16(std::string(modFile->getS("FILES","VDF")));
-    std::basic_stringstream<char16_t> stringstream { vdf };
-    while (std::getline(stringstream, vdf, char16_t(' '))) {
-      if(!vdf.empty())
-        modvdfs.push_back(vdf);
+    for (size_t start = 0, split = 0; split != std::string::npos; start = split+1) {
+      split = vdf.find(' ', start);
+      std::u16string mod = vdf.substr(start, split-start);
+      if (!mod.empty())
+        modvdfs.push_back(mod);
       }
     }
   Resources::loadAssets(modvdfs);

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -100,13 +100,22 @@ Gothic::Gothic() {
     modFile.reset(new IniFile(mod));
     }
 
+  std::vector<std::u16string> modvdfs;
   if(modFile!=nullptr) {
     wrldDef = modFile->getS("SETTINGS","WORLD");
     size_t split = wrldDef.rfind('\\');
     if(split!=std::string::npos)
       wrldDef = wrldDef.substr(split+1);
     plDef = modFile->getS("SETTINGS","PLAYER");
+
+    std::u16string vdf = TextCodec::toUtf16(std::string(modFile->getS("FILES","VDF")));
+    std::basic_stringstream<char16_t> stringstream { vdf };
+    while (std::getline(stringstream, vdf, char16_t(' '))) {
+      if(!vdf.empty())
+        modvdfs.push_back(vdf);
+      }
     }
+  Resources::loadAssets(modvdfs);
 
   if(wrldDef.empty()) {
     if(version().game==2)

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -6,8 +6,9 @@
 #include <zenload/zCMesh.h>
 #include <cstring>
 #include <cctype>
-#include <vector>
+#include <locale>
 #include <sstream>
+#include <vector>
 
 #include "game/definitions/visualfxdefinitions.h"
 #include "game/definitions/sounddefinitions.h"

--- a/game/resources.cpp
+++ b/game/resources.cpp
@@ -104,7 +104,7 @@ Resources::Resources(Tempest::Device &device)
   }
   }
 
-void Resources::loadAssets(const std::vector<std::u16string>& modvdfs) {
+void Resources::loadVdfs(const std::vector<std::u16string>& modvdfs) {
   std::vector<Archive> archives;
   inst->detectVdf(archives,Gothic::inst().nestedPath({u"Data"},Dir::FT_Dir));
 

--- a/game/resources.cpp
+++ b/game/resources.cpp
@@ -102,9 +102,23 @@ Resources::Resources(Tempest::Device &device)
   Pixmap pm(1,1,Pixmap::Format::RGBA);
   fbZero = device.texture(pm);
   }
+  }
 
+void Resources::loadAssets(const std::vector<std::u16string>& modvdfs) {
   std::vector<Archive> archives;
-  detectVdf(archives,Gothic::inst().nestedPath({u"Data"},Dir::FT_Dir));
+  inst->detectVdf(archives,Gothic::inst().nestedPath({u"Data"},Dir::FT_Dir));
+
+  // Remove all mod files, that are not listed in modvdfs
+  archives.erase(std::remove_if(archives.begin(), archives.end(),
+                [&modvdfs](const Archive& a){
+                  return a.isMod && modvdfs.end() == std::find_if(modvdfs.begin(), modvdfs.end(),
+                        [&a](const std::u16string& modname) {
+                          const std::u16string_view& full_path = a.name;
+                          const std::u16string_view& file_name = modname;
+                          return (0 == full_path.compare(full_path.length() - file_name.length(),
+                                                         file_name.length(), file_name));
+                          });
+                  }), archives.end());
 
   // addon archives first!
   std::stable_sort(archives.begin(),archives.end(),[](const Archive& a,const Archive& b){
@@ -115,8 +129,8 @@ Resources::Resources(Tempest::Device &device)
     });
 
   for(auto& i:archives)
-    gothicAssets.loadVDF(i.name);
-  gothicAssets.finalizeLoad();
+    inst->gothicAssets.loadVDF(i.name);
+  inst->gothicAssets.finalizeLoad();
 
   //for(auto& i:gothicAssets.getKnownFiles())
   //  Log::i(i);

--- a/game/resources.cpp
+++ b/game/resources.cpp
@@ -17,6 +17,7 @@
 #include <zenload/zenParser.h>
 #include <zenload/ztex2dds.h>
 
+#include <algorithm>
 #include <fstream>
 
 #include "graphics/mesh/submesh/staticmesh.h"

--- a/game/resources.cpp
+++ b/game/resources.cpp
@@ -17,7 +17,6 @@
 #include <zenload/zenParser.h>
 #include <zenload/ztex2dds.h>
 
-#include <algorithm>
 #include <fstream>
 
 #include "graphics/mesh/submesh/staticmesh.h"

--- a/game/resources.h
+++ b/game/resources.h
@@ -81,6 +81,7 @@ class Resources final {
 
     static Tempest::Device&          device() { return inst->dev; }
     static const char*               renderer();
+    static void                      loadAssets(const std::vector<std::u16string> &modvdfs);
 
     static const Tempest::Sampler2d& shadowSampler();
 

--- a/game/resources.h
+++ b/game/resources.h
@@ -81,7 +81,7 @@ class Resources final {
 
     static Tempest::Device&          device() { return inst->dev; }
     static const char*               renderer();
-    static void                      loadAssets(const std::vector<std::u16string> &modvdfs);
+    static void                      loadVdfs(const std::vector<std::u16string> &modvdfs);
 
     static const Tempest::Sampler2d& shadowSampler();
 


### PR DESCRIPTION
Currently all files in Data/ and Data/modvdf are loaded. This prevents having multiple mods installed. With this change, only the .mod files listed in the ini file (with -game:\<inifile>) are loaded.

>  [FILES]
vdf=FunnyMod.mod (Gothic 1)
VDF=FunnyMod.mod (Gothic 2)
List of all .mod files created for the mod. If this is more than one, they are listed separated by spaces (FunnyMod1.mod FunnyMod2.mod ...). GothicStarter first copies all *.mod files from .../Data/ to .../Data/modvdf/ before starting a modification and then copies all specified files from .../Data/modvdf/ to .../Data. The value "VDF" must exist (even if it is empty) for GothicStarter to accept the INI. In G2, the special value "!<invalid>" can be used to explicitly disable reading by the GothicStarter. During development a VDF list is most useful. It is very important with G2 that the parameter GohticGame.mod is not here! This leads to the fact that all changes to the scripts are ignored. 

https://wiki.worldofgothic.de/doku.php?id=ini-datei
