### PR TITLE
Introduce hideFocus and discard noFrate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ make -C build -j $(nproc)
 | `-g`                   | specify path containing Gothic game data                         |
 | `-game:<modfile.init>` | specify game modification manifest (GothicStarter compatibility) |
 | `-nomenu`              | skip main menu                                                   |
-| `-nofrate`             | disable FPS display in-game                                      |
 | `-w <worldname.zen>`   | startup world; newworld.zen is default                           |
 | `-save q`              | load the quick save on start                                     |
 | `-save <number>`       | load a specified save-game slot on start                         |

--- a/game/commandline.cpp
+++ b/game/commandline.cpp
@@ -53,9 +53,6 @@ CommandLine::CommandLine(int argc, const char** argv) {
     else if(arg=="-nomenu") {
       noMenu   = true;
       }
-    else if(arg=="-nofrate") {
-      noFrate  = true;
-      }
     else if(arg=="-g1") {
       forceG1 = true;
       }

--- a/game/commandline.h
+++ b/game/commandline.h
@@ -33,7 +33,6 @@ class CommandLine {
     std::string_view    defaultSave()   const { return saveDef;  }
 
     std::string         wrldDef;
-    bool                noFrate = false;
 
   private:
     bool                validateGothicPath() const;

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -38,12 +38,15 @@ static bool hasMeshShader() {
 Gothic::Gothic() {
   instance = this;
 
+  systemPackIniFile.reset(new IniFile(nestedPath({u"system",u"SystemPack.ini"},Dir::FT_File)));
+  frate = systemPackIniFile->getI("DEBUG","Show_FPS_Counter");
+  systemPackIniFile->getI("PARAMETERS","HideFocus");
+
 #ifndef NDEBUG
   setMarvinEnabled(true);
   setFRate(true);
 #endif
 
-  noFrate = CommandLine::inst().noFrate;
   wrldDef = CommandLine::inst().wrldDef;
   if(hasMeshShader())
     isMeshSh = CommandLine::inst().isMeshShading();
@@ -593,6 +596,14 @@ phoenix::script Gothic::loadPhoenixScriptCode(std::string_view datFile) {
   auto path = caseInsensitiveSegment(gscript,str16,Dir::FT_File);
   auto buf = phoenix::buffer::mmap(path);
   return phoenix::script::parse(buf);
+  }
+
+int Gothic::settingsSystemPackGetI(std::string_view sec, std::string_view name) {
+  if(name.empty())
+    return 0;
+  if(instance->systemPackIniFile->has(sec,name))
+    return instance->systemPackIniFile->getI(sec,name);
+  return 0;
   }
 
 int Gothic::settingsGetI(std::string_view sec, std::string_view name) {

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -39,8 +39,8 @@ Gothic::Gothic() {
   instance = this;
 
   systemPackIniFile.reset(new IniFile(nestedPath({u"system",u"SystemPack.ini"},Dir::FT_File)));
-  frate = systemPackIniFile->getI("DEBUG","Show_FPS_Counter");
-  systemPackIniFile->getI("PARAMETERS","HideFocus");
+  showFpsCounter = systemPackIniFile->getI("DEBUG","Show_FPS_Counter");
+  hideFocus      = systemPackIniFile->getI("PARAMETERS","HideFocus");
 
 #ifndef NDEBUG
   setMarvinEnabled(true);
@@ -596,14 +596,6 @@ phoenix::script Gothic::loadPhoenixScriptCode(std::string_view datFile) {
   auto path = caseInsensitiveSegment(gscript,str16,Dir::FT_File);
   auto buf = phoenix::buffer::mmap(path);
   return phoenix::script::parse(buf);
-  }
-
-int Gothic::settingsSystemPackGetI(std::string_view sec, std::string_view name) {
-  if(name.empty())
-    return 0;
-  if(instance->systemPackIniFile->has(sec,name))
-    return instance->systemPackIniFile->getI(sec,name);
-  return 0;
   }
 
 int Gothic::settingsGetI(std::string_view sec, std::string_view name) {

--- a/game/gothic.h
+++ b/game/gothic.h
@@ -86,8 +86,8 @@ class Gothic final {
     bool         isMarvinEnabled() const;
     void         setMarvinEnabled(bool m);
 
-    bool         doFrate() const { return !noFrate; }
-    void         setFRate(bool f) { noFrate = !f; }
+    bool         doFrate() const { return frate; }
+    void         setFRate(bool f) { frate = f; }
 
     bool         doRayQuery() const;
     bool         doMeshShading() const;
@@ -145,6 +145,8 @@ class Gothic final {
     static const MusicDefinitions&        musicDef();
     static const CameraDefinitions&       cameraDef();
 
+    static int                            settingsSystemPackGetI(std::string_view sec, std::string_view name);
+
     static int                            settingsGetI(std::string_view sec, std::string_view name);
     static void                           settingsSetI(std::string_view sec, std::string_view name, int val);
     static std::string_view               settingsGetS(std::string_view sec, std::string_view name);
@@ -158,7 +160,7 @@ class Gothic final {
     std::mt19937                            randGen;
     uint16_t                                pauseSum=0;
     bool                                    isMarvin = false;
-    bool                                    noFrate  = false;
+    bool                                    frate    = false;
     bool                                    isMeshSh = false;
     std::string                             wrldDef, plDef;
 
@@ -166,6 +168,7 @@ class Gothic final {
     std::unique_ptr<IniFile>                baseIniFile;
     std::unique_ptr<IniFile>                iniFile;
     std::unique_ptr<IniFile>                modFile;
+    std::unique_ptr<IniFile>                systemPackIniFile;
 
     const Tempest::Texture2d*               loadTex=nullptr;
     Tempest::Texture2d                      saveTex;

--- a/game/gothic.h
+++ b/game/gothic.h
@@ -86,8 +86,9 @@ class Gothic final {
     bool         isMarvinEnabled() const;
     void         setMarvinEnabled(bool m);
 
-    bool         doFrate() const { return frate; }
-    void         setFRate(bool f) { frate = f; }
+    bool         doHideFocus () const { return hideFocus; }
+    bool         doFrate() const { return showFpsCounter; }
+    void         setFRate(bool f) { showFpsCounter = f; }
 
     bool         doRayQuery() const;
     bool         doMeshShading() const;
@@ -145,8 +146,6 @@ class Gothic final {
     static const MusicDefinitions&        musicDef();
     static const CameraDefinitions&       cameraDef();
 
-    static int                            settingsSystemPackGetI(std::string_view sec, std::string_view name);
-
     static int                            settingsGetI(std::string_view sec, std::string_view name);
     static void                           settingsSetI(std::string_view sec, std::string_view name, int val);
     static std::string_view               settingsGetS(std::string_view sec, std::string_view name);
@@ -159,9 +158,10 @@ class Gothic final {
     VersionInfo                             vinfo;
     std::mt19937                            randGen;
     uint16_t                                pauseSum=0;
-    bool                                    isMarvin = false;
-    bool                                    frate    = false;
-    bool                                    isMeshSh = false;
+    bool                                    isMarvin       = false;
+    bool                                    showFpsCounter = false;
+    bool                                    hideFocus      = false;
+    bool                                    isMeshSh       = false;
     std::string                             wrldDef, plDef;
 
     std::unique_ptr<IniFile>                defaults;

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -717,8 +717,8 @@ Npc* WorldObjects::findNpc(const Npc &pl, Npc *def, const SearchOpt& opt) {
       return def;
     }
   auto r = findObj(npcArr,pl,opt);
-  const bool hideFocus = Gothic::inst().settingsSystemPackGetI("PARAMETERS","HideFocus")!=0;
-  if(r!=nullptr && (!hideFocus || !r->get()->isDead() || r->get()->inventory().iterator(Inventory::T_Ransack).isValid()))
+  if(r!=nullptr && (!Gothic::inst().doHideFocus() || !r->get()->isDead() ||
+                    r->get()->inventory().iterator(Inventory::T_Ransack).isValid()))
     return r->get();
   return nullptr;
   }

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -10,6 +10,7 @@
 #include "world.h"
 #include "utils/workers.h"
 #include "utils/dbgpainter.h"
+#include "gothic.h"
 
 #include <Tempest/Painter>
 #include <Tempest/Application>
@@ -716,7 +717,10 @@ Npc* WorldObjects::findNpc(const Npc &pl, Npc *def, const SearchOpt& opt) {
       return def;
     }
   auto r = findObj(npcArr,pl,opt);
-  return r ? r->get() : nullptr;
+  const bool hideFocus = Gothic::inst().settingsSystemPackGetI("PARAMETERS","HideFocus")!=0;
+  if(r!=nullptr && (!hideFocus || !r->get()->isDead() || r->get()->inventory().iterator(Inventory::T_Ransack).isValid()))
+    return r->get();
+  return nullptr;
   }
 
 Item *WorldObjects::findItem(const Npc &pl, Item *def, const SearchOpt& opt) {


### PR DESCRIPTION
Currently fps are always shown and can only be disabled by the `-noFrate` option. This has been changed , so that in release mode it now depends on the `Show_FPS_Counter` setting in `SystemPack.ini`, which is off by default (`Show_FPS_Counter=0`). In debug this setting is ignored and the fps are now always shown. I discarded the `noFrate` option, because there's no use left.

The `hideFoucs` setting is read from `SystemPack.ini` as well  (default: `hideFoucs=0`). If activated dead npc's/monsters can't be in focus if their inventory is empty.