### PR TITLE
Respawn System

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,5 @@ make -C build -j $(nproc)
 | `-g2`                  | assume a Gothic 2 installation                                   |
 | `-rt <boolean>`        | explicitly enable or disable ray-query                           |
 | `-ms <boolean>`        | explicitly enable or disable meshlets                            |
+| `-respawn`             | enable respawn system (monsters will respawn after some days)    |
 | `-window`              | windowed debugging mode (not to be used for playing)             |

--- a/game/commandline.cpp
+++ b/game/commandline.cpp
@@ -78,6 +78,9 @@ CommandLine::CommandLine(int argc, const char** argv) {
       if(i<argc)
         isMeshSh = (std::string_view(argv[i])!="0" && std::string_view(argv[i])!="false");
       }
+    else if(arg=="-respawn") {
+      respawn  = true;
+      }
     }
 
   if(gpath.empty()) {

--- a/game/commandline.h
+++ b/game/commandline.h
@@ -30,6 +30,7 @@ class CommandLine {
     bool                doStartMenu()   const { return !noMenu;  }
     bool                doForceG1()     const { return forceG1;  }
     bool                doForceG2()     const { return forceG2;  }
+    bool                doRespawn()     const { return respawn;  }
     std::string_view    defaultSave()   const { return saveDef;  }
 
     std::string         wrldDef;
@@ -52,5 +53,6 @@ class CommandLine {
     bool                isMeshSh = true;
     bool                forceG1  = false;
     bool                forceG2  = false;
+    bool                respawn  = false;
   };
 

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -13,6 +13,7 @@
 #include "world/objects/npc.h"
 #include "world/objects/item.h"
 #include "world/objects/interactive.h"
+#include "world/respawnobject.h"
 #include "graphics/visualfx.h"
 #include "utils/fileutil.h"
 #include "gothic.h"
@@ -1370,6 +1371,7 @@ bool GameScript::game_initenglish() {
 
 void GameScript::wld_settime(int hour, int minute) {
   world().setDayTime(hour,minute);
+  RespawnObject::processRespawnList();
   }
 
 int GameScript::wld_getday() {

--- a/game/game/gamesession.cpp
+++ b/game/game/gamesession.cpp
@@ -8,6 +8,7 @@
 
 #include "worldstatestorage.h"
 #include "world/objects/npc.h"
+#include "world/respawnobject.h"
 #include "world/world.h"
 #include "sound/soundfx.h"
 #include "serialize.h"
@@ -121,6 +122,10 @@ GameSession::GameSession(Serialize &fin) {
   vm.reset(new GameScript(*this));
   vm->initDialogs();
 
+  if (fin.setEntry("game/respawn"))
+    // Load respawn state if entry exists (backward compatibility with older savegames)
+    RespawnObject::loadRespawnState(fin);
+
   if(true) {
     setWorld(std::unique_ptr<World>(new World(*this,wname,false,[&](int v){
       Gothic::inst().setLoadingProgress(int(v*0.55));
@@ -191,6 +196,10 @@ void GameSession::save(Serialize &fout, std::string_view name, const Pixmap& scr
 
   fout.setEntry("game/quests");
   vm->saveQuests(fout);
+
+  Gothic::inst().setLoadingProgress(70);
+  fout.setEntry("game/respawn");
+  RespawnObject::saveRespawnState(fout);
 
   fout.setEntry("game/daedalus");
   vm->saveVar(fout);

--- a/game/game/gamesession.cpp
+++ b/game/game/gamesession.cpp
@@ -226,6 +226,7 @@ std::unique_ptr<World> GameSession::clearWorld() {
 void GameSession::changeWorld(std::string_view world, std::string_view wayPoint) {
   chWorld.zen = world;
   chWorld.wp  = wayPoint;
+  Gothic::inst().setChangeWldFlg();
   }
 
 void GameSession::exitSession() {

--- a/game/game/serialize.cpp
+++ b/game/game/serialize.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 
 #include "savegameheader.h"
+#include "world/respawnobject.h"
 #include "world/world.h"
 #include "world/fplock.h"
 #include "world/waypoint.h"
@@ -239,6 +240,14 @@ void Serialize::implRead(Interactive*& mobsi) {
   uint32_t id=uint32_t(-1);
   implRead(id);
   mobsi = ctx==nullptr ? nullptr : ctx->mobsiById(id);
+  }
+
+void Serialize::implWrite(const RespawnObject& ro) {
+  ro.save(*this);
+  }
+
+void Serialize::implRead(RespawnObject& ro) {
+  ro = RespawnObject(*this);
   }
 
 void Serialize::implWrite(const SaveGameHeader& p) {

--- a/game/game/serialize.h
+++ b/game/game/serialize.h
@@ -254,9 +254,6 @@ class Serialize {
     void implWrite(const RespawnObject& ro);
     void implRead (RespawnObject&       ro);
 
-    void implWrite(const Daedalus::GEngineClasses::C_Npc& h);
-    void implRead (Daedalus::GEngineClasses::C_Npc&       h);
-
     void implWrite(const FpLock& fp);
     void implRead (FpLock& fp);
 

--- a/game/game/serialize.h
+++ b/game/game/serialize.h
@@ -24,6 +24,7 @@
 
 class WayPoint;
 class Npc;
+class RespawnObject;
 class Interactive;
 class World;
 class FpLock;
@@ -250,6 +251,11 @@ class Serialize {
     void implRead (Tempest::Pixmap&       p);
 
     void implWrite(const phoenix::c_npc& h);
+    void implWrite(const RespawnObject& ro);
+    void implRead (RespawnObject&       ro);
+
+    void implWrite(const Daedalus::GEngineClasses::C_Npc& h);
+    void implRead (Daedalus::GEngineClasses::C_Npc&       h);
 
     void implWrite(const FpLock& fp);
     void implRead (FpLock& fp);

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -45,6 +45,7 @@ Gothic::Gothic() {
 
   noFrate = CommandLine::inst().noFrate;
   wrldDef = CommandLine::inst().wrldDef;
+  respawn = CommandLine::inst().doRespawn();
   if(hasMeshShader())
     isMeshSh = CommandLine::inst().isMeshShading();
 
@@ -456,6 +457,7 @@ void Gothic::cancelLoading() {
   if(loadingFlag.load()!=LoadState::Idle){
     loaderTh.join();
     loadingFlag.store(LoadState::Idle);
+    Gothic::inst().clearChangeWldFlg();
     }
   }
 

--- a/game/gothic.h
+++ b/game/gothic.h
@@ -92,11 +92,17 @@ class Gothic final {
     bool         doRayQuery() const;
     bool         doMeshShading() const;
 
+    bool         doRespawn() const { return respawn; };
+
     LoadState    checkLoading() const;
     bool         finishLoading();
     void         startLoad(std::string_view banner, const std::function<std::unique_ptr<GameSession>(std::unique_ptr<GameSession>&&)> f);
     void         startSave(Tempest::Texture2d&& tex, const std::function<std::unique_ptr<GameSession>(std::unique_ptr<GameSession>&&)> f);
     void         cancelLoading();
+
+    void         setChangeWldFlg() { changeWld = true; };
+    void         clearChangeWldFlg() { changeWld = false; };
+    bool         hasChangeWldFlg() { return changeWld; };
 
     void         tick(uint64_t dt);
 
@@ -160,6 +166,8 @@ class Gothic final {
     bool                                    isMarvin = false;
     bool                                    noFrate  = false;
     bool                                    isMeshSh = false;
+    bool                                    respawn = false;
+    bool                                    changeWld = false;
     std::string                             wrldDef, plDef;
 
     std::unique_ptr<IniFile>                defaults;

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -16,6 +16,7 @@
 
 #include "utils/mouseutil.h"
 #include "world/objects/npc.h"
+#include "world/respawnobject.h"
 #include "game/serialize.h"
 #include "game/globaleffects.h"
 #include "utils/crashlog.h"
@@ -944,6 +945,9 @@ void MainWindow::onWorldLoaded() {
     pl->multSpeed(1.f);
   lastTick = Application::tickCount();
   player.clearFocus();
+  if (Gothic::inst().hasChangeWldFlg())
+    RespawnObject::processRespawnList();
+  Gothic::inst().clearChangeWldFlg();
   }
 
 void MainWindow::onSessionExit() {

--- a/game/marvin.cpp
+++ b/game/marvin.cpp
@@ -5,6 +5,7 @@
 #include <cctype>
 
 #include "world/objects/npc.h"
+#include "world/respawnobject.h"
 #include "camera.h"
 #include "gothic.h"
 
@@ -117,6 +118,8 @@ Marvin::Marvin() {
     {"toogle camdebug",   C_ToogleCamDebug},
     {"toogle camera",     C_ToogleCamera},
     {"insert %c",         C_Insert},
+
+    {"respawn %s",        C_Respawn}, // Supports respawn [clear,show]
     };
   }
 
@@ -263,6 +266,9 @@ bool Marvin::exec(std::string_view v) {
       if(world==nullptr || player==nullptr)
         return false;
       return printVariable(world,ret.argv[0]);
+      }
+    case C_Respawn: {
+      return RespawnObject::handleCommand(ret.argv[0]);
       }
     }
 

--- a/game/marvin.cpp
+++ b/game/marvin.cpp
@@ -119,7 +119,8 @@ Marvin::Marvin() {
     {"toogle camera",     C_ToogleCamera},
     {"insert %c",         C_Insert},
 
-    {"respawn %s",        C_Respawn}, // Supports respawn [clear,show]
+    // Respawn system [clear,show,process]
+    {"respawn %s",        C_Respawn},
     };
   }
 

--- a/game/marvin.h
+++ b/game/marvin.h
@@ -34,6 +34,7 @@ class Marvin {
       C_ToogleCamera,
 
       C_Insert,
+      C_Respawn
       };
 
     struct Cmd {

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1767,7 +1767,7 @@ void Npc::takeDamage(Npc& other, const Bullet* b, const CollideMask bMask, int32
       else if(isDead()) {
         owner.sendPassivePerc(*this,other,*this,PERC_ASSESSMURDER);
         // Register monsters for respawn (method handles human / monster / orc evaluation)
-        RespawnObject::registerObject(size_t(instanceSymbol()), hnpc.wp.c_str(), guild());
+        RespawnObject::registerObject(size_t(instanceSymbol()), hnpc->wp.c_str(), guild());
         }
       else {
         if(owner.script().rand(2)==0)

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -10,6 +10,7 @@
 #include "game/gamescript.h"
 #include "world/objects/interactive.h"
 #include "world/objects/item.h"
+#include "world/respawnobject.h"
 #include "world/world.h"
 #include "utils/versioninfo.h"
 #include "utils/fileext.h"
@@ -1765,6 +1766,8 @@ void Npc::takeDamage(Npc& other, const Bullet* b, const CollideMask bMask, int32
         }
       else if(isDead()) {
         owner.sendPassivePerc(*this,other,*this,PERC_ASSESSMURDER);
+        // Register monsters for respawn (method handles human / monster / orc evaluation)
+        RespawnObject::registerObject(size_t(instanceSymbol()), hnpc.wp.c_str(), guild());
         }
       else {
         if(owner.script().rand(2)==0)

--- a/game/world/respawnobject.cpp
+++ b/game/world/respawnobject.cpp
@@ -24,12 +24,10 @@ void RespawnObject::save(Serialize &fout) const{
 }
 
 void RespawnObject::registerObject(size_t inst, std::string wp, uint32_t guild){
-    if (!RespawnObject::npcShouldRespawn(guild)) {
-        printMsg("Not a respawnable monster (Guild ID " + std::to_string(guild) + ")");
+    if (!RespawnObject::npcShouldRespawn(guild))
         return;
-    }
     World *world = Gothic::inst().world();
-    // Skip also if the waypoint is not findable
+    // Skip if waypoint is unknown
     if (!world->findPoint(wp))
         return;
     RespawnObject ro;
@@ -47,8 +45,11 @@ void RespawnObject::registerObject(size_t inst, std::string wp, uint32_t guild){
 }
 
 void RespawnObject::processRespawnList(){
+    World* world  = Gothic::inst().world();
+    // Ensure respawn list is not processed during world transition / loading sequences
+    if(world==nullptr || Gothic::inst().player()==nullptr)
+        return;
     printMsg("Process respawn list, currently " + std::to_string(respawnList.size()) + " monsters registered");
-    World *world = Gothic::inst().world();
     uint32_t currDay = (uint32_t)world->time().day();
     uint32_t cnt = 0;
     std::vector<RespawnObject>::iterator iter;

--- a/game/world/respawnobject.cpp
+++ b/game/world/respawnobject.cpp
@@ -1,0 +1,113 @@
+#include "respawnobject.h"
+
+#include "game/serialize.h"
+#include "gothic.h"
+#include <string>
+#include <vector>
+#include <sstream>
+#include <stdarg.h>
+
+using namespace Tempest;
+
+std::vector<RespawnObject> RespawnObject::respawnList = {};
+
+RespawnObject::RespawnObject(Serialize &fin){
+    fin.read(inst,wp,respawnDay);
+}
+
+void RespawnObject::save(Serialize &fout) const{
+    fout.write(inst,wp,respawnDay);
+}
+
+void RespawnObject::registerObject(size_t inst, std::string wp, uint32_t guild){
+    if (!RespawnObject::npcShouldRespawn(guild)) {
+        printMsg("Not a respawnable monster (Guild ID " + std::to_string(guild) + ")");
+        return;
+    }
+    RespawnObject ro;
+    ro.inst = inst;
+    ro.wp = wp;
+    uint32_t minDays = 3; // Should be at least 1
+    uint32_t maxDays = 10;
+    uint32_t currDay = (uint32_t)(Gothic::inst().world())->time().day();
+    uint32_t offset = minDays + (Gothic::inst().world())->script().rand(maxDays - minDays);
+    ro.respawnDay = currDay + offset;
+
+    printMsg("Register respawn for day " + std::to_string(ro.respawnDay));
+
+    // Store for respawn in respawn list
+    RespawnObject::respawnList.push_back(ro);
+}
+
+void RespawnObject::processRespawnList(){
+    printMsg("Process respawn list, currently " + std::to_string(respawnList.size()) + " monsters registered");
+    uint32_t currDay = (uint32_t)(Gothic::inst().world())->time().day();
+    uint32_t cnt = 0;
+    std::vector<RespawnObject>::iterator iter;
+    for (iter = respawnList.begin(); iter != respawnList.end(); ){
+        if ((*iter).respawnDay <= currDay) {
+            cnt++;
+            (Gothic::inst().world())->addNpc((*iter).inst, (*iter).wp);
+            iter = respawnList.erase(iter);
+        } else
+            ++iter;
+    }
+    printMsg("Respawned " + std::to_string(cnt) + " monsters", 3);
+    printMsg("Still " + std::to_string(respawnList.size()) + " entries in respawn-list registered", 5);
+    return;
+}
+
+void RespawnObject::saveRespawnState(Serialize &fout){
+    fout.write(respawnList);
+}
+
+void RespawnObject::loadRespawnState(Serialize &fin){
+    fin.read(respawnList);
+}
+
+bool RespawnObject::npcShouldRespawn(uint32_t guild){
+    // Check which NPCs should respawn -- return true if npc should respawn, otherwise false
+    // Skip humans and orcs (test for monsters in general)
+    if (Guild::GIL_SEPERATOR_HUM > guild || guild > Guild::GIL_SEPERATOR_ORC)
+        return false;
+    // Skip monsters with guild higher than GIL_SWAMPGOLEM
+    if (guild > Guild::GIL_SWAMPGOLEM)
+        return false;
+    // Skip specific monsters
+    uint32_t skipGuilds[] = {
+        // No summoned monsters
+        GIL_SUMMONED_GOBBO_SKELETON,
+        GIL_SUMMONED_WOLF,
+        GIL_SUMMONED_SKELETON,
+        GIL_SUMMONED_GOLEM,
+        GIL_SUMMONED_DEMON,
+        GIL_SummonedGuardian,
+        GIL_SummonedZombie,
+        // No dragons
+        GIL_DRAGON,
+        // No stoneguardians and gargoyles
+        GIL_Stoneguardian,
+        GIL_Gargoyle
+    };
+    auto it = std::find(std::begin(skipGuilds), std::end(skipGuilds), guild);
+    // Test guild is not in skip guilds array
+    if (it != std::end(skipGuilds))
+        return false;
+    return true;
+}
+
+void RespawnObject::printMsg(std::string msg){
+    printMsg(msg, 1);
+}
+void RespawnObject::printMsg(std::string msg, int y){
+    if(!Gothic::inst().doFrate())
+        return;
+    int x = 1;
+    int timeInSec = 5;
+    Gothic::inst().onPrintScreen(
+        msg.c_str(),
+        x, (y+1),
+        timeInSec,
+        Resources::font()
+    );
+}

--- a/game/world/respawnobject.cpp
+++ b/game/world/respawnobject.cpp
@@ -1,22 +1,26 @@
 #include "respawnobject.h"
 
 #include "game/serialize.h"
+#include "world/world.h"
 #include "gothic.h"
 #include <string>
 #include <vector>
+#include <map>
 #include <sstream>
 #include <stdarg.h>
 
 using namespace Tempest;
 
 std::vector<RespawnObject> RespawnObject::respawnList = {};
+uint32_t RespawnObject::minDays = 2;  // Should be at least 1
+uint32_t RespawnObject::maxDays = 10; // Must be bigger than minDays
 
 RespawnObject::RespawnObject(Serialize &fin){
-    fin.read(inst,wp,respawnDay);
+    fin.read(inst,wp,respawnDay,world);
 }
 
 void RespawnObject::save(Serialize &fout) const{
-    fout.write(inst,wp,respawnDay);
+    fout.write(inst,wp,respawnDay,world);
 }
 
 void RespawnObject::registerObject(size_t inst, std::string wp, uint32_t guild){
@@ -24,16 +28,19 @@ void RespawnObject::registerObject(size_t inst, std::string wp, uint32_t guild){
         printMsg("Not a respawnable monster (Guild ID " + std::to_string(guild) + ")");
         return;
     }
+    World *world = Gothic::inst().world();
+    // Skip also if the waypoint is not findable
+    if (!world->findPoint(wp))
+        return;
     RespawnObject ro;
     ro.inst = inst;
     ro.wp = wp;
-    uint32_t minDays = 3; // Should be at least 1
-    uint32_t maxDays = 10;
-    uint32_t currDay = (uint32_t)(Gothic::inst().world())->time().day();
-    uint32_t offset = minDays + (Gothic::inst().world())->script().rand(maxDays - minDays);
+    uint32_t currDay = (uint32_t)world->time().day();
+    uint32_t offset = minDays + world->script().rand(maxDays - minDays);
     ro.respawnDay = currDay + offset;
+    ro.world = world->name();
 
-    printMsg("Register respawn for day " + std::to_string(ro.respawnDay));
+    printMsg("Register respawn for day " + std::to_string(ro.respawnDay) + " (" + ro.world + ")");
 
     // Store for respawn in respawn list
     RespawnObject::respawnList.push_back(ro);
@@ -41,19 +48,20 @@ void RespawnObject::registerObject(size_t inst, std::string wp, uint32_t guild){
 
 void RespawnObject::processRespawnList(){
     printMsg("Process respawn list, currently " + std::to_string(respawnList.size()) + " monsters registered");
-    uint32_t currDay = (uint32_t)(Gothic::inst().world())->time().day();
+    World *world = Gothic::inst().world();
+    uint32_t currDay = (uint32_t)world->time().day();
     uint32_t cnt = 0;
     std::vector<RespawnObject>::iterator iter;
     for (iter = respawnList.begin(); iter != respawnList.end(); ){
-        if ((*iter).respawnDay <= currDay) {
+        if ((*iter).respawnDay <= currDay && world->name().compare((*iter).world) == 0) {
             cnt++;
-            (Gothic::inst().world())->addNpc((*iter).inst, (*iter).wp);
+            world->addNpc((*iter).inst, (*iter).wp);
             iter = respawnList.erase(iter);
         } else
             ++iter;
     }
-    printMsg("Respawned " + std::to_string(cnt) + " monsters", 3);
-    printMsg("Still " + std::to_string(respawnList.size()) + " entries in respawn-list registered", 5);
+    printMsg("Respawned " + std::to_string(cnt) + " monsters", 2);
+    printMsg("Still " + std::to_string(respawnList.size()) + " entries in respawn-list registered", 3);
     return;
 }
 
@@ -63,6 +71,37 @@ void RespawnObject::saveRespawnState(Serialize &fout){
 
 void RespawnObject::loadRespawnState(Serialize &fin){
     fin.read(respawnList);
+}
+
+/**
+ * Handle one of following commands:
+ * - 'show': Make a printlog to the game screen
+ * - 'clear': Clear respawn list completely
+ */
+bool RespawnObject::handleCommand(std::string_view cmd){
+    if (cmd.compare("show") == 0) {
+        // Make print output
+        std::map<std::string, int> map;
+        for (auto iter = respawnList.begin(); iter != respawnList.end(); ++iter){
+            if (map.contains((*iter).world))
+                map[(*iter).world] = map[(*iter).world] +1;
+            else
+                map[(*iter).world] = 0;
+        }
+        int line = 1;
+        printMsg("Respawn list stats", line++, true);
+        printMsg("-------------------", line++, true);
+        printMsg("Monsters will respawn between " + std::to_string(minDays) + " and " + std::to_string(maxDays) + " days after being killed", line++, true);
+        printMsg("Currently " + std::to_string(respawnList.size()) + " monsters stored for respawn", line++, true);
+        for (auto iter = map.begin(); iter != map.end(); ++iter)
+            printMsg(" - " + iter->first + ": " + std::to_string(iter->second) + " entries", line++, true);
+    } else if (cmd.compare("clear") == 0) {
+        // Clear respawn list
+        respawnList.clear();
+        printMsg("Respawn list cleared", 1, true);
+    } else
+        return false;
+    return true;
 }
 
 bool RespawnObject::npcShouldRespawn(uint32_t guild){
@@ -83,6 +122,9 @@ bool RespawnObject::npcShouldRespawn(uint32_t guild){
         GIL_SUMMONED_DEMON,
         GIL_SummonedGuardian,
         GIL_SummonedZombie,
+        // No shadowbeasts and bloodhounds (due to shadowbeast-horn quest)
+        GIL_SHADOWBEAST,
+        GIL_SHADOWBEAST_SKELETON,
         // No dragons
         GIL_DRAGON,
         // No stoneguardians and gargoyles
@@ -99,14 +141,19 @@ bool RespawnObject::npcShouldRespawn(uint32_t guild){
 void RespawnObject::printMsg(std::string msg){
     printMsg(msg, 1);
 }
+
 void RespawnObject::printMsg(std::string msg, int y){
-    if(!Gothic::inst().doFrate())
+    printMsg(msg, 1, false);
+}
+
+void RespawnObject::printMsg(std::string msg, int y, bool forcePrint){
+    if(!(forcePrint || Gothic::inst().doFrate()))
         return;
     int x = 1;
     int timeInSec = 5;
     Gothic::inst().onPrintScreen(
         msg.c_str(),
-        x, (y+1),
+        x, 2*y+1, // Double y value due to low line height
         timeInSec,
         Resources::font()
     );

--- a/game/world/respawnobject.h
+++ b/game/world/respawnobject.h
@@ -18,14 +18,22 @@ class RespawnObject final {
     static void registerObject(size_t inst, std::string wp, uint32_t guild);
     static void processRespawnList();
 
+    static bool handleCommand(std::string_view cmd);
+
   private:
     size_t inst;         // NPC monster instance
     std::string wp;      // waypoint
     uint32_t respawnDay; // Day of respawn
+    std::string world;   // World name
 
     static bool npcShouldRespawn(uint32_t guild);
+
+    // Print output methods
     static void printMsg(std::string msg);
     static void printMsg(std::string msg, int y);
+    static void printMsg(std::string msg, int y, bool forcePrint);
 
     static std::vector<RespawnObject> respawnList;
+    static uint32_t minDays;
+    static uint32_t maxDays;
 };

--- a/game/world/respawnobject.h
+++ b/game/world/respawnobject.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 
+class World;
 class GameScript;
 class Serialize;
 
@@ -27,6 +28,7 @@ class RespawnObject final {
     std::string world;   // World name
 
     static bool npcShouldRespawn(uint32_t guild);
+    static uint32_t getCurrDay(World* world);
 
     // Print output methods
     static void printMsg(std::string msg);
@@ -34,6 +36,7 @@ class RespawnObject final {
     static void printMsg(std::string msg, int y, bool forcePrint);
 
     static std::vector<RespawnObject> respawnList;
+    static std::string processedDayWorld; // Cache value to not process multiple times per day / check also world
     static uint32_t minDays;
     static uint32_t maxDays;
 };

--- a/game/world/respawnobject.h
+++ b/game/world/respawnobject.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+class GameScript;
+class Serialize;
+
+class RespawnObject final {
+  public:
+    RespawnObject() = default;
+    RespawnObject(Serialize& fin);
+    void save(Serialize& fout) const;
+
+    static void saveRespawnState(Serialize &fout);
+    static void loadRespawnState(Serialize &fin);
+
+    static void registerObject(size_t inst, std::string wp, uint32_t guild);
+    static void processRespawnList();
+
+  private:
+    size_t inst;         // NPC monster instance
+    std::string wp;      // waypoint
+    uint32_t respawnDay; // Day of respawn
+
+    static bool npcShouldRespawn(uint32_t guild);
+    static void printMsg(std::string msg);
+    static void printMsg(std::string msg, int y);
+
+    static std::vector<RespawnObject> respawnList;
+};


### PR DESCRIPTION
Dead @Try 

Though I used it initially for playing around with the code, my expiremt went so well that I created a PR.

The respawn system mostly implements the class RespawnObject which uses itself as a RespawnObject for monsters that will initialized and stored within a static respawn-list vector object. There are two main methods:

- `RespawnObject::registerObject` which is called when a npc dies. Here respawnable monsters will added to the vector list.
- `RespawnObject::processRespawnList` is the actual respawn routine which makes some initial tests and then walks through the list and respawns all monsters that reached a precalculated respawn day. The method is called within `GameScript::wld_settime` and `MainWindow::onWorldLoaded`. The ladder is for switching between worlds as wld_settime is called when the world is not yet there (nullptr) during world-change events. To avoid processing after loading a savegame I also added a change-world flag.

Regarding __what will respawn__ (see `RespawnObject::npcShouldRespawn`):
- Only monsters, no humans or orcs
- No dragons, shadowbeasts & alike, summoned monsters, stoneguardians

Regarding __when monsters will respawn__:
- There are two static uint values `RespawnObject::minDays` and `RespawnObject::maxDays`
- With minDays and maxDays monsters will get registered with _respawnDay = currDay + minDays + random( maxDays - minDays )_
- When the current day is equal or greater than the stored respawn day, the monster will respawn

The respawn system comes with some additional __functionality__:
- Global activation by cli option `-respawn` (also adapted Readme)
- Cache-processing for fast-skip if the current day in the current world has already been processed
- Added marvin commands `respawn [show|clear|process]`
- Own log and screen-print messages. Except for marvin commands screen-print is only processed when doFrate is active
- Serialization with support for savegames without respawn-list stored (backward-compatible savegame format) 

I tested everything, from simply respawn, monsters that should not respawn and switching between worlds. Respawn can only happen within the current loaded world, thus the current world is stored alongside when registering the respawn entries. When entering a world (world-change) the list is processed and all registered respawns for that world (with `currDay >= respawnDay`) are respawned immediately. Same when sleeping.

Greetings
Steve