### PR TITLE
allow using Enter in addition to LMB in journal and inventory

### DIFF
--- a/game/ui/gamemenu.cpp
+++ b/game/ui/gamemenu.cpp
@@ -123,6 +123,10 @@ struct GameMenu::ListViewDialog : Dialog {
 
   void keyDownEvent(KeyEvent &e) override { e.accept(); }
   void keyUpEvent  (KeyEvent &e) override {
+    if(e.key==Event::K_Return) {
+      showQuest();
+      return;
+      }
     if(e.key==Event::K_ESCAPE) {
       close();
       return;

--- a/game/ui/inventorymenu.cpp
+++ b/game/ui/inventorymenu.cpp
@@ -321,7 +321,7 @@ void InventoryMenu::keyDownEvent(KeyEvent &e) {
     takeTimer.start(200);
     onTakeStuff();
     }
-  else if (keycodec.tr(e)==KeyCodec::ActionGeneric) {
+  else if (keycodec.tr(e)==KeyCodec::ActionGeneric || e.key==KeyEvent::K_Return) {
     onItemAction(Item::NSLOT);
     }
   else if((KeyEvent::K_3<=e.key && e.key<=KeyEvent::K_9) || e.key==KeyEvent::K_0) {


### PR DESCRIPTION
Some game UI parts only support the left mouse button click and not the Enter button for certain actions, making the control a bit more cumbersome on Steam Deck than it needs to be. This PR allows to show quest details and to interact with items in the inventory using the Enter key. This improves user experience when playing on Steam Deck.

Since neither the original nor OpenGothic support gamepad controls, the Steam Deck uses Steam Input to map the physical buttons to simulated keyboard/mouse button presses. In the input mapping assigned by default, the A button is mapped to Enter key.