### PR TITLE
Unequip Sengrath's sword

### DIFF
--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1141,8 +1141,10 @@ void Npc::changeAttribute(Attribute a, int32_t val, bool allowUnconscious) {
 
   if(a==ATR_HITPOINTS) {
     checkHealth(true,allowUnconscious);
-    if(aiPolicy==AiFar || aiPolicy==AiFar2)
+    if(aiPolicy==AiFar || aiPolicy==AiFar2) {
       aiState.started = true;
+      invent.unequipWeapons(owner.script(),*this);
+      }
     }
   }
 


### PR DESCRIPTION
The unequip routine is not called upon his death, so do it manually.
https://github.com/Try/OpenGothic/issues/309