### PR TITLE
Svm's for G1

### DIFF
--- a/game/game/gamescript.h
+++ b/game/game/gamescript.h
@@ -202,6 +202,8 @@ class GameScript final {
     auto  findInfo    (size_t id) -> phoenix::c_info*;
     auto  findFocus(std::string_view name) -> phoenix::c_focus;
 
+    Npc*  globalOther();
+
     void  storeItem(Item* it);
 
     bool  aiOutput   (Npc &from, std::string_view name, bool overlay);

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -2796,7 +2796,9 @@ gtime Npc::endTime(const Npc::Routine &r) const {
       }
     }
   if(r.start<=time && time<r.end) {
-    return gtime(wtime.day(),r.end.hour(),r.end.minute());
+    if(r.end.hour()==0)
+      return gtime(wtime.day()+1,r.end.hour(),r.end.minute()); else
+      return gtime(wtime.day(),r.end.hour(),r.end.minute());
     }
   // error - routine is not active now
   return wtime;


### PR DESCRIPTION
In G1 output related script functions sometimes have `NULL` as target instead of `other`. This is corrected by assigning `other` in gamescript file in those cases. This is motivated by e.g. a line like this  
`if (Wld_DetectNpc(self,	-1, ZS_Smalltalk, -1) && (Npc_GetDistToNpc	(self, other)<HAI_DIST_SMALLTALK))`
where `other` is assigned and distance checked just to call `B_Say( self, NULL, "$SMALLTALK01");` without a target.

When a daily routine ends at midnight `hours` returned from `endTime` in `tickRoutine` are zero. In that case `day` is incremented by one now as compensation. This should fix the npc's looking at a wall https://github.com/Try/OpenGothic/issues/409. This behavior is caused by the lines	

```
else if (Npc_GetStateTime(self) >= 5)
	{
	    PrintDebugNpc		(PD_TA_CHECK,	"... kein Gesprächspartner gefunden!");
	    
	    AI_StartState	(self, ZS_Stand, 1, "");
	};

```
If no talking partner is found npc just stands. This can be observed in vanilla when talking to an npc. `ZS_Smalltalk` state is left and other talking partner npc turns away. This is generally a problem when smalltalk routine starts and one npc still has to walk to that location, for example `Baal Taran` has to walk to location mentioned in the issue at midnight and conversation fails. In vanilla this is alleviated by offloading npc's out of range and reloading at right location.



