### PR TITLE
Fix for G1 chests

### DIFF
--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -905,8 +905,8 @@ void PlayerControl::processPickLock(Npc& pl, Interactive& inter, KeyCodec::Actio
 
   if(pickLockProgress<cmp.size() && std::toupper(cmp[pickLockProgress])!=ch) {
     pickLockProgress = 0;
-    const int32_t dex = pl.attribute(ATR_DEXTERITY);
-    if(dex<int32_t(script.rand(100)))  {
+    const int32_t dex = Gothic::inst().version().game==2 ? pl.attribute(ATR_DEXTERITY) : 100 - pl.talentValue(TALENT_PICKLOCK);
+    if(dex<=int32_t(script.rand(100)))  {
       script.invokePickLock(pl,0,1);
       pl.delItem(ItKE_lockpick,1);
       if(pl.inventory().itemCount(ItKE_lockpick)==0) {

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -879,9 +879,10 @@ void PlayerControl::implMoveMobsi(Npc& pl, uint64_t /*dt*/) {
   }
 
 void PlayerControl::processPickLock(Npc& pl, Interactive& inter, KeyCodec::Action k) {
-  auto         w             = Gothic::inst().world();
-  auto&        script        = w->script();
-  const size_t ItKE_lockpick = script.findSymbolIndex("ItKE_lockpick");
+  auto                   w             = Gothic::inst().world();
+  auto&                  script        = w->script();
+  const std::string_view name          = Gothic::inst().version().game==2 ? "ItKE_lockpick" : "itkelockpick";
+  const size_t           ItKE_lockpick = script.findSymbolIndex(name);
 
   char ch = '\0';
   if(k==KeyCodec::Left || k==KeyCodec::RotateL)
@@ -905,7 +906,7 @@ void PlayerControl::processPickLock(Npc& pl, Interactive& inter, KeyCodec::Actio
 
   if(pickLockProgress<cmp.size() && std::toupper(cmp[pickLockProgress])!=ch) {
     pickLockProgress = 0;
-    const int32_t dex = Gothic::inst().version().game==2 ? pl.attribute(ATR_DEXTERITY) : 100 - pl.talentValue(TALENT_PICKLOCK);
+    const int32_t dex = Gothic::inst().version().game==2 ? pl.attribute(ATR_DEXTERITY) : (100 - pl.talentValue(TALENT_PICKLOCK));
     if(dex<=int32_t(script.rand(100)))  {
       script.invokePickLock(pl,0,1);
       pl.delItem(ItKE_lockpick,1);

--- a/game/world/objects/interactive.cpp
+++ b/game/world/objects/interactive.cpp
@@ -12,6 +12,7 @@
 #include "world/objects/npc.h"
 #include "world/world.h"
 #include "utils/dbgpainter.h"
+#include "gothic.h"
 
 Interactive::Interactive(Vob* parent, World &world, const phoenix::vobs::mob& vob, Flags flags)
   : Vob(parent,world,vob,flags) {
@@ -576,12 +577,14 @@ bool Interactive::checkUseConditions(Npc& npc) {
   auto& sc = npc.world().script();
 
   if(isPlayer) {
-    const size_t ItKE_lockpick  = world.script().findSymbolIndex("ItKE_lockpick");
-    const size_t lockPickCnt    = npc.inventory().itemCount(ItKE_lockpick);
-    const bool   canLockPick    = (npc.talentSkill(TALENT_PICKLOCK)!=0 && lockPickCnt>0);
+    const bool             g2             = Gothic::inst().version().game==2;
+    const std::string_view name           = g2 ? "ItKE_lockpick" : "itkelockpick";
+    const size_t           ItKE_lockpick  = world.script().findSymbolIndex(name);
+    const size_t           lockPickCnt    = npc.inventory().itemCount(ItKE_lockpick);
+    const bool             canLockPick    = ((!g2 || npc.talentSkill(TALENT_PICKLOCK)!=0) && lockPickCnt>0);
 
-    const size_t keyInst        = keyInstance.empty() ? size_t(-1) : world.script().findSymbolIndex(keyInstance);
-    const bool   needToPicklock = (pickLockStr.size()>0);
+    const size_t           keyInst        = keyInstance.empty() ? size_t(-1) : world.script().findSymbolIndex(keyInstance);
+    const bool             needToPicklock = (pickLockStr.size()>0);
 
     if(keyInst!=size_t(-1) && npc.itemCount(keyInst)>0)
       return true;


### PR DESCRIPTION
If trying to open a locked chest there's a check if at least one lockpick is in inventory. The game checks only for the G2 name `ItKE_lockpick`. Now also the G1 name `itkelockpick` is considered.
https://github.com/Try/OpenGothic/issues/409

Gothic 1 also allows lockpicking without having to learn the respective Talent. Lockpick loss probability depends on talent skill rather than dexterity.
