### PR TITLE
`npc_isdead` : return false if npc is null

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1829,7 +1829,7 @@ void GameScript::npc_exchangeroutine(std::shared_ptr<phoenix::c_npc> npcRef, std
 
 bool GameScript::npc_isdead(std::shared_ptr<phoenix::c_npc> npcRef) {
   auto npc = findNpc(npcRef);
-  return npc==nullptr || isDead(*npc);
+  return npc==nullptr ? false : isDead(*npc);
   }
 
 bool GameScript::npc_knowsinfo(std::shared_ptr<phoenix::c_npc> npcRef, int infoinstance) {


### PR DESCRIPTION
In `ZS_Attack.d` there's this line that checks in G1 if plunder animation should be played:

`if (!C_NpcIsBoss(self) && C_NpcIsHuman(other) && (Npc_IsInState(other, ZS_Unconscious) || Npc_IsDead(other) || Npc_IsInState(other, ZS_MagicSleep)) ) `

`other` can be `null` (triggered when running away) and then animation is played if `true` is returned but npc is still up.

G2 has only four occurrences of `Npc_IsDead(other)` and always connected with other script functions so nothing is executed if npc is `null`.