### PR TITLE
Adjust camera selection for G1

### DIFF
--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -897,6 +897,7 @@ Camera::Mode MainWindow::solveCameraMode() const {
       return Camera::Dive;
     if(pl->isSwim())
       return Camera::Swim;
+    bool g2 = Gothic::inst().version().game==2;
     switch(pl->weaponState()){
       case WeaponState::Fist:
       case WeaponState::W1H:
@@ -904,9 +905,9 @@ Camera::Mode MainWindow::solveCameraMode() const {
         return Camera::Melee;
       case WeaponState::Bow:
       case WeaponState::CBow:
-        return Camera::Ranged;
+        return g2 ? Camera::Ranged : Camera::Normal;
       case WeaponState::Mage:
-        return Camera::Ranged;
+        return g2 ? Camera::Ranged : Camera::Melee;
       case WeaponState::NoWeapon:
         return Camera::Normal;
       }


### PR DESCRIPTION
If in certain weapon or move state G1 does not always use the corresponding camera. If a ranged weapon is drawn `CAMMODNORMAL` is used because `CAMMODRANGED` has a unwanted 30 degree rotation offset. 

There are other cams in vanilla like `CAMMODNORMAL` while swimming or `CAMMODRUN` for non combat moving. I haven't touched any of those because there are no issues with current camera usage.
