### PR TITLE
Prevent ranged damage from hitting twice

### DIFF
--- a/game/world/bullet.cpp
+++ b/game/world/bullet.cpp
@@ -130,7 +130,7 @@ void Bullet::onCollide(phoenix::material_group matId) {
   }
 
 void Bullet::onCollide(Npc& npc) {
-  if(&npc==origin())
+  if(&npc==origin() || isFinished())
     return;
 
   if(ow!=nullptr) {

--- a/game/world/bullet.cpp
+++ b/game/world/bullet.cpp
@@ -115,6 +115,8 @@ void Bullet::onMove() {
   }
 
 void Bullet::onCollide(phoenix::material_group matId) {
+  if(isFinished())
+    return;
   if(matId != phoenix::material_group::none) {
     if(material < ItemMaterial::MAT_COUNT) {
       auto s = wrld->addLandHitEffect(ItemMaterial(material),matId,obj->matrix());


### PR DESCRIPTION
After a npc is hit by a bolt it's stopped. In move routine there's a check if npc is moving into the shooting line. If true this causes a double hit because it happens before the bolt is deleted from `bullets` list.  This can be prevented by checking if bolt has the `Stopped` flag.