### PR TITLE
Ladder for pathfinding

### DIFF
--- a/game/game/movealgo.cpp
+++ b/game/game/movealgo.cpp
@@ -686,9 +686,7 @@ bool MoveAlgo::isClose(const Tempest::Vec3& p, float dist) {
   auto  dp  = npc.position()-p;
   dp.y = 0;
   float len = dp.quadLength();
-  if(len<dist*dist)
-    return true;
-  return false;
+  return (len<dist*dist);
   }
 
 bool MoveAlgo::startClimb(JumpStatus jump) {

--- a/game/graphics/mdlvisual.cpp
+++ b/game/graphics/mdlvisual.cpp
@@ -591,7 +591,7 @@ const Animation::Sequence* MdlVisual::startAnimAndGet(Npc& npc, AnimationSolver:
     auto inter = npc.interactive();
     const Animation::Sequence *sq = solver.solveAnim(inter,a,*skInst);
     if(sq!=nullptr){
-      auto bs=inter->isLadder() ? BS_CLIMB : BS_MOBINTERACT;
+      auto bs = inter->isLadder() ? BS_CLIMB : BS_MOBINTERACT;
       if(skInst->startAnim(solver,sq,comb,bs,Pose::NoHint,npc.world().tickCount()))
         return sq;
       }

--- a/game/world/objects/interactive.cpp
+++ b/game/world/objects/interactive.cpp
@@ -416,9 +416,11 @@ std::string_view Interactive::focusName() const {
 
 bool Interactive::checkMobName(std::string_view dest) const {
   std::string_view scheme=schemeName();
-  if(scheme==dest)
-    return true;
-  return false;
+  return scheme==dest;
+  }
+
+bool Interactive::checkMobType(phoenix::vob_type type) const {
+  return vobType==type;
   }
 
 std::string_view Interactive::ownerName() const {

--- a/game/world/objects/interactive.h
+++ b/game/world/objects/interactive.h
@@ -44,6 +44,7 @@ class Interactive : public Vob {
     std::string_view    tag() const;
     std::string_view    focusName() const;
     bool                checkMobName(std::string_view dest) const;
+    bool                checkMobType(phoenix::vob_type type) const;
     std::string_view    ownerName() const;
 
     bool                overrideFocus() const;

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -363,6 +363,7 @@ class Npc final {
     GoToHint  moveHint() const { return go2.flag; }
     void      clearGoTo();
     void      stopWalking();
+    void      recalculateWayPath();
 
     bool      canSeeNpc(const Npc& oth,bool freeLos) const;
     bool      canSeeSource() const;

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -285,7 +285,7 @@ class Npc final {
 
     auto      interactive() const -> Interactive* { return currentInteract; }
     bool      setInteraction(Interactive* id, bool quick=false);
-    void      quitIneraction();
+    void      quitIneraction(bool aniWait = true);
     void      processDefInvTorch();
 
     auto      detectedMob() const -> Interactive*;

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -130,14 +130,14 @@ void World::setPlayer(Npc* npc) {
   if (!npcPlayer->isDead()) {
     npcPlayer->resumeAiRoutine();
   }
-  
+
   npc->setProcessPolicy(Npc::ProcessPolicy::Player);
   npc->clearState(true);
   npc->clearAiQueue();
 
   for(size_t i=0;i<PERC_Count;++i)
     npc->setPerceptionDisable(PercType(i));
-  
+
   npcPlayer = npc;
   }
 
@@ -446,8 +446,8 @@ bool World::testFocusNpc(Npc* def) {
   return wobj.testFocusNpc(*npcPlayer,def,optNpc);
   }
 
-Interactive *World::availableMob(const Npc &pl, std::string_view name) {
-  return wobj.availableMob(pl,name);
+Interactive *World::availableMob(const Npc &pl, std::string_view name, bool ignoreInUse) {
+  return wobj.availableMob(pl,name,ignoreInUse);
   }
 
 Interactive* World::findInteractive(const Npc& pl) {

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -446,8 +446,12 @@ bool World::testFocusNpc(Npc* def) {
   return wobj.testFocusNpc(*npcPlayer,def,optNpc);
   }
 
-Interactive *World::availableMob(const Npc &pl, std::string_view name, bool ignoreInUse) {
-  return wobj.availableMob(pl,name,ignoreInUse);
+Interactive *World::availableMob(const Npc &pl, std::string_view name) {
+  return wobj.availableMob(pl,name);
+  }
+
+Interactive *World::availableMob(const Npc &pl, phoenix::vob_type type) {
+  return wobj.availableMob(pl,type);
   }
 
 Interactive* World::findInteractive(const Npc& pl) {

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -130,7 +130,7 @@ class World final {
     void                 enableCollizionZone (CollisionZone& z);
     void                 disableCollizionZone(CollisionZone& z);
 
-    Interactive*         availableMob(const Npc &pl, std::string_view name);
+    Interactive*         availableMob(const Npc &pl, std::string_view name, bool ignoreInUse = false);
     Interactive*         findInteractive(const Npc& pl);
     void                 setMobRoutine(gtime time, std::string_view scheme, int32_t state);
 

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -130,7 +130,8 @@ class World final {
     void                 enableCollizionZone (CollisionZone& z);
     void                 disableCollizionZone(CollisionZone& z);
 
-    Interactive*         availableMob(const Npc &pl, std::string_view name, bool ignoreInUse = false);
+    Interactive*         availableMob(const Npc &pl, std::string_view name);
+    Interactive*         availableMob(const Npc &pl, phoenix::vob_type type);
     Interactive*         findInteractive(const Npc& pl);
     void                 setMobRoutine(gtime time, std::string_view scheme, int32_t state);
 

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -788,9 +788,9 @@ void WorldObjects::marchInteractives(DbgPainter &p) const {
     }
   }
 
-Interactive *WorldObjects::availableMob(const Npc &pl, std::string_view dest, bool ignoreInUse) {
-  const float  dist=100*10.f;
-  Interactive* ret =nullptr;
+Interactive *WorldObjects::availableMob(const Npc &pl, std::string_view dest) {
+  const float  dist = 100*10.f;
+  Interactive* ret  = nullptr;
 
   if(auto i = pl.interactive()){
     if(i->checkMobName(dest))
@@ -799,9 +799,35 @@ Interactive *WorldObjects::availableMob(const Npc &pl, std::string_view dest, bo
 
   float curDist=dist*dist;
   interactiveObj.find(pl.position(),dist,[&](Interactive& i){
-    if((ignoreInUse || i.isAvailable()) && i.checkMobName(dest)) {
+    if(i.isAvailable() && i.checkMobName(dest)) {
       float d = pl.qDistTo(i);
       if(d<curDist){
+        ret    = &i;
+        curDist = d;
+        }
+      }
+    return false;
+    });
+
+  if(ret==nullptr)
+    return nullptr;
+  return ret;
+  }
+
+Interactive *WorldObjects::availableMob(const Npc &pl, phoenix::vob_type type) {
+  const float  dist = 100*10.f;
+  Interactive* ret  = nullptr;
+
+  if(auto i = pl.interactive()){
+    if(i->checkMobType(type))
+      return i;
+    }
+
+  float curDist=dist*dist;
+  interactiveObj.find(pl.position(),dist,[&](Interactive& i){
+    if(i.isAvailable() && i.checkMobType(type)) {
+      float d = pl.qDistTo(i);
+      if(d<curDist) {
         ret    = &i;
         curDist = d;
         }

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -788,7 +788,7 @@ void WorldObjects::marchInteractives(DbgPainter &p) const {
     }
   }
 
-Interactive *WorldObjects::availableMob(const Npc &pl, std::string_view dest) {
+Interactive *WorldObjects::availableMob(const Npc &pl, std::string_view dest, bool ignoreInUse) {
   const float  dist=100*10.f;
   Interactive* ret =nullptr;
 
@@ -799,7 +799,7 @@ Interactive *WorldObjects::availableMob(const Npc &pl, std::string_view dest) {
 
   float curDist=dist*dist;
   interactiveObj.find(pl.position(),dist,[&](Interactive& i){
-    if(i.isAvailable() && i.checkMobName(dest)) {
+    if((ignoreInUse || i.isAvailable()) && i.checkMobName(dest)) {
       float d = pl.qDistTo(i);
       if(d<curDist){
         ret    = &i;

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -118,7 +118,8 @@ class WorldObjects final {
 
     void           marchInteractives(DbgPainter& p) const;
 
-    Interactive*   availableMob(const Npc& pl, std::string_view name, bool ignoreInUse = false);
+    Interactive*   availableMob(const Npc& pl, std::string_view name);
+    Interactive*   availableMob(const Npc& pl, phoenix::vob_type type);
     void           setMobRoutine(gtime time, std::string_view scheme, int32_t state);
 
     void           sendPassivePerc(Npc& self,Npc& other,Npc& victum,int32_t perc);

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -118,7 +118,7 @@ class WorldObjects final {
 
     void           marchInteractives(DbgPainter& p) const;
 
-    Interactive*   availableMob(const Npc& pl, std::string_view name);
+    Interactive*   availableMob(const Npc& pl, std::string_view name, bool ignoreInUse = false);
     void           setMobRoutine(gtime time, std::string_view scheme, int32_t state);
 
     void           sendPassivePerc(Npc& self,Npc& other,Npc& victum,int32_t perc);


### PR DESCRIPTION
Ladder is used in G1 by Lester when going on focus search or by guards in old camp. For now Ladder is only considered if the waynet is used. I  also tried to make it work if a npc is in follow mode or attack mode but this wasn't working reliably. 

In this context i fixed a bug introduced with last ladder patch. It wasn't checked if  `started` was already true which allowed to climb into the ground. I also did some rework to make marvin command `aigoto` work with ladder plus some formation cleaning.

