### PR TITLE
Implemented AI_LOOKAT

### DIFF
--- a/game/game/constants.h
+++ b/game/game/constants.h
@@ -289,7 +289,7 @@ enum ItmFlags : uint32_t {
 
 enum Action:uint32_t {
   AI_None  =0,
-  AI_LookAt,
+  AI_LookAtNpc,
   AI_StopLookAt,
   AI_RemoveWeapon,
   AI_TurnToNpc,

--- a/game/game/constants.h
+++ b/game/game/constants.h
@@ -336,6 +336,7 @@ enum Action:uint32_t {
   AI_PointAt,
   AI_StopPointAt,
   AI_PrintScreen,
+  AI_LookAt
   };
 
 

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -209,6 +209,7 @@ void GameScript::initCommon() {
   bindExternal("ai_standupquick",                &GameScript::ai_standupquick);
   bindExternal("ai_continueroutine",             &GameScript::ai_continueroutine);
   bindExternal("ai_stoplookat",                  &GameScript::ai_stoplookat);
+  bindExternal("ai_lookat",                      &GameScript::ai_lookat);
   bindExternal("ai_lookatnpc",                   &GameScript::ai_lookatnpc);
   bindExternal("ai_removeweapon",                &GameScript::ai_removeweapon);
   bindExternal("ai_turntonpc",                   &GameScript::ai_turntonpc);
@@ -2543,6 +2544,13 @@ void GameScript::ai_stoplookat(std::shared_ptr<phoenix::c_npc> selfRef) {
   auto self = findNpc(selfRef);
   if(self!=nullptr)
     self->aiPush(AiQueue::aiStopLookAt());
+  }
+
+void GameScript::ai_lookat(std::shared_ptr<phoenix::c_npc> selfRef, std::string_view waypoint) {
+  auto self = findNpc(selfRef);
+  auto to  = world().findPoint(waypoint);
+  if(self!=nullptr)
+    self->aiPush(AiQueue::aiLookAt(to));
   }
 
 void GameScript::ai_lookatnpc(std::shared_ptr<phoenix::c_npc> selfRef, std::shared_ptr<phoenix::c_npc> npcRef) {

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -2549,7 +2549,7 @@ void GameScript::ai_lookatnpc(std::shared_ptr<phoenix::c_npc> selfRef, std::shar
   auto npc  = findNpc(npcRef);
   auto self = findNpc(selfRef);
   if(self!=nullptr)
-    self->aiPush(AiQueue::aiLookAt(npc));
+    self->aiPush(AiQueue::aiLookAtNpc(npc));
   }
 
 void GameScript::ai_removeweapon(std::shared_ptr<phoenix::c_npc> npcRef) {

--- a/game/game/gamescript.h
+++ b/game/game/gamescript.h
@@ -341,6 +341,7 @@ class GameScript final {
     void ai_standupquick     (std::shared_ptr<phoenix::c_npc> selfRef);
     void ai_continueroutine  (std::shared_ptr<phoenix::c_npc> selfRef);
     void ai_stoplookat       (std::shared_ptr<phoenix::c_npc> selfRef);
+    void ai_lookat           (std::shared_ptr<phoenix::c_npc> selfRef, std::string_view waypoint);
     void ai_lookatnpc        (std::shared_ptr<phoenix::c_npc> selfRef, std::shared_ptr<phoenix::c_npc> npcRef);
     void ai_removeweapon     (std::shared_ptr<phoenix::c_npc> npcRef);
     void ai_turntonpc        (std::shared_ptr<phoenix::c_npc> selfRef, std::shared_ptr<phoenix::c_npc> npcRef);

--- a/game/game/serialize.h
+++ b/game/game/serialize.h
@@ -33,7 +33,7 @@ class SaveGameHeader;
 class Serialize {
   public:
     enum Version : uint16_t {
-      Current = 41
+      Current = 42
       };
     Serialize(Tempest::ODevice& fout);
     Serialize(Tempest::IDevice&  fin);

--- a/game/world/aiqueue.cpp
+++ b/game/world/aiqueue.cpp
@@ -72,6 +72,13 @@ void AiQueue::onWldItemRemoved(const Item& itm) {
       i.item = nullptr;
   }
 
+AiQueue::AiAction AiQueue::aiLookAt(const WayPoint* to) {
+  AiAction a;
+  a.act    = AI_LookAt;
+  a.point = to;
+  return a;
+  }
+
 AiQueue::AiAction AiQueue::aiLookAtNpc(Npc* other) {
   AiAction a;
   a.act    = AI_LookAtNpc;

--- a/game/world/aiqueue.cpp
+++ b/game/world/aiqueue.cpp
@@ -36,7 +36,7 @@ void AiQueue::clear() {
 
 void AiQueue::pushBack(AiAction&& a) {
   if(aiActions.size()>0) {
-    if(aiActions.back().act==AI_LookAt && a.act==AI_LookAt) {
+    if(aiActions.back().act==AI_LookAtNpc && a.act==AI_LookAtNpc) {
       aiActions.back() = a;
       return;
       }
@@ -72,9 +72,9 @@ void AiQueue::onWldItemRemoved(const Item& itm) {
       i.item = nullptr;
   }
 
-AiQueue::AiAction AiQueue::aiLookAt(Npc* other) {
+AiQueue::AiAction AiQueue::aiLookAtNpc(Npc* other) {
   AiAction a;
-  a.act    = AI_LookAt;
+  a.act    = AI_LookAtNpc;
   a.target = other;
   return a;
   }

--- a/game/world/aiqueue.h
+++ b/game/world/aiqueue.h
@@ -42,6 +42,7 @@ class AiQueue {
 
     void     onWldItemRemoved(const Item& itm);
 
+    static AiAction aiLookAt(const WayPoint* to);
     static AiAction aiLookAtNpc(Npc* other);
     static AiAction aiStopLookAt();
     static AiAction aiRemoveWeapon();

--- a/game/world/aiqueue.h
+++ b/game/world/aiqueue.h
@@ -42,7 +42,7 @@ class AiQueue {
 
     void     onWldItemRemoved(const Item& itm);
 
-    static AiAction aiLookAt(Npc* other);
+    static AiAction aiLookAtNpc(Npc* other);
     static AiAction aiStopLookAt();
     static AiAction aiRemoveWeapon();
     static AiAction aiTurnToNpc(Npc *other);

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -257,7 +257,7 @@ void Npc::load(Serialize &fin, size_t id) {
   loadAiState(fin);
 
   fin.read(currentInteract,currentOther,currentVictum);
-  if(fin.version()>42)
+  if(fin.version()>=42)
     fin.read(currentLookAt);
   fin.read(currentLookAtNpc,currentTarget,nearestEnemy);
 

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -257,7 +257,7 @@ void Npc::load(Serialize &fin, size_t id) {
   loadAiState(fin);
 
   fin.read(currentInteract,currentOther,currentVictum);
-  fin.read(currentLookAt,currentTarget,nearestEnemy);
+  fin.read(currentLookAtNpc,currentTarget,nearestEnemy);
 
   go2.load(fin);
   fin.read(currentFp,currentFpLock);
@@ -677,7 +677,7 @@ Vec3 Npc::centerPosition() const {
   }
 
 Npc *Npc::lookAtTarget() const {
-  return currentLookAt;
+  return currentLookAtNpc;
   }
 
 std::string_view Npc::portalName() {
@@ -1224,11 +1224,11 @@ bool Npc::implPointAt(const Tempest::Vec3& to) {
   return (setAnimAngGet(Npc::Anim::PointAt,comb)!=nullptr);
   }
 
-bool Npc::implLookAt(uint64_t dt) {
-  if(currentLookAt==nullptr)
+bool Npc::implLookAtNpc(uint64_t dt) {
+  if(currentLookAtNpc==nullptr)
     return false;
   auto selfHead  = visual.mapHeadBone();
-  auto otherHead = currentLookAt->visual.mapHeadBone();
+  auto otherHead = currentLookAtNpc->visual.mapHeadBone();
   auto dvec = otherHead - selfHead;
   return implLookAt(dvec.x,dvec.y,dvec.z,dt);
   }
@@ -1988,7 +1988,7 @@ void Npc::tick(uint64_t dt) {
     }
 
   if(!isDown()) {
-    implLookAt(dt);
+    implLookAtNpc(dt);
 
     if(implAtack(dt))
       return;
@@ -2010,8 +2010,8 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
   auto act = queue.pop();
   switch(act.act) {
     case AI_None: break;
-    case AI_LookAt:{
-      currentLookAt=act.target;
+    case AI_LookAtNpc:{
+      currentLookAtNpc=act.target;
       break;
       }
     case AI_TurnToNpc: {

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -202,6 +202,7 @@ void Npc::save(Serialize &fout, size_t id) {
 
   fout.write(currentInteract,currentOther,currentVictum);
   fout.write(currentLookAtNpc,currentTarget,nearestEnemy);
+  fout.write(currentLookAt);
 
   go2.save(fout);
   fout.write(currentFp,currentFpLock);
@@ -258,6 +259,9 @@ void Npc::load(Serialize &fin, size_t id) {
 
   fin.read(currentInteract,currentOther,currentVictum);
   fin.read(currentLookAtNpc,currentTarget,nearestEnemy);
+  if (fin.version()>42) {
+    fin.read(currentLookAt);
+  }
 
   go2.load(fin);
   fin.read(currentFp,currentFpLock);
@@ -1995,8 +1999,8 @@ void Npc::tick(uint64_t dt) {
     }
 
   if(!isDown()) {
-      implLookAtNpc(dt);
-      implLookAtWp(dt);
+    implLookAtNpc(dt);
+    implLookAtWp(dt);
 
     if(implAtack(dt))
       return;

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1224,6 +1224,13 @@ bool Npc::implPointAt(const Tempest::Vec3& to) {
   return (setAnimAngGet(Npc::Anim::PointAt,comb)!=nullptr);
   }
 
+bool Npc::implLookAtWp(uint64_t dt) {
+  if(currentLookAt==nullptr)
+    return false;
+  auto dvec = currentLookAt->position();
+  return implLookAt(dvec.x,dvec.y,dvec.z,dt);
+}
+
 bool Npc::implLookAtNpc(uint64_t dt) {
   if(currentLookAtNpc==nullptr)
     return false;
@@ -1988,7 +1995,8 @@ void Npc::tick(uint64_t dt) {
     }
 
   if(!isDown()) {
-    implLookAtNpc(dt);
+      implLookAtNpc(dt);
+      implLookAtWp(dt);
 
     if(implAtack(dt))
       return;
@@ -2011,7 +2019,13 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
   switch(act.act) {
     case AI_None: break;
     case AI_LookAtNpc:{
+      currentLookAt=nullptr;
       currentLookAtNpc=act.target;
+      break;
+      }
+    case AI_LookAt:{
+      currentLookAtNpc=nullptr;
+      currentLookAt=act.point;
       break;
       }
     case AI_TurnToNpc: {
@@ -2073,6 +2087,7 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
       break;
       }
     case AI_StopLookAt:
+      currentLookAtNpc=nullptr;
       currentLookAt=nullptr;
       visual.setHeadRotation(0,0);
       break;

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -201,8 +201,7 @@ void Npc::save(Serialize &fout, size_t id) {
   saveAiState(fout);
 
   fout.write(currentInteract,currentOther,currentVictum);
-  fout.write(currentLookAtNpc,currentTarget,nearestEnemy);
-  fout.write(currentLookAt);
+  fout.write(currentLookAt,currentLookAtNpc,currentTarget,nearestEnemy);
 
   go2.save(fout);
   fout.write(currentFp,currentFpLock);
@@ -258,10 +257,9 @@ void Npc::load(Serialize &fin, size_t id) {
   loadAiState(fin);
 
   fin.read(currentInteract,currentOther,currentVictum);
-  fin.read(currentLookAtNpc,currentTarget,nearestEnemy);
-  if (fin.version()>42) {
+  if(fin.version()>42)
     fin.read(currentLookAt);
-  }
+  fin.read(currentLookAtNpc,currentTarget,nearestEnemy);
 
   go2.load(fin);
   fin.read(currentFp,currentFpLock);
@@ -1233,7 +1231,7 @@ bool Npc::implLookAtWp(uint64_t dt) {
     return false;
   auto dvec = currentLookAt->position();
   return implLookAt(dvec.x,dvec.y,dvec.z,dt);
-}
+  }
 
 bool Npc::implLookAtNpc(uint64_t dt) {
   if(currentLookAtNpc==nullptr)

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -201,7 +201,7 @@ void Npc::save(Serialize &fout, size_t id) {
   saveAiState(fout);
 
   fout.write(currentInteract,currentOther,currentVictum);
-  fout.write(currentLookAt,currentTarget,nearestEnemy);
+  fout.write(currentLookAtNpc,currentTarget,nearestEnemy);
 
   go2.save(fout);
   fout.write(currentFp,currentFpLock);

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -455,7 +455,7 @@ class Npc final {
     gtime     endTime(const Routine& r) const;
 
     bool      implPointAt(const Tempest::Vec3& to);
-    bool      implLookAt (uint64_t dt);
+    bool      implLookAtNpc(uint64_t dt);
     bool      implLookAt (float dx, float dy, float dz, uint64_t dt);
     bool      implTurnTo (const Npc& oth, uint64_t dt);
     bool      implTurnTo (const Npc& oth, bool noAnim, uint64_t dt);
@@ -571,7 +571,8 @@ class Npc final {
     Npc*                           currentOther   =nullptr;
     Npc*                           currentVictum  =nullptr;
 
-    Npc*                           currentLookAt  =nullptr;
+    WayPoint*                      currentLookAt=nullptr;
+    Npc*                           currentLookAtNpc=nullptr;
     Npc*                           currentTarget  =nullptr;
     Npc*                           nearestEnemy   =nullptr;
     AiOuputPipe*                   outputPipe     =nullptr;

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -455,6 +455,7 @@ class Npc final {
     gtime     endTime(const Routine& r) const;
 
     bool      implPointAt(const Tempest::Vec3& to);
+    bool      implLookAtWp(uint64_t dt);
     bool      implLookAtNpc(uint64_t dt);
     bool      implLookAt (float dx, float dy, float dz, uint64_t dt);
     bool      implTurnTo (const Npc& oth, uint64_t dt);
@@ -571,7 +572,7 @@ class Npc final {
     Npc*                           currentOther   =nullptr;
     Npc*                           currentVictum  =nullptr;
 
-    WayPoint*                      currentLookAt=nullptr;
+    const WayPoint*                currentLookAt=nullptr;
     Npc*                           currentLookAtNpc=nullptr;
     Npc*                           currentTarget  =nullptr;
     Npc*                           nearestEnemy   =nullptr;


### PR DESCRIPTION
This is my first try at actually contributing here. So please be gentle.

Some NPCs in Gothic 1 don't look in the direction they're supposed to. I figured AI_LOOKAT could be the problem.
So I implemented it as best as I could, and the NPCs still don't look in the right direction.

It turns out AI_LOOKAT is only used in the new camp (Neues Lager in German) to make an NPC look at the big pile of ore there. (Waypoint FP_OREPILE_CENTER). I haven't figured out which NPCs but if that information is needed, I might now know how to get it.

I made AI_LOOKAT mutually exclusive with AI_LOOKATNPC as I figured an NPC can't really look at two points at the same time. So whichever function is called last wins.

Your code style is a bit unusual. I hope I got it right.