### PR TITLE
update Readme, add Fedora compilation info, document -dx12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,95 @@
-### OpenGothic
-Open source remake of Gothic 2: Night of the raven.
-Motivation: The original Gothic 1 and Gothic 2 are still great games, but it not easy to make them work on modern systems.  
-The goal of this project is to make a feature complete Gothic game client compatible with the game and mods.
+## OpenGothic
+Open source remake of Gothic 2: Night of the Raven.
+
+Motivation: The original Gothic 1 and Gothic 2 are still great games, but it's not easy to make them work on modern systems.
+The goal of this project is to make a feature complete Gothic game client compatible with the original game data and mods.
 
 ----
 [![Latest build](https://img.shields.io/github/release-pre/Try/opengothic?style=for-the-badge)](https://github.com/Try/opengothic/releases/latest)
 ![Screenshoot](scr0.png)
-##### Work in progress
-[![Build status](https://ci.appveyor.com/api/projects/status/github/Try/opengothic?svg=true)](https://ci.appveyor.com/project/Try/opengothic)  
 
-The base game has been replicated fully: you can complete the main quest and addon. 
-Check out the [bugtracker](https://github.com/Try/OpenGothic/issues) for list of known issues.
+### Work in progress
+[![Build status](https://ci.appveyor.com/api/projects/status/github/Try/opengothic?svg=true)](https://ci.appveyor.com/project/Try/opengothic)
 
-##### Install on Windows
-1. Install original gothic game from CD/Steam/GOG/etc  
-*you have to install original game, since OpenGothic does not have any game assets or game scripts as built-in*
+The original game has been replicated fully; you can complete both the main quest and the addon.
+Check out the [bugtracker](https://github.com/Try/OpenGothic/issues) for a list of known issues.
+
+### Install on Windows
+1. Install original Gothic game from CD/Steam/GOG/etc.
+*you have to install the original game as OpenGothic does not provide any built-in game assets or game scripts*
 2. [Download latest stable build](https://github.com/Try/opengothic/releases/latest)
-3. run '/OpenGothic/bin/Gothic2Notr.exe -g "C:\Program Files (x86)\Path\To\Gothic II"'
-Common Gothic installation paths:  
+3. Run '/OpenGothic/bin/Gothic2Notr.exe -g "C:\Program Files (x86)\Path\To\Gothic II"'
+
+Common Gothic installation paths to be provided via `-g`:
 - "C:\Program Files (x86)\JoWooD\Gothic II"
 - "C:\Gothic II"
 - "C:\Program Files (x86)\Steam\steamapps\common\Gothic II"
 - "~/PlayOnLinux's virtual drives/Gothic2_gog/drive_c/Gothic II"
 
-##### Build it for Linux
+### Build on Linux
+#### Dependencies
+* Ubuntu 20.04
 ```bash
-# 1. Install dependencies
-# 1.1 Latest vulkan SDK
+# latest Vulkan SDK provided externally as Ubuntu packages are usually older
 wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
 sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list http://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list
 sudo apt update
 sudo apt install vulkan-sdk
-# 1.2 Ubuntu 20.04:
+
+# distro-provided packages
 sudo apt install git cmake g++ glslang-tools libvulkan-dev libasound2-dev libx11-dev libxcursor-dev
-# 1.3 Arch:
-sudo pacman -S git cmake gcc glslang vulkan-devel alsa-lib libx11 libxcursor vulkan-icd-loader libglvnd
-# 2. Clone this repo, including submodules:
-git clone --recurse-submodules https://github.com/Try/OpenGothic.git
-# 2.1 if you pull a new version:
-git pull --recurse-submodules
-# 3. Create build dir and build as usual:
-cd OpenGothic
-cmake -B build -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo
-make -C build -j <number_of_cpucores>
-# 4.
-# locate executables at OpenGothic/build/opengothic
 ```
 
-#### Gameplay video
-[![Video](https://img.youtube.com/vi/R9MNhNsBVQ0/0.jpg)](https://www.youtube.com/watch?v=R9MNhNsBVQ0) [![Video](https://img.youtube.com/vi/6BvwNkPMbwM/0.jpg)](https://www.youtube.com/watch?v=6BvwNkPMbwM)
+* Arch
+```bash
+sudo pacman -S git cmake gcc glslang vulkan-devel alsa-lib libx11 libxcursor vulkan-icd-loader libglvnd
+```
 
-##### Mods compatibility
+* Fedora
+```bash
+sudo dnf install git cmake gcc-c++ glslang vulkan-loader-devel alsa-lib-devel libX11-devel libXcursor-devel vulkan-validation-layers-devel libglvnd-devel
+```
+
+#### Compilation
+```bash
+# 1st time build:
+git clone --recurse-submodules https://github.com/Try/OpenGothic.git
+cd OpenGothic
+cmake -B build -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo
+make -C build -j $(nproc)
+
+# following builds:
+git pull --recurse-submodules
+make -C build -j $(nproc)
+
+# locate the executables at OpenGothic/build/opengothic
+```
+
+### Gameplay video
+[![Video](https://img.youtube.com/vi/R9MNhNsBVQ0/0.jpg)](https://www.youtube.com/watch?v=R9MNhNsBVQ0)
+[![Video](https://img.youtube.com/vi/6BvwNkPMbwM/0.jpg)](https://www.youtube.com/watch?v=6BvwNkPMbwM)
+
+### Mods compatibility
 - [x] Content mods (retexture/reworld/animations)
-- [ ] Mods bases on Ikarus/LeGo 
+- [ ] Mods bases on Ikarus/LeGo
 - [ ] AST sdk
 - [ ] Mods bases on Union (not possible)
 - [ ] DirectX11 - same as Union, but don't worry - OpenGothic has nice graphics out of the box
 
-##### Command line arguments
-* -g specify gothic game catalog
-* -game:<modfile.init> specify game modification manifest (GothicStarter compatibility)
-* -nomenu - skip main menu
-* -nofrate - disable FPS display in-game
-* -w <worldname.zen> - startup world; newworld.zen is default
-* -save \<q> - startup with quick save
-* -save \<number> - startup with specified save-game slot
-* -window - window mode
-* -v -validation - enable Vulkan validation mode
-* -g1 - assume a Gothic 1 installation
-* -g2 - assume a Gothic 2 installation
-* -rt \<boolean> - explicitly enable or disable ray-query
-* -ms \<boolean> - explicitly enable or disable meshlets
+### Command line arguments
+| Argument(s)            | Description                                                      |
+| ---------------------- | -------                                                          |
+| `-g`                   | specify path containing Gothic game data                         |
+| `-game:<modfile.init>` | specify game modification manifest (GothicStarter compatibility) |
+| `-nomenu`              | skip main menu                                                   |
+| `-nofrate`             | disable FPS display in-game                                      |
+| `-w <worldname.zen>`   | startup world; newworld.zen is default                           |
+| `-save q`              | load the quick save on start                                     |
+| `-save <number>`       | load a specified save-game slot on start                         |
+| `-v -validation`       | enable Vulkan validation mode                                    |
+| `-dx12`                | force DirectX 12 renderer instead of Vulkan (Windows only)       |
+| `-g1`                  | assume a Gothic 1 installation                                   |
+| `-g2`                  | assume a Gothic 2 installation                                   |
+| `-rt <boolean>`        | explicitly enable or disable ray-query                           |
+| `-ms <boolean>`        | explicitly enable or disable meshlets                            |
+| `-window`              | windowed debugging mode (not to be used for playing)             |


### PR DESCRIPTION
The result can be seen in practice here: https://github.com/Nindaleth/OpenGothic/tree/feature/readme-fedora

Summary of changes:

* improve individual sections, but don't change the section order or presence - most obvious refactors are in the Linux compilation and the command line argument description sections
* document dependencies for compiling on Fedora
* document the -dx12 flag
* make the headlines bit more headline-y