### PR TITLE
Remove kuba-zip from submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "lib/TinySoundFont"]
 	path = lib/TinySoundFont
 	url = https://github.com/schellingb/TinySoundFont.git
-[submodule "lib/kuba-zip"]
-	path = lib/kuba-zip
-	url = https://github.com/kuba--/zip.git


### PR DESCRIPTION
This causes issues with cloning OpenGothic in some setups, and I don't think it was intended to be left here.