### PR TITLE
Set correct Weapon Damage after dead/downstate

### DIFF
--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -564,6 +564,7 @@ bool Npc::checkHealth(bool onChange,bool allowUnconscious) {
   }
 
 void Npc::onNoHealth(bool death, HitSound sndMask) {
+  invent.switchActiveWeapon(*this,Item::NSLOT);
   visual.dropWeapon(*this);
   dropTorch();
   visual.setToFightMode(WeaponState::NoWeapon);


### PR DESCRIPTION
If you get killed or become unconscious while wielding a e.g. 1H weapon, every other 1H weapon you have or pick up will have  the dropped weapon's damage added.

For testing start a new game and grab a branch from the goblins at Cavalorn's place. Now let the bandit kill you, revive with F8 and  pick-up your branch or get a new one from the goblins. If you now attack the bandit, weapon damage is now 20 instead of 10.

fixes https://github.com/Try/OpenGothic/issues/310