### PR TITLE
Porting To FreeBSD: Bash is not always in /bin

### DIFF
--- a/scripts/Gothic2Notr.sh
+++ b/scripts/Gothic2Notr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export LD_LIBRARY_PATH="$DIR:$LD_LIBRARY_PATH"
 export DYLD_LIBRARY_PATH="$DIR:$DYLD_LIBRARY_PATH"


### PR DESCRIPTION
FreeBSD and other BSDs store ported software under /usr/local This includes bash.

This change uses /usr/bin/env to find the location of bash