### PR TITLE
stop Npc animation if player wants to talk

### DIFF
--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -3510,10 +3510,13 @@ void Npc::setPerceptionDisable(PercType t) {
   }
 
 void Npc::startDialog(Npc& pl) {
-   if(pl.isDown() || pl.isInAir() || isPlayer())
+  if(pl.isDown() || pl.isInAir() || isPlayer())
     return;
-  if(perceptionProcess(pl,nullptr,0,PERC_ASSESSTALK))
+  if(perceptionProcess(pl,nullptr,0,PERC_ASSESSTALK)) {
     setOther(&pl);
+    if(aniWaitTime>owner.tickCount())
+      aniWaitTime=owner.tickCount();
+    }
   }
 
 bool Npc::perceptionProcess(Npc &pl) {


### PR DESCRIPTION
For long duration animations like the sword training.

fixes https://github.com/Try/OpenGothic/issues/296