### PR TITLE
Bump phoenix to v1.1.1 and update remote URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,5 +9,5 @@
 	url = https://github.com/schellingb/TinySoundFont.git
 [submodule "lib/phoenix"]
 	path = lib/phoenix
-	url = https://github.com/lmichaelis/phoenix.git
-	branch = v/1.0
+	url = https://github.com/GothicKit/phoenix.git
+	branch = main


### PR DESCRIPTION
Hi @Try, I'm moving phoenix into a new [GitHub organization](https://github.com/GothicKit) so the Git submodule remote should be updated with this patch. I also noticed that you're on an old version of phoenix, so I have bumped it up to [`v1.1.1`](https://github.com/GothicKit/phoenix/releases/tag/v1.1.1) :>