### PR TITLE
Allow open inventory while walking

### DIFF
--- a/game/ui/inventorymenu.cpp
+++ b/game/ui/inventorymenu.cpp
@@ -104,7 +104,7 @@ void InventoryMenu::close() {
   }
 
 void InventoryMenu::open(Npc &pl) {
-  if(pl.isDown() || pl.isMonster() || !pl.isStanding())
+  if(pl.isDown() || pl.isMonster() || pl.isInAir() || pl.isSlide() || (pl.interactive()!=nullptr))
     return;
   if(pl.weaponState()!=WeaponState::NoWeapon) {
     pl.stopAnim("");


### PR DESCRIPTION
A small update to https://github.com/Try/OpenGothic/pull/317.  Currently if you press the inventory key while walking the character just stops instead of opening the inventory.