### PR TITLE
Add commandline options to ini file

### DIFF
--- a/game/commandline.cpp
+++ b/game/commandline.cpp
@@ -6,11 +6,7 @@
 
 #include "gothic.h"
 
-#include "utils/installdetect.h"
-#include "utils/fileutil.h"
-
 using namespace Tempest;
-using namespace FileUtil;
 
 static CommandLine* instance = nullptr;
 
@@ -79,28 +75,7 @@ CommandLine::CommandLine(int argc, const char** argv) {
         isMeshSh = (std::string_view(argv[i])!="0" && std::string_view(argv[i])!="false");
       }
     }
-
-  if(gpath.empty()) {
-    InstallDetect inst;
-    gpath = inst.detectG2();
-    }
-
-  for(auto& i:gpath)
-    if(i=='\\')
-      i='/';
-
-  if(gpath.size()>0 && gpath.back()!='/')
-    gpath.push_back('/');
-
-  gscript = nestedPath({u"_work",u"Data",u"Scripts",u"_compiled"},Dir::FT_Dir);
-  gmod    = TextCodec::toUtf16(std::string(mod));
-  if(!gmod.empty())
-    gmod = nestedPath({u"system",gmod.c_str()},Dir::FT_File);
-
-  if(!validateGothicPath()) {
-    Log::e("invalid gothic path: \"",TextCodec::toUtf8(gpath),"\"");
-    throw std::logic_error("gothic not found!"); //TODO: user-friendly message-box
-    }
+  gmod = TextCodec::toUtf16(std::string(mod));
   }
 
 const CommandLine& CommandLine::inst() {
@@ -113,24 +88,4 @@ CommandLine::GraphicBackend CommandLine::graphicsApi() const {
 
 std::u16string_view CommandLine::rootPath() const {
   return gpath;
-  }
-
-std::u16string_view CommandLine::scriptPath() const {
-  return gscript;
-  }
-
-std::u16string CommandLine::nestedPath(const std::initializer_list<const char16_t*>& name, Tempest::Dir::FileType type) const {
-  return FileUtil::nestedPath(gpath, name, type);
-  }
-
-bool CommandLine::validateGothicPath() const {
-  if(gpath.empty())
-    return false;
-  if(!FileUtil::exists(gscript))
-    return false;
-  if(!FileUtil::exists(nestedPath({u"Data"},Dir::FT_Dir)))
-    return false;
-  if(!FileUtil::exists(nestedPath({u"_work",u"Data"},Dir::FT_Dir)))
-    return false;
-  return true;
   }

--- a/game/commandline.h
+++ b/game/commandline.h
@@ -19,9 +19,7 @@ class CommandLine {
       };
     auto                graphicsApi() const -> GraphicBackend;
     std::u16string_view rootPath() const;
-    std::u16string_view scriptPath() const;
     std::u16string_view modPath() const { return gmod; }
-    std::u16string      nestedPath(const std::initializer_list<const char16_t*> &name, Tempest::Dir::FileType type) const;
 
     bool                isDebugMode()   const { return isDebug;  }
     bool                isWindowMode()  const { return isWindow; }
@@ -36,10 +34,9 @@ class CommandLine {
     bool                noFrate = false;
 
   private:
-    bool                validateGothicPath() const;
 
     GraphicBackend      graphics = GraphicBackend::Vulkan;
-    std::u16string      gpath, gscript, gmod;
+    std::u16string      gpath, gmod;
     std::string         saveDef;
     bool                noMenu   = false;
     bool                isWindow = false;

--- a/game/gothic.h
+++ b/game/gothic.h
@@ -58,6 +58,7 @@ class Gothic final {
     Camera*      camera();
     auto         questLog() const -> const QuestLog*;
 
+    void         initialSetup();
     void         setupGlobalScripts();
 
     auto         loadingBanner() const -> const Tempest::Texture2d*;
@@ -161,6 +162,7 @@ class Gothic final {
     bool                                    noFrate  = false;
     bool                                    isMeshSh = false;
     std::string                             wrldDef, plDef;
+    std::u16string                          gscript, gpath;
 
     std::unique_ptr<IniFile>                defaults;
     std::unique_ptr<IniFile>                baseIniFile;
@@ -200,6 +202,7 @@ class Gothic final {
                                                               const std::function<std::unique_ptr<GameSession>(std::unique_ptr<GameSession>&&)> f);
 
     void                                    detectGothicVersion();
+    void                                    validateGothicPath();
     void                                    setupSettings();
 
     auto                                    getDocument(int id) -> std::unique_ptr<DocumentMenu::Show>&;

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -40,7 +40,7 @@ MainWindow::MainWindow(Device& device)
   Gothic::inst().onSettingsChanged.bind(this,&MainWindow::onSettings);
   onSettings();
 
-  if(!CommandLine::inst().isWindowMode())
+  if(!CommandLine::inst().isWindowMode() && Gothic::inst().settingsGetI("COMMANDLINE","windowedMode")==0)
     setFullscreen(true);
 
   renderer.resetSwapchain();
@@ -71,7 +71,8 @@ MainWindow::MainWindow(Device& device)
     Gothic::inst().load(Gothic::inst().defaultSave());
     rootMenu.popMenu();
     }
-  else if(!CommandLine::inst().doStartMenu()) {
+  else if(!CommandLine::inst().doStartMenu() ||
+           Gothic::inst().settingsGetI("COMMANDLINE","skipMenu")!=0) {
     startGame(Gothic::inst().defaultWorld());
     rootMenu.popMenu();
     }

--- a/game/utils/inifile.cpp
+++ b/game/utils/inifile.cpp
@@ -28,7 +28,10 @@ static bool compareNoCase(std::string_view a, std::string_view b) {
 IniFile::IniFile(std::u16string_view file) {
   fileName = std::u16string(file);
   if(!FileUtil::exists(fileName)) {
-    Log::e("no *.ini file in path - using default settings");
+    if (fileName==u"OpenGothic.ini")
+      Log::e("no OpenGothic.ini file in path - generating default ini");
+    else
+      Log::e("no *.ini file in path - using default settings");
     return;
     }
 


### PR DESCRIPTION
Commandline options are now accessible from the ini file as proposed here https://github.com/Try/OpenGothic/pull/84. In case there are conflicting options set command line takes precedence over ini settings.

I renamed the `Gothic.ini` in the executable path to `OpenGothic.ini` to avoid confusion and to emphasize that those settings are only used in OpenGothic. The ini is now generated at game start by default if it doesn't exist already.