### PR TITLE
Set `bestAzimuth` to zero in ranged camera mode for G1

### DIFF
--- a/game/camera.cpp
+++ b/game/camera.cpp
@@ -594,6 +594,9 @@ void Camera::calcControlPoints(float dtF) {
     rotBest      = Vec3();
     //spin.y += def.bestAzimuth;
     }
+  else if(Gothic::inst().version().game==1 && camMod==Ranged) {
+    rotBest = Vec3();
+    }
 
   followAng(src.spin,  dst.spin+rotBest, dtF);
   if(!isMarvin())


### PR DESCRIPTION
Only for ranged Cam `bestAzimuth` differs between G1 and G2. It's `0` for G2 but `30` for G1. This leads to an unwanted camera perspective, so set it to `0` instead.