### PR TITLE
Play stow animation if a drawn weapon is unequipped

### DIFF
--- a/game/game/inventory.cpp
+++ b/game/game/inventory.cpp
@@ -356,6 +356,9 @@ bool Inventory::unequip(size_t cls, Npc &owner) {
   }
 
 void Inventory::unequip(Item *it, Npc &owner) {
+  if (it==activeWeapon())
+  owner.closeWeapon(false);
+  
   if(armour==it) {
     setSlot(armour,nullptr,owner,false);
     return;

--- a/game/game/inventory.cpp
+++ b/game/game/inventory.cpp
@@ -356,9 +356,6 @@ bool Inventory::unequip(size_t cls, Npc &owner) {
   }
 
 void Inventory::unequip(Item *it, Npc &owner) {
-  if (it==activeWeapon())
-  owner.closeWeapon(false);
-  
   if(armour==it) {
     setSlot(armour,nullptr,owner,false);
     return;

--- a/game/ui/inventorymenu.cpp
+++ b/game/ui/inventorymenu.cpp
@@ -106,6 +106,7 @@ void InventoryMenu::close() {
 void InventoryMenu::open(Npc &pl) {
   if(pl.isDown())
     return;
+  pl.closeWeapon(false);
   state  = State::Equip;
   player = &pl;
   trader = nullptr;

--- a/game/ui/inventorymenu.cpp
+++ b/game/ui/inventorymenu.cpp
@@ -104,9 +104,12 @@ void InventoryMenu::close() {
   }
 
 void InventoryMenu::open(Npc &pl) {
-  if(pl.isDown())
+  if(pl.isDown() || pl.isMonster())
     return;
-  pl.closeWeapon(false);
+  if(pl.weaponState()!=WeaponState::NoWeapon) {
+    pl.stopAnim("");
+    pl.closeWeapon(false);
+    }
   state  = State::Equip;
   player = &pl;
   trader = nullptr;

--- a/game/ui/inventorymenu.cpp
+++ b/game/ui/inventorymenu.cpp
@@ -104,7 +104,7 @@ void InventoryMenu::close() {
   }
 
 void InventoryMenu::open(Npc &pl) {
-  if(pl.isDown() || pl.isMonster())
+  if(pl.isDown() || pl.isMonster() || !pl.isStanding())
     return;
   if(pl.weaponState()!=WeaponState::NoWeapon) {
     pl.stopAnim("");


### PR DESCRIPTION
As a  followup to [9f01e8f](https://github.com/Try/OpenGothic/commit/9f01e8fdca346b32e0195c78733104cbc56cbe7e).