### PR TITLE
Ladder for pathfinding

### DIFF
--- a/game/game/movealgo.cpp
+++ b/game/game/movealgo.cpp
@@ -47,10 +47,8 @@ void MoveAlgo::tickMobsi(uint64_t dt) {
   auto pos = npc.position();
   if(npc.interactive()->isLadder()) {
     auto mat = npc.interactive()->transform();
-    Tempest::Vec3 p0 = {}, p1 = dp;
-    mat.project(p0);
-    mat.project(p1);
-    dp = p1-p0;
+    mat.project(dp);
+    dp -= npc.interactive()->position();
     } else {
     Tempest::Vec3 ret;
     applyRotation(ret,dp);

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -448,7 +448,7 @@ void PlayerControl::marvinF8(uint64_t dt) {
   pl.clearState(false);
   pl.setPosition(pos);
   pl.clearSpeed();
-  pl.quitIneraction();
+  pl.setInteraction(nullptr,true);
   pl.setAnim(AnimationSolver::Idle);
   pl.clearAiQueue();
 
@@ -472,7 +472,7 @@ void PlayerControl::marvinK(uint64_t dt) {
   pl.clearState(false);
   pl.setPosition(pos);
   pl.clearSpeed();
-  pl.quitIneraction();
+  pl.setInteraction(nullptr,true);
   // pl.setAnim(AnimationSolver::Idle); // Original G2 behaviour: K doesn't stop running
   }
 
@@ -582,14 +582,14 @@ void PlayerControl::implMove(uint64_t dt) {
   if(pl.bodyStateMasked()==BS_UNCONSCIOUS)
     return;
 
-  if(pl.interactive()!=nullptr) {
+  if(!pl.isAiQueueEmpty()) {
     runAngleDest = 0;
-    implMoveMobsi(pl,dt);
     return;
     }
 
-  if(!pl.isAiQueueEmpty()) {
+  if(pl.interactive()!=nullptr) {
     runAngleDest = 0;
+    implMoveMobsi(pl,dt);
     return;
     }
 

--- a/game/game/serialize.h
+++ b/game/game/serialize.h
@@ -33,7 +33,7 @@ class SaveGameHeader;
 class Serialize {
   public:
     enum Version : uint16_t {
-      Current = 43
+      Current = 44
       };
     Serialize(Tempest::ODevice& fout);
     Serialize(Tempest::IDevice&  fin);

--- a/game/game/serialize.h
+++ b/game/game/serialize.h
@@ -33,7 +33,7 @@ class SaveGameHeader;
 class Serialize {
   public:
     enum Version : uint16_t {
-      Current = 44
+      Current = 43
       };
     Serialize(Tempest::ODevice& fout);
     Serialize(Tempest::IDevice&  fin);

--- a/game/world/objects/interactive.cpp
+++ b/game/world/objects/interactive.cpp
@@ -96,6 +96,9 @@ Interactive::Interactive(Vob* parent, World &world, const phoenix::vobs::mob& vo
       --at;
     stepsCount = std::atoi(mdlVisual.c_str()+at);
     stateNum   = stepsCount;
+
+    transform().project(displayOffset);
+    displayOffset -= position();
     }
 
   world.addInteractive(this);
@@ -242,7 +245,7 @@ void Interactive::tick(uint64_t dt) {
   if(p->user==nullptr && (state==stateNum && p->attachMode))
     return;
 
-  if(isLadder() && p->started==Started)
+  if(isLadder() && p->started==Started && p->user!=nullptr && p->user->isAiQueueEmpty())
     return;
   implTick(*p);
   }
@@ -754,7 +757,7 @@ bool Interactive::dettach(Npc &npc, bool quick) {
     if(i.user==&npc && i.attachMode) {
       if(canQuitAtState(*i.user,state)) {
         auto sq = npc.setAnimAngGet(Npc::Anim::InteractToStand);
-        if(sq==nullptr)
+        if(sq==nullptr && !quick)
           return false;
         i.user       = nullptr;
         i.attachMode = false;

--- a/game/world/objects/interactive.cpp
+++ b/game/world/objects/interactive.cpp
@@ -416,6 +416,10 @@ std::string_view Interactive::displayName() const {
   return s->get_string();
   }
 
+const Tempest::Vec3* Interactive::bBox() const {
+  return bbox;
+  }
+
 bool Interactive::setMobState(std::string_view scheme, int32_t st) {
   const bool ret = Vob::setMobState(scheme,st);
   if(state==st)
@@ -755,16 +759,12 @@ bool Interactive::attach(Npc &npc) {
 bool Interactive::dettach(Npc &npc, bool quick) {
   for(auto& i:attPos) {
     if(i.user==&npc && i.attachMode) {
-      if(canQuitAtState(*i.user,state)) {
-        auto sq = npc.setAnimAngGet(Npc::Anim::InteractToStand);
-        if(sq==nullptr && !quick)
-          return false;
-        i.user       = nullptr;
-        i.attachMode = false;
-        npc.quitIneraction();
-        return true;
-        }
-      else if(quick) {
+      if(quick || canQuitAtState(*i.user,state)) {
+        if(!quick) {
+          auto sq = npc.setAnimAngGet(Npc::Anim::InteractToStand);
+          if(sq==nullptr)
+            return false;
+          }
         i.user       = nullptr;
         i.attachMode = false;
         npc.quitIneraction();

--- a/game/world/objects/interactive.h
+++ b/game/world/objects/interactive.h
@@ -46,7 +46,7 @@ class Interactive : public Vob {
     Tempest::Vec3       displayPosition() const;
     std::string_view    displayName() const;
 
-    auto                bBox() const { return &bbox; }
+    auto                bBox() const -> const Tempest::Vec3*;
 
     int32_t             stateId() const { return state; }
     int32_t             stateCount() const { return stateNum; }

--- a/game/world/objects/interactive.h
+++ b/game/world/objects/interactive.h
@@ -46,6 +46,8 @@ class Interactive : public Vob {
     Tempest::Vec3       displayPosition() const;
     std::string_view    displayName() const;
 
+    auto                bBox() const { return &bbox; }
+
     int32_t             stateId() const { return state; }
     int32_t             stateCount() const { return stateNum; }
     bool                setMobState(std::string_view scheme,int32_t st) override;

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1361,7 +1361,7 @@ bool Npc::implGoTo(uint64_t dt, float destDist) {
       go2.wp = go2.wp->hasLadderConn(wayPath.first()) ? wayPath.first() : wayPath.pop();
       if(go2.wp!=nullptr) {
         attachToPoint(go2.wp);
-        if(useLadder()) {
+        if(setGoToLadder()) {
           mvAlgo.tick(dt);
           return true;
           }
@@ -1371,7 +1371,11 @@ bool Npc::implGoTo(uint64_t dt, float destDist) {
     if(finished)
       clearGoTo();
     } else {
-    if(useLadder() || (mvAlgo.checkLastBounce() && implTurnTo(dpos.x,dpos.z,false,dt))) {
+    if(setGoToLadder()) {
+      mvAlgo.tick(dt);
+      return true;
+      }
+    if(mvAlgo.checkLastBounce() && implTurnTo(dpos.x,dpos.z,false,dt)) {
       mvAlgo.tick(dt);
       return true;
       }
@@ -1695,7 +1699,7 @@ bool Npc::implAiFlee(uint64_t dt) {
   return true;
   }
 
-bool Npc::useLadder() {
+bool Npc::setGoToLadder() {
   if(go2.wp==nullptr || go2.wp!=wayPath.first())
     return false;
   auto inter = go2.wp->ladder;
@@ -2120,7 +2124,7 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
       break;
       }
     case AI_GoToPoint: {
-      if(!setInteraction(nullptr)) {
+      if(isInAir() || !setInteraction(nullptr)) {
         queue.pushFront(std::move(act));
         break;
         }

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -3991,15 +3991,15 @@ bool Npc::recalculateWayPath() {
   wayPath.clear();
   go2.clear();
   attachToPoint(nullptr);
-  wayPath       = owner.wayTo(*this,*target);
-  auto wpoint   = wayPath.pop();
+  wayPath     = owner.wayTo(*this,*target);
+  auto wpoint = wayPath.pop();
   if(wpoint!=nullptr) {
     go2.set(wpoint);
     attachToPoint(wpoint);
-  } else {
+    } else {
     attachToPoint(target);
     clearGoTo();
-  }
+    }
   return true;
 }
 

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -474,7 +474,7 @@ class Npc final {
     void      implSetFightMode(const Animation::EvCount& ev);
     bool      implAiFlee(uint64_t dt);
 
-    bool      useLadder();
+    bool      setGoToLadder();
 
     void      tickRoutine();
     void      nextAiAction(AiQueue& queue, uint64_t dt);

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -361,7 +361,6 @@ class Npc final {
     void      attachToPoint(const WayPoint* p);
     GoToHint  moveHint() const { return go2.flag; }
     void      clearGoTo();
-    bool      recalculateWayPath();
     void      stopWalking();
 
     bool      canSeeNpc(const Npc& oth,bool freeLos) const;
@@ -427,11 +426,10 @@ class Npc final {
       };
 
     struct GoTo final {
-      GoToHint         flag   = GoToHint::GT_No;
-      Npc*             npc    = nullptr;
-      const WayPoint*  wp     = nullptr;
-      Interactive*     ladder = nullptr;
-      Tempest::Vec3    pos    = {};
+      GoToHint         flag = GoToHint::GT_No;
+      Npc*             npc  = nullptr;
+      const WayPoint*  wp   = nullptr;
+      Tempest::Vec3    pos  = {};
 
       void             save(Serialize& fout) const;
       void             load(Serialize&  fin);
@@ -475,6 +473,8 @@ class Npc final {
     void      implFaiWait(uint64_t dt);
     void      implSetFightMode(const Animation::EvCount& ev);
     bool      implAiFlee(uint64_t dt);
+
+    bool      useLadder();
 
     void      tickRoutine();
     void      nextAiAction(AiQueue& queue, uint64_t dt);

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -361,6 +361,7 @@ class Npc final {
     void      attachToPoint(const WayPoint* p);
     GoToHint  moveHint() const { return go2.flag; }
     void      clearGoTo();
+    bool      recalculateWayPath();
     void      stopWalking();
 
     bool      canSeeNpc(const Npc& oth,bool freeLos) const;
@@ -426,10 +427,11 @@ class Npc final {
       };
 
     struct GoTo final {
-      GoToHint         flag = GoToHint::GT_No;
-      Npc*             npc  = nullptr;
-      const WayPoint*  wp   = nullptr;
-      Tempest::Vec3    pos  = {};
+      GoToHint         flag   = GoToHint::GT_No;
+      Npc*             npc    = nullptr;
+      const WayPoint*  wp     = nullptr;
+      Interactive*     ladder = nullptr;
+      Tempest::Vec3    pos    = {};
 
       void             save(Serialize& fout) const;
       void             load(Serialize&  fin);

--- a/game/world/waymatrix.cpp
+++ b/game/world/waymatrix.cpp
@@ -6,6 +6,7 @@
 
 #include "utils/dbgpainter.h"
 #include "utils/versioninfo.h"
+#include "world/objects/interactive.h"
 #include "world.h"
 
 using namespace Tempest;
@@ -53,15 +54,17 @@ void WayMatrix::buildIndex() {
     return a->x<b->x;
     });
 
-  for(auto& i:edges){
-    if(i.a<wayPoints.size() && i.b<wayPoints.size()){
-      auto& a = wayPoints[i.a ];
+  for(auto& i:edges) {
+    if(i.a<wayPoints.size() && i.b<wayPoints.size()) {
+      auto& a = wayPoints[i.a];
       auto& b = wayPoints[i.b];
 
       a.connect(b);
       b.connect(a);
       }
     }
+
+  calculateLadderPoints();
   }
 
 const WayPoint *WayMatrix::findWayPoint(const Vec3& at, const std::function<bool(const WayPoint&)>& filter) const {
@@ -178,8 +181,48 @@ void WayMatrix::marchPoints(DbgPainter &p) const {
 
 void WayMatrix::adjustWaypoints(std::vector<WayPoint> &wp) {
   for(auto& w:wp) {
-    w.y = world.physic()->landRay(w.position()).v.y;
+    auto ray = world.physic()->landRay(w.position());
+    if(ray.hasCol)
+      w.y = ray.v.y;
     indexPoints.push_back(&w);
+    }
+  }
+
+void WayMatrix::calculateLadderPoints() {
+  float dist   = 100.f;
+  Vec3  offset = {3.f,0,3.f};
+  for(uint32_t i=0;;++i) {
+    auto inter = world.mobsiById(i);
+    if(inter==nullptr)
+      break;
+    if(!inter->isLadder())
+      continue;
+    auto& box  = *inter->bBox();
+    for(auto& e:edges) {
+      if(e.a>=wayPoints.size() || e.b>=wayPoints.size() || e.a==e.b)
+        continue;
+      auto& a     = wayPoints[e.a], b    = wayPoints[e.b];
+      Vec3  posA  = a.position(),   posB = b.position();
+      Vec3  dTopA = box[1] - posA + offset;
+      Vec3  dBotA = box[0] - posA - offset;
+      Vec3  dBA   = posB - posA;
+      if(dBA.x<0)
+        std::swap(dTopA.x,dBotA .x);
+      if(dBA.y<0)
+        std::swap(dTopA.y,dBotA .y);
+      if(dBA.z<0)
+        std::swap(dTopA.z,dBotA .z);
+      float max = std::min({dTopA.x/dBA.x,dTopA.y/dBA.y,dTopA.z/dBA.z});
+      float min = std::max({dBotA.x/dBA.x,dBotA.y/dBA.y,dBotA.z/dBA.z});
+      if(max<min || max<0.f || min>1.f)
+        continue;
+      float dy = 0.5f * std::abs(box[0].y+box[1].y-posA.y-posB.y);
+      if(dy<dist) {
+        wayPoints[e.a].ladder = inter;
+        wayPoints[e.b].ladder = inter;
+        break;
+        }
+      }
     }
   }
 

--- a/game/world/waymatrix.cpp
+++ b/game/world/waymatrix.cpp
@@ -189,29 +189,28 @@ void WayMatrix::adjustWaypoints(std::vector<WayPoint> &wp) {
   }
 
 void WayMatrix::calculateLadderPoints() {
-  float dist   = 100.f;
-  Vec3  offset = {3.f,0,3.f};
+  static const float dist = 100.f;
   for(uint32_t i=0;;++i) {
     auto inter = world.mobsiById(i);
     if(inter==nullptr)
       break;
     if(!inter->isLadder())
       continue;
-    auto& box  = *inter->bBox();
+    auto box = inter->bBox();
     for(auto& e:edges) {
       if(e.a>=wayPoints.size() || e.b>=wayPoints.size() || e.a==e.b)
         continue;
       auto& a     = wayPoints[e.a], b    = wayPoints[e.b];
       Vec3  posA  = a.position(),   posB = b.position();
-      Vec3  dTopA = box[1] - posA + offset;
-      Vec3  dBotA = box[0] - posA - offset;
+      Vec3  dTopA = box[1] - posA;
+      Vec3  dBotA = box[0] - posA;
       Vec3  dBA   = posB - posA;
       if(dBA.x<0)
-        std::swap(dTopA.x,dBotA .x);
+        std::swap(dTopA.x,dBotA.x);
       if(dBA.y<0)
-        std::swap(dTopA.y,dBotA .y);
+        std::swap(dTopA.y,dBotA.y);
       if(dBA.z<0)
-        std::swap(dTopA.z,dBotA .z);
+        std::swap(dTopA.z,dBotA.z);
       float max = std::min({dTopA.x/dBA.x,dTopA.y/dBA.y,dTopA.z/dBA.z});
       float min = std::max({dBotA.x/dBA.x,dBotA.y/dBA.y,dBotA.z/dBA.z});
       if(max<min || max<0.f || min>1.f)

--- a/game/world/waymatrix.h
+++ b/game/world/waymatrix.h
@@ -56,6 +56,7 @@ class WayMatrix final {
     mutable std::vector<const WayPoint*>  stk[2];
 
     void                   adjustWaypoints(std::vector<WayPoint> &wp);
+    void                   calculateLadderPoints();
 
     const FpIndex&         findFpIndex(std::string_view name) const;
     const WayPoint*        findFreePoint(float x, float y, float z, const FpIndex &ind,

--- a/game/world/waypath.cpp
+++ b/game/world/waypath.cpp
@@ -40,6 +40,12 @@ const WayPoint *WayPath::pop() {
   return ret;
   }
 
+const WayPoint *WayPath::first() const {
+  if(dat.size()==0)
+    return nullptr;
+  return dat[dat.size()-1];
+  }
+
 const WayPoint *WayPath::last() const {
   if(dat.size()==0)
     return nullptr;

--- a/game/world/waypath.h
+++ b/game/world/waypath.h
@@ -17,7 +17,8 @@ class WayPath final {
     void reverse();
 
     const WayPoint* pop();
-    const WayPoint* last() const;
+    const WayPoint* first() const;
+    const WayPoint* last()  const;
 
   private:
     std::vector<const WayPoint*> dat;

--- a/game/world/waypoint.cpp
+++ b/game/world/waypoint.cpp
@@ -71,6 +71,12 @@ void WayPoint::connect(WayPoint &w) {
   conn.push_back(c);
   }
 
+bool WayPoint::hasLadderConn(const WayPoint* w) const {
+  if(w!=nullptr && w->ladder!=nullptr && w->ladder==ladder)
+    return true;
+  return false;
+  }
+
 std::string WayPoint::upcaseof(std::string_view src) {
   auto ret = std::string(src);
   for(auto& i:ret)

--- a/game/world/waypoint.h
+++ b/game/world/waypoint.h
@@ -6,6 +6,7 @@
 #include <Tempest/Vec>
 
 class FpLock;
+class Interactive;
 
 class WayPoint final {
   public:
@@ -36,6 +37,8 @@ class WayPoint final {
     bool  underWater = false;
 
     std::string name;
+
+    Interactive* ladder = nullptr;
 
     struct Conn final {
       WayPoint* point=nullptr;

--- a/game/world/waypoint.h
+++ b/game/world/waypoint.h
@@ -53,6 +53,7 @@ class WayPoint final {
 
     void connect(WayPoint& w);
     const std::vector<Conn>& connections() const { return conn; }
+    bool hasLadderConn(const WayPoint* w) const;
 
   private:
     mutable uint32_t useCount=0;


### PR DESCRIPTION
Marvin `G` in vanilla shows that `USEMOB` events are triggered when the waypoint next to ladder is reached. The idea is to precompute ladder points by considering all edges of the waynet that intersect a ladder bounding box. The edge whose midpoint y-value is within a small fixed distance of the bbox's midpoint y-value is taken. The corresponding ladder is referenced in the waypoints of the edge. 
There's one edge which slips through between the bbox's of a double ladder, which is interestingly the only spot where no `USEMOB` event is sent in vanilla. To make it work the bbox's volume used is slightly increased.

Then in `implGoTo` it's checked if the waypoint and successor are ladder points and interaction is forced that case. Because the starting waypoint can be arbitrarily far away from interaction point it was necessary to save ladder in `GoTo` structure. Some small adjustments were made so `aigoto` marvin command works aswell.

Sometimes  e.g. when npc has reached top of ladder they fall down if there's a monster. In case the next waypoint has already been popped from `wayPath` a recalculation is required to make npc use ladder again because y-value isn't considered in pathfinding. There were some waypoints triggering this recalculation because they were sent down by `adjustWaypoints` routine if below the map. I added a check to ignore those.

I shifted the display label to the correct position for tilted ladders by using the formula from `tickMobsi` routine. For consistency I changed it there to look like in `interactive` constructor.

There was also a bug that interaction wasn't correctly ended when `quick` parameter is true in `deattach` routine. I also changed the used  routine for interaction ending in marvin `F8` to make sure `user` is `nullptr` afterwards.

For testing `goto waypoint NC_TAVERN_BACKROOM` and `set time 21 59` or `set time 2 59`. Then a npc should use ladder. There's also marvin `insert` or marvin `O` to watch them walk to their spots.