### PR TITLE
Set diving state to false after marvinF8 moving to air

### DIFF
--- a/game/game/movealgo.h
+++ b/game/game/movealgo.h
@@ -53,6 +53,7 @@ class MoveAlgo final {
 
     bool    startClimb(JumpStatus ani);
     void    startDive();
+    void    invalidatePhysics();
 
     bool    isFaling()  const;
     bool    isSlide()   const;

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -431,6 +431,7 @@ void PlayerControl::marvinF8(uint64_t dt) {
   pl.quitIneraction();
   pl.setAnim(AnimationSolver::Idle);
   pl.clearAiQueue();
+  pl.invalidatePhysics();
 
   if(auto c = Gothic::inst().camera())
     c->reset();
@@ -441,18 +442,20 @@ void PlayerControl::marvinK(uint64_t dt) {
   if (w == nullptr || w->player() == nullptr)
     return;
 
-  auto& pl = *w->player();
-  auto  pos = pl.position();
-  float rot = pl.rotationRad();
-  float s = std::sin(rot), c = std::cos(rot);
+  auto& pl   = *w->player();
+  auto  pos  = pl.position();
+  float rot  = pl.rotationRad();
+  float rotY = pl.isDive() ? pl.rotationYRad() : 0;
+  float s    = std::sin(rot), c = std::cos(rot);
 
-  Tempest::Vec3 dp(s, 0.0f, -c);
+  Tempest::Vec3 dp(s,rotY,-c);
   pos += dp * 6000 * float(dt) / 1000.f;
 
   pl.clearState(false);
   pl.setPosition(pos);
   pl.clearSpeed();
   pl.quitIneraction();
+  pl.invalidatePhysics();
   // pl.setAnim(AnimationSolver::Idle); // Original G2 behaviour: K doesn't stop running
   }
 

--- a/game/marvin.cpp
+++ b/game/marvin.cpp
@@ -284,6 +284,7 @@ bool Marvin::exec(std::string_view v) {
           return false;
         }
       player->setPosition(float(c[0]),float(c[1]),float(c[2]));
+      player->invalidatePhysics();
       player->updateTransform();
       Gothic::inst().camera()->reset(player);
       return true;
@@ -297,6 +298,7 @@ bool Marvin::exec(std::string_view v) {
       if(wpoint==nullptr)
         return false;
       player->setPosition(wpoint->x,wpoint->y,wpoint->z);
+      player->invalidatePhysics();
       player->updateTransform();
       Gothic::inst().camera()->reset(player);
       return true;

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1021,6 +1021,10 @@ bool Npc::isInAir() const {
   return mvAlgo.isInAir();
   }
 
+void Npc::invalidatePhysics() {
+  mvAlgo.invalidatePhysics();
+  }
+
 void Npc::setTalentSkill(Talent t, int32_t lvl) {
   if(t>=TALENT_MAX_G2)
     return;

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -184,6 +184,7 @@ class Npc final {
     bool       isInWater() const;
     bool       isDive() const;
     bool       isCasting() const;
+    void       invalidatePhysics();
 
     void       setTalentSkill(Talent t,int32_t lvl);
     int32_t    talentSkill(Talent t) const;


### PR DESCRIPTION
This time it should work. There are still some corner cases like the paladin ship. If you F8 up from the seabed you stay in diving mode until you reach the deck. But in the end you can escape dive/swimming state.

I guess It's better to have everything in `movealgo.cpp` but there we don't know if the movement is caused by marvin or normal play. 

Is there a better way to access the move states from the marvin routines  than introducing 2 new functions?