### PR TITLE
Rework damage calculation

### DIFF
--- a/game/game/constants.h
+++ b/game/game/constants.h
@@ -81,8 +81,9 @@ enum {
   };
 
 enum {
-  MaxBowRange = 3500, // from Focus_Ranged
-  MaxMagRange = 3500,
+  CritBowRange = 1500,
+  MaxBowRange  = 4500,
+  MaxMagRange  = 3500, // from Focus_Ranged
   };
 
 enum BodyState:uint32_t {

--- a/game/game/constants.h
+++ b/game/game/constants.h
@@ -81,9 +81,10 @@ enum {
   };
 
 enum {
-  CritBowRange = 1500,
-  MaxBowRange  = 4500,
-  MaxMagRange  = 3500, // from Focus_Ranged
+  ReferenceBowRangeG1 = 2000,
+  ReferenceBowRangeG2 = 1500,
+  MaxBowRange         = 4500,
+  MaxMagRange         = 3500, // from Focus_Ranged
   };
 
 enum BodyState:uint32_t {

--- a/game/game/damagecalculator.cpp
+++ b/game/game/damagecalculator.cpp
@@ -21,7 +21,7 @@ DamageCalculator::Val DamageCalculator::damageValue(Npc& src, Npc& other, const 
     ret = swordDamage(src,other);
     }
 
-  if(ret.hasHit && !ret.invinsible)
+  if(ret.hasHit && !ret.invincible && Gothic::inst().version().game==2)
     ret.value = std::max<int32_t>(ret.value,MinDamage);
   if(other.isImmortal() || (other.isPlayer() && Gothic::inst().isGodMode()))
     ret.value = 0;
@@ -40,9 +40,9 @@ DamageCalculator::Val DamageCalculator::damageFall(Npc& npc, float speed) {
   int32_t prot        = npc.protection(::PROT_FALL);
 
   Val ret;
-  ret.invinsible = (prot<0 || npc.isImmortal() || (npc.isPlayer() && Gothic::inst().isGodMode()));
+  ret.invincible = (prot<0 || npc.isImmortal() || (npc.isPlayer() && Gothic::inst().isGodMode()));
   ret.value      = int32_t(dmgPerMeter*(height-h0)/100.f - float(prot));
-  if(ret.value<=0 || ret.invinsible) {
+  if(ret.value<=0 || ret.invincible) {
     ret.value = 0;
     return ret;
     }
@@ -51,17 +51,44 @@ DamageCalculator::Val DamageCalculator::damageFall(Npc& npc, float speed) {
   }
 
 DamageCalculator::Val DamageCalculator::rangeDamage(Npc& nsrc, Npc& nother, const Bullet& b, const CollideMask bMsk) {
-  bool invinsible = !checkDamageMask(nsrc,nother,&b);
-  if(b.pathLength() > float(MaxBowRange) * b.hitChance() && b.hitChance()<1.f)
-    return Val(0,false,invinsible);
+  float dist       = b.pathLength();
+  bool  noHit      = dist>float(MaxMagRange);
+  bool  invincible = !checkDamageMask(nsrc,nother,&b);
+  auto  dmg        = b.damage();
 
-  if(invinsible)
+  if(!b.isSpell()) {
+    auto& script    = nsrc.world().script();
+    int   hitChance = int(script.rand(100));
+    int   hitCh     = 0;
+    bool  g2        = Gothic::inst().version().game==2;
+    float critRange = g2 ? CritBowRange : (CritBowRange + 500);
+    float skill     = b.hitChanceVal();
+
+    if(dist<critRange)
+      hitCh = int((skill - 100.f) / critRange * dist + 100.f + 0.5f); else
+      hitCh = int(skill / (critRange - float(MaxBowRange)) * (dist - float(MaxBowRange)) + 0.5f);
+
+    noHit = (dist>float(MaxBowRange) || hitCh<=hitChance);
+
+    auto w = nsrc.inventory().activeWeapon();
+    if(!g2 && !noHit && !invincible && w!=nullptr) {
+      Talent tal        = w->isCrossbow() ? TALENT_CROSSBOW : TALENT_BOW;
+      int    critChance = int(script.rand(100));
+      if(nsrc.talentValue(tal)>critChance)
+        dmg*=2;
+      }
+    }
+
+  if(noHit)
+    return Val(0,false,invincible);
+
+  if(invincible)
     return Val(0,true,true);
 
   if((bMsk & (COLL_APPLYDAMAGE | COLL_APPLYDOUBLEDAMAGE | COLL_APPLYHALVEDAMAGE | COLL_DOEVERYTHING))==0)
     return Val(0,true,true);
 
-  return rangeDamage(nsrc,nother,b.damage(),bMsk);
+  return rangeDamage(nsrc,nother,dmg,bMsk);
   }
 
 DamageCalculator::Val DamageCalculator::rangeDamage(Npc&, Npc& nother, Damage dmg, const CollideMask bMsk) {
@@ -72,7 +99,7 @@ DamageCalculator::Val DamageCalculator::rangeDamage(Npc&, Npc& nother, Damage dm
   if(bMsk & COLL_APPLYHALVEDAMAGE)
     dmg/=2;
 
-  int  value = 0;
+  int value = 0;
   for(unsigned int i=0; i<phoenix::damage_type::count; ++i) {
     if(dmg[size_t(i)]==0)
       continue;
@@ -88,35 +115,35 @@ DamageCalculator::Val DamageCalculator::swordDamage(Npc& nsrc, Npc& nother) {
   if(!checkDamageMask(nsrc,nother,nullptr))
     return Val(0,true,true);
 
-  auto&  script = nsrc.world().script();
+  auto& script = nsrc.world().script();
   auto& src    = nsrc.handle();
   auto& other  = nother.handle();
 
   // Swords/Fists
   const int dtype      = damageTypeMask(nsrc);
-  uint8_t   hitCh      = TALENT_UNKNOWN;
+  Talent    tal        = TALENT_UNKNOWN;
   int       str        = nsrc.attribute(Attribute::ATR_STRENGTH);
   int       critChance = int(script.rand(100));
 
-  int  value=0;
+  int value = 0;
 
-  if(auto w = nsrc.inventory().activeWeapon()){
+  if(auto w = nsrc.inventory().activeWeapon()) {
     if(w->is2H())
-      hitCh = TALENT_2H; else
-      hitCh = TALENT_1H;
+      tal = TALENT_2H; else
+      tal = TALENT_1H;
     }
 
   if(Gothic::inst().version().game==2) {
-    if(nsrc.isMonster() && hitCh==TALENT_UNKNOWN) {
+    if(nsrc.isMonster() && tal==TALENT_UNKNOWN) {
       // regular monsters always do critical damage
       critChance = 0;
       }
 
-    for(unsigned int i=0; i<phoenix::damage_type::count; ++i){
+    for(unsigned int i=0; i<phoenix::damage_type::count; ++i) {
       if((dtype & (1<<i))==0)
         continue;
       int vd = std::max(str + src.damage[i] - other.protection[i],0);
-      if(src.hitchance[hitCh]<critChance)
+      if(src.hitchance[tal]<=critChance)
         vd = (vd-1)/10;
       if(other.protection[i]>=0) // Filter immune
         value += vd;
@@ -127,10 +154,10 @@ DamageCalculator::Val DamageCalculator::swordDamage(Npc& nsrc, Npc& nother) {
     for(unsigned int i=0; i<phoenix::damage_type::count; ++i) {
       if((dtype & (1<<i))==0)
         continue;
-      int vd = std::max(str + src.damage[i] - other.protection[i],0);
-      if(src.hitchance[hitCh]<critChance)
-        vd = std::max(str + src.damage[i]   - other.protection[i],0); else
-        vd = std::max(str + src.damage[i]*2 - other.protection[i],0);
+      int vd = 0;
+      if(nsrc.talentValue(tal)<=critChance)
+        vd = std::max(str +   src.damage[i] - other.protection[i],0); else
+        vd = std::max(str + 2*src.damage[i] - other.protection[i],0);
       if(other.protection[i]>=0) // Filter immune
         value += vd;
       }
@@ -168,7 +195,7 @@ bool DamageCalculator::checkDamageMask(Npc& nsrc, Npc& nother, const Bullet* b) 
 
 DamageCalculator::Damage DamageCalculator::rangeDamageValue(Npc& src) {
   const int dtype = damageTypeMask(src);
-  int d = src.attribute(Attribute::ATR_DEXTERITY);
+  int d = Gothic::inst().version().game==2 ? src.attribute(Attribute::ATR_DEXTERITY) : 0;
   Damage ret={};
   for(unsigned int i=0;i<phoenix::damage_type::count;++i){
     if((dtype & (1<<i))==0)

--- a/game/game/damagecalculator.cpp
+++ b/game/game/damagecalculator.cpp
@@ -58,23 +58,21 @@ DamageCalculator::Val DamageCalculator::rangeDamage(Npc& nsrc, Npc& nother, cons
 
   if(!b.isSpell()) {
     auto& script    = nsrc.world().script();
-    int   hitChance = int(script.rand(100));
-    int   hitCh     = 0;
+    float hitChance = float(script.rand(100))/100.f;
+    float hitCh     = 0;
     bool  g2        = Gothic::inst().version().game==2;
-    float critRange = g2 ? CritBowRange : (CritBowRange + 500);
+    float refRange  = g2 ? ReferenceBowRangeG2 : ReferenceBowRangeG1;
     float skill     = b.hitChanceVal();
 
-    if(dist<critRange)
-      hitCh = int((skill - 100.f) / critRange * dist + 100.f + 0.5f); else
-      hitCh = int(skill / (critRange - float(MaxBowRange)) * (dist - float(MaxBowRange)) + 0.5f);
+    if(dist<refRange)
+      hitCh = (skill - 1.f) / refRange * dist + 1.f; else
+      hitCh = skill / (refRange - float(MaxBowRange)) * (dist - float(MaxBowRange));
 
     noHit = (dist>float(MaxBowRange) || hitCh<=hitChance);
 
-    auto w = nsrc.inventory().activeWeapon();
-    if(!g2 && !noHit && !invincible && w!=nullptr) {
-      Talent tal        = w->isCrossbow() ? TALENT_CROSSBOW : TALENT_BOW;
-      int    critChance = int(script.rand(100));
-      if(nsrc.talentValue(tal)>critChance)
+    if(!g2 && !noHit && !invincible) {
+      int critChance = int(script.rand(100));
+      if(std::lround(100.f * b.critChance())>critChance)
         dmg*=2;
       }
     }

--- a/game/game/damagecalculator.h
+++ b/game/game/damagecalculator.h
@@ -18,11 +18,11 @@ class DamageCalculator {
     struct Val final {
       Val()=default;
       Val(int32_t v,bool b):value(v),hasHit(b){}
-      Val(int32_t v,bool b,bool i):value(v),hasHit(b),invinsible(i){}
+      Val(int32_t v,bool b,bool i):value(v),hasHit(b),invincible(i){}
 
       int32_t value      = 0;
       bool    hasHit     = false;
-      bool    invinsible = false;
+      bool    invincible = false;
       };
 
     struct Damage final {

--- a/game/game/fightalgo.cpp
+++ b/game/game/fightalgo.cpp
@@ -288,6 +288,7 @@ float FightAlgo::weaponRange(GameScript &owner, const Npc &npc) {
   auto& gv  = owner.guildVal();
   auto  w   = npc.inventory().activeWeapon();
   int   add = w ? w->swordLength() : 0;
+  auto  bR  = Gothic::inst().version().game==2 ? ReferenceBowRangeG2 : ReferenceBowRangeG1;
 
   switch(npc.weaponState()) {
     case WeaponState::W1H:
@@ -299,7 +300,7 @@ float FightAlgo::weaponRange(GameScript &owner, const Npc &npc) {
       return float(gv.fight_range_fist[gl]);
     case WeaponState::Bow:
     case WeaponState::CBow:
-      return float(MaxBowRange);
+      return float(bR);
     case WeaponState::Mage:
       return float(MaxMagRange);
     }

--- a/game/game/fightalgo.cpp
+++ b/game/game/fightalgo.cpp
@@ -298,9 +298,8 @@ float FightAlgo::weaponRange(GameScript &owner, const Npc &npc) {
     case WeaponState::Fist:
       return float(gv.fight_range_fist[gl]);
     case WeaponState::Bow:
-      return float((MaxBowRange*npc.hitChanse(TALENT_BOW))/100);
     case WeaponState::CBow:
-      return float((MaxBowRange*npc.hitChanse(TALENT_CROSSBOW))/100);
+      return float(MaxBowRange);
     case WeaponState::Mage:
       return float(MaxMagRange);
     }

--- a/game/ui/gamemenu.cpp
+++ b/game/ui/gamemenu.cpp
@@ -1190,7 +1190,7 @@ void GameMenu::setPlayer(const Npc &pl) {
       continue;
 
     const int sk  = pl.talentSkill(Talent(i));
-    const int val = g2 ? pl.hitChanse(Talent(i)) : pl.talentValue(Talent(i));
+    const int val = g2 ? pl.hitChance(Talent(i)) : pl.talentValue(Talent(i));
 
     set(string_frm("MENU_ITEM_TALENT_",i,"_TITLE"), str);
     set(string_frm("MENU_ITEM_TALENT_",i,"_SKILL"), strEnum(talV->get_string(size_t(i)),sk,textBuf));

--- a/game/world/bullet.h
+++ b/game/world/bullet.h
@@ -50,6 +50,8 @@ class Bullet final : public DynamicWorld::BulletCallback {
     auto     damage() const -> const DamageCalculator::Damage& { return dmg; }
     void     setDamage(DamageCalculator::Damage d) { dmg=d; }
 
+    float    critChance() const { return critCh; }
+    void     setCritChance(float v) { critCh=v; }
     float    hitChanceVal() const { return hitCh; }
     void     setHitChanceVal(float v) { hitCh=v; }
     bool     isFinished() const;
@@ -67,8 +69,9 @@ class Bullet final : public DynamicWorld::BulletCallback {
     World*                    wrld=nullptr;
     Npc*                      ow=nullptr;
 
-    DamageCalculator::Damage  dmg     = {};
-    float                     hitCh   = 100.f;
+    DamageCalculator::Damage  dmg    = {};
+    float                     hitCh  = 1.f;
+    float                     critCh = 0.f;
 
     MeshObjects::Mesh         view;
     Effect                    vfx;

--- a/game/world/bullet.h
+++ b/game/world/bullet.h
@@ -50,8 +50,8 @@ class Bullet final : public DynamicWorld::BulletCallback {
     auto     damage() const -> const DamageCalculator::Damage& { return dmg; }
     void     setDamage(DamageCalculator::Damage d) { dmg=d; }
 
-    float    hitChance() const { return hitCh; }
-    void     setHitChance(float h) { hitCh=h; }
+    float    hitChanceVal() const { return hitCh; }
+    void     setHitChanceVal(float v) { hitCh=v; }
     bool     isFinished() const;
 
     float    pathLength() const;
@@ -68,7 +68,7 @@ class Bullet final : public DynamicWorld::BulletCallback {
     Npc*                      ow=nullptr;
 
     DamageCalculator::Damage  dmg     = {};
-    float                     hitCh   = 1.f;
+    float                     hitCh   = 100.f;
 
     MeshObjects::Mesh         view;
     Effect                    vfx;

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1116,7 +1116,7 @@ int32_t Npc::talentValue(Talent t) const {
   return 0;
   }
 
-int32_t Npc::hitChanse(Talent t) const {
+int32_t Npc::hitChance(Talent t) const {
   if(t<=phoenix::c_npc::hitchance_count)
     return hnpc->hitchance[t];
   return 0;
@@ -2686,7 +2686,6 @@ void Npc::commitSpell() {
 
     auto& b = owner.shootSpell(*active, *this, currentTarget);
     b.setDamage(dmg);
-    b.setHitChance(1.f);
     b.setOrigin(this);
     b.setTarget(nullptr);
     visual.setMagicWeaponKey(owner,SpellFxKey::Init);
@@ -3503,12 +3502,15 @@ bool Npc::shootBow(Interactive* focOverride) {
   invent.delItem(size_t(munition),1,*this);
   b.setOrigin(this);
   b.setDamage(DamageCalculator::rangeDamageValue(*this));
-
-  auto rgn = currentRangeWeapon();
-  if(rgn!=nullptr && rgn->isCrossbow())
-    b.setHitChance(float(hnpc->hitchance[TALENT_CROSSBOW])/100.f); else
-    b.setHitChance(float(hnpc->hitchance[TALENT_BOW]     )/100.f);
-
+  if(Gothic::inst().version().game==1) {
+    b.setHitChanceVal(float(hnpc->attribute[ATR_DEXTERITY]));
+    }
+  else {
+    auto rgn = currentRangeWeapon();
+    if(rgn!=nullptr && rgn->isCrossbow())
+      b.setHitChanceVal(float(hnpc->hitchance[TALENT_CROSSBOW])); else
+      b.setHitChanceVal(float(hnpc->hitchance[TALENT_BOW]     ));
+    }
   return true;
   }
 

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -3502,14 +3502,18 @@ bool Npc::shootBow(Interactive* focOverride) {
   invent.delItem(size_t(munition),1,*this);
   b.setOrigin(this);
   b.setDamage(DamageCalculator::rangeDamageValue(*this));
+
+  auto rgn = currentRangeWeapon();
   if(Gothic::inst().version().game==1) {
-    b.setHitChanceVal(float(hnpc->attribute[ATR_DEXTERITY]));
+    b.setHitChanceVal(float(hnpc->attribute[ATR_DEXTERITY])/100.f);
+    if(rgn!=nullptr && rgn->isCrossbow())
+      b.setCritChance(float(talentsVl[TALENT_CROSSBOW])/100.f); else
+      b.setCritChance(float(talentsVl[TALENT_BOW]     )/100.f);
     }
   else {
-    auto rgn = currentRangeWeapon();
     if(rgn!=nullptr && rgn->isCrossbow())
-      b.setHitChanceVal(float(hnpc->hitchance[TALENT_CROSSBOW])); else
-      b.setHitChanceVal(float(hnpc->hitchance[TALENT_BOW]     ));
+      b.setHitChanceVal(float(hnpc->hitchance[TALENT_CROSSBOW])/100.f); else
+      b.setHitChanceVal(float(hnpc->hitchance[TALENT_BOW]     )/100.f);
     }
   return true;
   }

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -191,7 +191,7 @@ class Npc final {
 
     void       setTalentValue(Talent t,int32_t lvl);
     int32_t    talentValue(Talent t) const;
-    int32_t    hitChanse(Talent t) const;
+    int32_t    hitChance(Talent t) const;
 
     void       setRefuseTalk(uint64_t milis);
     bool       isRefuseTalk() const;


### PR DESCRIPTION
The hit chance for physical ranged damage is defined at three distance points from target with a linear scaling in between:

- 100% hit chance at `0`
- Bow/Crossbow skill value (Dexterity for G1) hit chance at `RANGED_CHANCE_MINDIST`
- 0% hit chance at `RANGED_CHANCE_MAXDIST`

 where `RANGED_CHANCE_MINDIST=1500` (`2000` for G1 based on some testing) and `RANGED_CHANCE_MAXDIST=4500`. These constans are defined in `AI_Constants.d` script file. I found a good explanation [here](https://strafkolonie-online.net/forum/board/thread/1895-info-erkl%C3%A4rung-der-berechnung-der-trefferchance-im-fernkampf/) (german, but chart and table are self-explaining).
Since distance is only known at hit time the hit chance calculation was moved to the damage calculation code. Critical hit chance calculation was added and the dexterity bonus to damage removed for G1.  

I also adjusted G1 sword damage to consider `talentValue` instead of the not present `hitChance` attribute.  In crit chance calculation`<` were changed to `<=`  to keep 0% hit chance if the skill value is 0 instead of 1%.

G1 has no minimal damage so don't consider `MinDamage`. Plus some spelling and code style rework.


