### PR TITLE
Rechargable spells

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -2792,7 +2792,7 @@ void GameScript::ai_readyrangedweapon(std::shared_ptr<phoenix::c_npc> npcRef) {
 
 void GameScript::ai_readyspell(std::shared_ptr<phoenix::c_npc> npcRef, int spell, int mana) {
   auto npc = findNpc(npcRef);
-  if(npc!=nullptr)
+  if(npc!=nullptr && mana>0)
     npc->aiPush(AiQueue::aiReadySpell(spell,mana));
   }
 

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1002,7 +1002,7 @@ void GameScript::invokeItem(Npc *npc, ScriptFn fn) {
   vm.call_function<void>(functionSymbol);
   }
 
-int GameScript::invokeMana(Npc &npc, Npc* target, Item &) {
+int GameScript::invokeMana(Npc &npc, Npc* target, int mana) {
   auto fn = vm.find_symbol_by_name("Spell_ProcessMana");
   if(fn==nullptr)
     return SpellCode::SPL_SENDSTOP;
@@ -1010,7 +1010,18 @@ int GameScript::invokeMana(Npc &npc, Npc* target, Item &) {
   ScopeVar self (*vm.global_self(),  npc.handlePtr());
   ScopeVar other(*vm.global_other(), target != nullptr ? target->handlePtr() : nullptr);
 
-  return vm.call_function<int>(fn, npc.attribute(ATR_MANA));
+  return vm.call_function<int>(fn,mana);
+  }
+
+int GameScript::invokeManaRelease(Npc &npc, Npc* target, int mana) {
+  auto fn = vm.find_symbol_by_name("Spell_ProcessMana_Release");
+  if(fn==nullptr)
+    return SpellCode::SPL_SENDSTOP;
+
+  ScopeVar self (*vm.global_self(),  npc.handlePtr());
+  ScopeVar other(*vm.global_other(), target != nullptr ? target->handlePtr() : nullptr);
+
+  return vm.call_function<int>(fn,mana);
   }
 
 void GameScript::invokeSpell(Npc &npc, Npc* target, Item &it) {

--- a/game/game/gamescript.h
+++ b/game/game/gamescript.h
@@ -130,7 +130,8 @@ class GameScript final {
     void invokeState(const std::shared_ptr<phoenix::c_npc>& hnpc, const std::shared_ptr<phoenix::c_npc>& hother, const char* name);
     int  invokeState(Npc* npc, Npc* other, Npc *victum, ScriptFn fn);
     void invokeItem (Npc* npc, ScriptFn fn);
-    int  invokeMana (Npc& npc, Npc* target, Item&  fn);
+    int  invokeMana (Npc& npc, Npc* target, int mana);
+    int  invokeManaRelease (Npc& npc, Npc* target, int mana);
     void invokeSpell(Npc& npc, Npc *target, Item&  fn);
     int  invokeCond (Npc& npc, std::string_view func);
     void invokePickLock(Npc& npc, int bSuccess, int bBrokenOpen);

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -212,7 +212,7 @@ void PlayerControl::onKeyReleased(KeyCodec::Action a, KeyCodec::Mapping mapping)
 
   auto ws = pl==nullptr ? WeaponState::NoWeapon : pl->weaponState();
   if(ws==WeaponState::Bow || ws==WeaponState::CBow || ws==WeaponState::Mage) {
-    if(a==KeyCodec::ActionGeneric)
+    if(a==KeyCodec::ActionGeneric || (!g2Ctrl && ws==WeaponState::Mage && a==KeyCodec::Forward))
       std::memset(actrl,0,sizeof(actrl));
     } else {
     std::memset(actrl,0,sizeof(actrl));
@@ -674,9 +674,9 @@ void PlayerControl::implMove(uint64_t dt) {
     }
 
   if(casting) {
-    if(!actrl[ActForward]) {
+    if(!actrl[ActForward] || (Gothic::inst().version().game==1 && pl.attribute(ATR_MANA)==0)) {
       casting = false;
-      pl.releaseSpell();
+      pl.endCastSpell(true);
       }
     return;
     }
@@ -758,7 +758,8 @@ void PlayerControl::implMove(uint64_t dt) {
         }
       case WeaponState::Mage: {
         casting = pl.beginCastSpell();
-        actrl[ActForward] = false;
+        if(!casting)
+          actrl[ActForward] = false;
         return;
         }
       }

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -676,7 +676,7 @@ void PlayerControl::implMove(uint64_t dt) {
   if(casting) {
     if(!actrl[ActForward]) {
       casting = false;
-      pl.endCastSpell();
+      pl.endCastSpell(true);
       }
     return;
     }

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -676,7 +676,7 @@ void PlayerControl::implMove(uint64_t dt) {
   if(casting) {
     if(!actrl[ActForward]) {
       casting = false;
-      pl.endCastSpell(true);
+      pl.releaseSpell();
       }
     return;
     }

--- a/game/game/serialize.h
+++ b/game/game/serialize.h
@@ -33,7 +33,7 @@ class SaveGameHeader;
 class Serialize {
   public:
     enum Version : uint16_t {
-      Current = 44
+      Current = 45
       };
     Serialize(Tempest::ODevice& fout);
     Serialize(Tempest::IDevice&  fin);

--- a/game/graphics/mesh/pose.cpp
+++ b/game/graphics/mesh/pose.cpp
@@ -181,7 +181,7 @@ bool Pose::startAnim(const AnimationSolver& solver, const Animation::Sequence *s
         string_frm tansition("T_STAND_2_",sq->shortName);
         tr = solver.solveFrm(tansition);
         }
-      if(tr==nullptr && i.seq->shortName!=nullptr && sq->isIdle()) {
+      if(tr==nullptr && i.seq->shortName!=nullptr) {
         string_frm tansition("T_",i.seq->shortName,"_2_STAND");
         tr = solver.solveFrm(tansition);
         bs = tr ? i.bs : bs;

--- a/game/graphics/mesh/pose.cpp
+++ b/game/graphics/mesh/pose.cpp
@@ -181,7 +181,7 @@ bool Pose::startAnim(const AnimationSolver& solver, const Animation::Sequence *s
         string_frm tansition("T_STAND_2_",sq->shortName);
         tr = solver.solveFrm(tansition);
         }
-      if(tr==nullptr && i.seq->shortName!=nullptr) {
+      if(tr==nullptr && i.seq->shortName!=nullptr && sq->isIdle()) {
         string_frm tansition("T_",i.seq->shortName,"_2_STAND");
         tr = solver.solveFrm(tansition);
         bs = tr ? i.bs : bs;

--- a/game/world/aiqueue.cpp
+++ b/game/world/aiqueue.cpp
@@ -244,10 +244,11 @@ AiQueue::AiAction AiQueue::aiReadyRangeWeapon() {
   return a;
   }
 
-AiQueue::AiAction AiQueue::aiReadySpell(int32_t spell,int32_t /*mana*/) {
+AiQueue::AiAction AiQueue::aiReadySpell(int32_t spell,int32_t mana) {
   AiAction a;
   a.act = AI_DrawSpell;
   a.i0  = spell;
+  a.i1  = mana;
   return a;
   }
 

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -194,7 +194,7 @@ void Npc::save(Serialize &fout, size_t id) {
   if(currentSpellCast<uint32_t(-1))
     fout.write(uint32_t(currentSpellCast)); else
     fout.write(uint32_t(-1));
-  fout.write(uint8_t(castLevel),castNextTime);
+  fout.write(uint8_t(castLevel),castNextTime,manaInvested);
   fout.write(spellInfo);
 
   saveTrState(fout);
@@ -253,6 +253,8 @@ void Npc::load(Serialize &fin, size_t id) {
   currentSpellCast = (currentSpellCastU32==uint32_t(-1) ? size_t(-1) : currentSpellCastU32);
   }
   fin.read(reinterpret_cast<uint8_t&>(castLevel),castNextTime,spellInfo);
+  if(fin.version()>43)
+    fin.read(manaInvested);
   loadTrState(fin);
   loadAiState(fin);
 
@@ -3478,7 +3480,7 @@ bool Npc::tickCast(uint64_t dt) {
     case SpellCode::SPL_NEXTLEVEL: {
       if(castLvl<=15)
         castLevel = CastState(castLevel+1);
-        }
+      }
     case SpellCode::SPL_RECEIVEINVEST:
     case SpellCode::SPL_STATUS_CANINVEST_NO_MANADEC: {
       auto& spl = owner.script().spellDesc(active->spellId());

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -3469,7 +3469,7 @@ bool Npc::tickCast(uint64_t dt) {
   if(owner.version().game==1) {
     changeAttribute(ATR_MANA,-1,false);
     if(attribute(ATR_MANA)==0 && code!=SpellCode::SPL_SENDCAST) {
-      endCastSpell(true);
+      releaseSpell();
       return true;
       }
     }
@@ -3501,18 +3501,21 @@ bool Npc::tickCast(uint64_t dt) {
   return true;
   }
 
-void Npc::endCastSpell(bool abort) {
+void Npc::endCastSpell() {
   int32_t castLvl = int(castLevel)-int(CS_Invest_0);
   if(castLvl<0)
     return;
-  if(abort) {
-    const SpellCode code = SpellCode(owner.script().invokeManaRelease(*this,currentTarget,manaInvested));
-    if(code==SpellCode::SPL_SENDSTOP) {
-      castLevel = CS_Finalize;
-      return;
-      }
-    }
   castLevel = CastState(castLvl+CS_Cast_0);
+  }
+
+void Npc::releaseSpell() {
+  int32_t castLvl = int(castLevel)-int(CS_Invest_0);
+  if(castLvl<0)
+    return;
+  SpellCode code = SpellCode(owner.script().invokeManaRelease(*this,currentTarget,manaInvested));
+  if(code==SpellCode::SPL_SENDCAST)
+    castLevel = CastState(castLvl+CS_Cast_0); else
+    castLevel = CS_Finalize;
   }
 
 void Npc::setActiveSpellInfo(int32_t info) {

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -253,7 +253,7 @@ void Npc::load(Serialize &fin, size_t id) {
   currentSpellCast = (currentSpellCastU32==uint32_t(-1) ? size_t(-1) : currentSpellCastU32);
   }
   fin.read(reinterpret_cast<uint8_t&>(castLevel),castNextTime,spellInfo);
-  if(fin.version()>43)
+  if(fin.version()>44)
     fin.read(manaInvested,aiExpectedInvest);
   loadTrState(fin);
   loadAiState(fin);

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -3484,11 +3484,11 @@ bool Npc::tickCast(uint64_t dt) {
     case SpellCode::SPL_NEXTLEVEL: {
       if(castLvl<=15)
         castLevel = CastState(castLevel+1);
+      visual.setMagicWeaponKey(owner,SpellFxKey::Invest,castLvl+1);
       }
     case SpellCode::SPL_RECEIVEINVEST:
     case SpellCode::SPL_STATUS_CANINVEST_NO_MANADEC: {
       auto& spl = owner.script().spellDesc(active->spellId());
-      visual.setMagicWeaponKey(owner,SpellFxKey::Invest,castLvl+1);
       castNextTime += uint64_t(spl.time_per_mana);
       break;
       }

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -552,6 +552,7 @@ class Npc final {
     // spell cast
     CastState                      castLevel        = CS_NoCast;
     int32_t                        manaInvested     = 0;
+    int32_t                        spellMana        = 1;
     size_t                         currentSpellCast = size_t(-1);
     uint64_t                       castNextTime     = 0;
     int32_t                        spellInfo        = 0;

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -254,7 +254,8 @@ class Npc final {
     bool      swingSwordR();
     bool      blockSword();
     bool      beginCastSpell();
-    void      endCastSpell(bool abort = false);
+    void      endCastSpell();
+    void      releaseSpell();
     void      setActiveSpellInfo(int32_t info);
     int32_t   activeSpellLevel() const;
     bool      castSpell();

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -254,7 +254,7 @@ class Npc final {
     bool      swingSwordR();
     bool      blockSword();
     bool      beginCastSpell();
-    void      endCastSpell();
+    void      endCastSpell(bool abort = false);
     void      setActiveSpellInfo(int32_t info);
     int32_t   activeSpellLevel() const;
     bool      castSpell();
@@ -550,6 +550,7 @@ class Npc final {
 
     // spell cast
     CastState                      castLevel        = CS_NoCast;
+    int32_t                        manaInvested     = 0;
     size_t                         currentSpellCast = size_t(-1);
     uint64_t                       castNextTime     = 0;
     int32_t                        spellInfo        = 0;

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -254,11 +254,9 @@ class Npc final {
     bool      swingSwordR();
     bool      blockSword();
     bool      beginCastSpell();
-    void      endCastSpell();
-    void      releaseSpell();
+    void      endCastSpell(bool playerCtrl = false);
     void      setActiveSpellInfo(int32_t info);
     int32_t   activeSpellLevel() const;
-    bool      castSpell();
     bool      aimBow();
     bool      shootBow(Interactive* focOverride = nullptr);
     bool      hasAmmunition() const;
@@ -552,7 +550,7 @@ class Npc final {
     // spell cast
     CastState                      castLevel        = CS_NoCast;
     int32_t                        manaInvested     = 0;
-    int32_t                        spellMana        = 1;
+    int32_t                        aiExpectedInvest = 1;
     size_t                         currentSpellCast = size_t(-1);
     uint64_t                       castNextTime     = 0;
     int32_t                        spellInfo        = 0;


### PR DESCRIPTION
Most spells in G1 and rechargeable ones in G2 rely on `manaInvested` variable in script. This value is increased by one per iteration of `tickCast()` and passed to the corresponding script functions. The resulting npc mana stat reduction has to be done by engine for G1, G2  case is handled by script. `SPL_RECEIVEINVEST` for G1 and `SPL_STATUS_CANINVEST_NO_MANADEC` for G2  seem to be used as a waiting state if neither a new level is reached nor spell is cast.

If a spell's investing phase is interrupted by player interaction script function `Spell_ProcessMana_Release` is called to decide if spell should be cast or aborted.

In G1`S_MAGRUN` animation has no idle flag. I removed the check to let idle animation correctly play but don't know if this has other effects. There's is other G1 specific stuff like firerain and stormfist have `TARGET_COLLECT_ALL_FALLBACK_NONE` flag, but stormfist does no damage if flag is added to the `isSpellShoot()` check to make firerain effect play.

G1 also has no `Spell_Cast` script routine so only call it in G2 case.


