### PR TITLE
Add Sengrath's crossbow to his inventory if he's dead

### DIFF
--- a/game/ui/inventorymenu.cpp
+++ b/game/ui/inventorymenu.cpp
@@ -104,7 +104,7 @@ void InventoryMenu::close() {
   }
 
 void InventoryMenu::open(Npc &pl) {
-  if(pl.isDown() || pl.isMonster() || pl.isInAir() || pl.isSlide() || (pl.interactive()!=nullptr))
+  if(pl.isDown() || pl.isMonster() || pl.isInAir() || pl.isSlide() || pl.interactive()!=nullptr)
     return;
   if(pl.weaponState()!=WeaponState::NoWeapon) {
     pl.stopAnim("");
@@ -145,6 +145,9 @@ bool InventoryMenu::ransack(Npc &pl, Npc &tr) {
   auto it = tr.inventory().iterator(Inventory::T_Ransack);
   if(!it.isValid())
     return false;
+  // fix quest "Lost in Darkness"
+  if (tr.displayName()=="Sengrath" && tr.isDead())
+    tr.addItem(7674,1);
   state  = State::Ransack;
   player = &pl;
   trader = &tr;


### PR DESCRIPTION
... so you can solve the corresponding quest. I attached a save file to verify. Also removed unnecessary parentheses.

 [save_slot_1.zip](https://github.com/Try/OpenGothic/files/9638752/save_slot_1.zip)

fixes https://github.com/Try/OpenGothic/issues/309

Ah just noticed this can be abused if not the entire inventory is looted. Looking into it.
