### PR TITLE
Fallback for invalid start point

### DIFF
--- a/game/game/gamesession.cpp
+++ b/game/game/gamesession.cpp
@@ -39,12 +39,15 @@ void GameSession::HeroStorage::putToWorld(World& owner, std::string_view wayPoin
 
   if(auto pl = owner.player()) {
     pl->load(sr,0);
-    if(auto pos = owner.findPoint(wayPoint)) {
-      pl->setPosition  (pos->x,pos->y,pos->z);
-      pl->setDirection (pos->dirX,pos->dirY,pos->dirZ);
-      pl->attachToPoint(pos);
-      pl->updateTransform();
+    auto pos = owner.findPoint(wayPoint);
+    if(pos==nullptr) {
+       // freemine.zen
+       pos = &owner.startPoint();
       }
+    pl->setPosition  (pos->x,pos->y,pos->z);
+    pl->setDirection (pos->dirX,pos->dirY,pos->dirZ);
+    pl->attachToPoint(pos);
+    pl->updateTransform();
     } else {
     auto ptr = std::make_unique<Npc>(owner,-1,wayPoint);
     ptr->load(sr,0);

--- a/game/world/objects/vob.cpp
+++ b/game/world/objects/vob.cpp
@@ -185,7 +185,8 @@ std::unique_ptr<Vob> Vob::load(Vob* parent, World& world, const phoenix::vob& vo
       float dx = vob.rotation[2].x;
       float dy = vob.rotation[2].y;
       float dz = vob.rotation[2].z;
-      world.addStartPoint(Vec3(vob.position.x,vob.position.y,vob.position.z),Vec3(dx,dy,dz),vob.vob_name);
+      std::string vobName = vob.vob_name.empty() ? "START" : vob.vob_name;
+      world.addStartPoint(Vec3(vob.position.x,vob.position.y,vob.position.z),Vec3(dx,dy,dz),vobName);
       // FIXME
       return std::unique_ptr<Vob>(new Vob(parent,world,vob,flags));
       }

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -848,6 +848,10 @@ const WayPoint *World::findNextPoint(const WayPoint &pos) const {
   return wmatrix->findNextPoint(pos.position());
   }
 
+const WayPoint& World::startPoint() const {
+  return wmatrix->startPoint();
+  }
+
 const WayPoint& World::deadPoint() const {
   return wmatrix->deadPoint();
   }

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -68,6 +68,7 @@ class World final {
     const WayPoint*      findNextFreePoint(const Npc& pos, std::string_view name) const;
     const WayPoint*      findNextPoint(const WayPoint& pos) const;
 
+    const WayPoint&      startPoint() const;
     const WayPoint&      deadPoint() const;
 
     void                 detectNpcNear(std::function<void(Npc&)> f);

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -355,22 +355,21 @@ Npc* WorldObjects::addNpc(size_t npcInstance, const Vec3& pos) {
 
 Npc* WorldObjects::insertPlayer(std::unique_ptr<Npc> &&npc, std::string_view at) {
   auto pos = owner.findPoint(at);
-  if(pos==nullptr){
-    Log::e("insertPlayer: invalid waypoint");
-    return nullptr;
+  if(pos==nullptr) {
+    Log::e("insertPlayer: invalid waypoint, using fallback");
+    // freemine.zen
+    pos = &owner.startPoint();
     }
 
-  if(pos!=nullptr && pos->isLocked()){
+  if(pos->isLocked()) {
     auto p = owner.findNextPoint(*pos);
     if(p)
       pos=p;
     }
-  if(pos!=nullptr) {
-    npc->setPosition  (pos->x,pos->y,pos->z);
-    npc->setDirection (pos->dirX,pos->dirY,pos->dirZ);
-    npc->attachToPoint(pos);
-    npc->updateTransform();
-    }
+  npc->setPosition  (pos->x,pos->y,pos->z);
+  npc->setDirection (pos->dirX,pos->dirY,pos->dirZ);
+  npc->attachToPoint(pos);
+  npc->updateTransform();
   npcArr.emplace_back(std::move(npc));
   return npcArr.back().get();
   }


### PR DESCRIPTION
When entering `freemine.zen` the waypoint `ENTRANCE_FREEMINE_FREEMINECAMP` is requested in `insertPlayer` routine. But the real name is `ENTRANCE_OLDMINE_SURFACE` and player insertion fails. Vanilla uses `(0,0,0)` as fallback which works because it's close to that point in this particular world.

Instead of failing just fall back to the waypoint from `startPoint` routine which uses `(0,0,0)` as well as last resort, but usually returns a better point created from `zCVobStartpoint`. 

Start points created from `zCVobStartpoint` have an empty name except for `world.zen` in G1. Since empty names aren't considered in `findPoint` routine, I set it to `START` for these cases so zen loading with `-w` start parameter inserts the character at the correct position. 