### PR TITLE
marvin 'toggle desktop'

### DIFF
--- a/game/gothic.h
+++ b/game/gothic.h
@@ -88,6 +88,9 @@ class Gothic final {
     bool         isGodMode() const { return godMode; }
     void         setGodMode(bool g) { godMode = g; }
 
+    void         toggleDesktop() { desktop = !desktop; }
+    bool         isDesktop() { return desktop; }
+
     bool         doHideFocus () const { return hideFocus; }
     bool         doFrate() const { return showFpsCounter; }
     void         setFRate(bool f) { showFpsCounter = f; }
@@ -166,6 +169,7 @@ class Gothic final {
     uint16_t                                pauseSum=0;
     bool                                    isMarvin       = false;
     bool                                    godMode        = false;
+    bool                                    desktop        = false;
     bool                                    showFpsCounter = false;
     bool                                    showTime       = false;
     bool                                    hideFocus      = false;

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -198,16 +198,18 @@ void MainWindow::paintEvent(PaintEvent& event) {
       paintFocus(p,focus,vp);
 
       if(auto pl = Gothic::inst().player()){
-        float hp = float(pl->attribute(ATR_HITPOINTS))/float(pl->attribute(ATR_HITPOINTSMAX));
-        float mp = float(pl->attribute(ATR_MANA))     /float(pl->attribute(ATR_MANAMAX));
-        drawBar(p,barHp,  10,    h()-10, hp, AlignLeft  | AlignBottom);
-        drawBar(p,barMana,w()-10,h()-10, mp, AlignRight | AlignBottom);
-        if(pl->isDive()) {
-          uint32_t gl = pl->guild();
-          auto     v  = float(pl->world().script().guildVal().dive_time[gl]);
-          if(v>0) {
-            auto t = float(pl->diveTime())/1000.f;
-            drawBar(p,barMisc,w()/2,h()-10, (v-t)/(v), AlignHCenter | AlignBottom);
+        if (!Gothic::inst().isDesktop()) {
+          float hp = float(pl->attribute(ATR_HITPOINTS))/float(pl->attribute(ATR_HITPOINTSMAX));
+          float mp = float(pl->attribute(ATR_MANA))     /float(pl->attribute(ATR_MANAMAX));
+          drawBar(p,barHp,  10,    h()-10, hp, AlignLeft  | AlignBottom);
+          drawBar(p,barMana,w()-10,h()-10, mp, AlignRight | AlignBottom);
+          if(pl->isDive()) {
+            uint32_t gl = pl->guild();
+            auto     v  = float(pl->world().script().guildVal().dive_time[gl]);
+            if(v>0) {
+              auto t = float(pl->diveTime())/1000.f;
+              drawBar(p,barMisc,w()/2,h()-10, (v-t)/(v), AlignHCenter | AlignBottom);
+              }
             }
           }
         }
@@ -234,7 +236,7 @@ void MainWindow::paintEvent(PaintEvent& event) {
 
   renderer.dbgDraw(p);
 
-  if(Gothic::inst().doFrate()) {
+  if(Gothic::inst().doFrate() && !Gothic::inst().isDesktop()) {
     char fpsT[64]={};
     std::snprintf(fpsT,sizeof(fpsT),"fps = %.2f",fps.get());
     //string_frm fpsT("fps = ", fps.get(), " ", info);
@@ -244,11 +246,13 @@ void MainWindow::paintEvent(PaintEvent& event) {
     }
 
   if(Gothic::inst().doClock() && world!=nullptr) {
-    auto hour = world->time().hour();
-    auto min  = world->time().minute();
-    auto& fnt = Resources::font();
-    string_frm clockT(int(hour),":",int(min));
-    fnt.drawText(p,w()-fnt.textSize(clockT).w-5,fnt.pixelSize()+5,clockT);
+    if (!Gothic::inst().isDesktop()) {
+      auto hour = world->time().hour();
+      auto min  = world->time().minute();
+      auto& fnt = Resources::font();
+      string_frm clockT(int(hour),":",int(min));
+      fnt.drawText(p,w()-fnt.textSize(clockT).w-5,fnt.pixelSize()+5,clockT);
+      }
     }
   }
 

--- a/game/marvin.cpp
+++ b/game/marvin.cpp
@@ -95,7 +95,7 @@ Marvin::Marvin() {
     {"set time %d %d",             C_SetTime},
     {"spawnmass %d",               C_Invalid},
     {"spawnmass giga %d",          C_Invalid},
-    {"toggle desktop",             C_Invalid},
+    {"toggle desktop",             C_ToggleDesktop},
     {"toggle freepoints",          C_Invalid},
     {"toggle screen",              C_Invalid},
     {"toggle time",                C_ToggleTime},
@@ -326,6 +326,10 @@ bool Marvin::exec(std::string_view v) {
     case C_ToggleInertia: {
       if(auto c = Gothic::inst().camera())
         c->setInertiaTargetEnable(!c->isInertiaTargetEnabled());
+      return true;
+      }
+    case C_ToggleDesktop: {
+      Gothic::inst().toggleDesktop();
       return true;
       }
     case C_Insert: {

--- a/game/marvin.h
+++ b/game/marvin.h
@@ -26,6 +26,8 @@ class Marvin {
       // rendering
       C_ToggleFrame,
       C_ToggleTime,
+      // game
+      C_ToggleDesktop,
       // npc
       C_CheatFull,
       C_CheatGod,


### PR DESCRIPTION
- hides the framerate, clock, HP bar, mana bar, oxygen bar from UI

This is something I've noticed in the screenshots - AFAIK all of them contain the HP bar and mana bar and it turns out the code is nicely prepared to hide them when needed. I'm not sure if it's something that should be available through a shortcut, so I've added a new marvin command instead.