### PR TITLE
parse Game and OutputUnits from mod ini if set

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -60,7 +60,7 @@ bool GameScript::GlobalOutput::isFinished() {
   }
 
 GameScript::GameScript(GameSession &owner)
-  :owner(owner), vm(Gothic::inst().loadPhoenixScriptCode(Gothic::inst().getGameDatName()), phoenix::execution_flag::vm_allow_null_instance_access) {
+  :owner(owner), vm(Gothic::inst().loadPhoenixScriptCode(Gothic::inst().defaultGameDatFile()), phoenix::execution_flag::vm_allow_null_instance_access) {
 
   if (vm.global_self() == nullptr || vm.global_other() == nullptr || vm.global_item() == nullptr ||
       vm.global_victim() == nullptr || vm.global_hero() == nullptr)
@@ -404,15 +404,8 @@ void GameScript::initDialogs() {
 
 void GameScript::loadDialogOU() {
   auto gCutscene = Gothic::inst().nestedPath({u"_work",u"Data",u"Scripts",u"content",u"CUTSCENE"},Dir::FT_Dir);
-  std::string prefix = std::string(Gothic::inst().settingsGetS("FILES","OutputUnits"));
-  std::vector<std::string> names;
-  if (prefix == "") {
-    names.emplace_back("OU.DAT");
-    names.emplace_back("OU.BIN");
-    } else {
-    names.emplace_back(prefix + ".DAT");
-    names.emplace_back(prefix + ".BIN");
-    }
+  std::string prefix = std::string(Gothic::inst().defaultOutputUnits());
+  std::vector<std::string> names = {prefix + ".DAT", prefix + ".BIN"};
 
   for(auto OU:names) {
     if(Resources::hasFile(OU)) {

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -60,7 +60,7 @@ bool GameScript::GlobalOutput::isFinished() {
   }
 
 GameScript::GameScript(GameSession &owner)
-  :owner(owner), vm(Gothic::inst().loadPhoenixScriptCode("GOTHIC.DAT"), phoenix::execution_flag::vm_allow_null_instance_access) {
+  :owner(owner), vm(Gothic::inst().loadPhoenixScriptCode(Gothic::inst().getGameDatName()), phoenix::execution_flag::vm_allow_null_instance_access) {
 
   if (vm.global_self() == nullptr || vm.global_other() == nullptr || vm.global_item() == nullptr ||
       vm.global_victim() == nullptr || vm.global_hero() == nullptr)
@@ -404,10 +404,15 @@ void GameScript::initDialogs() {
 
 void GameScript::loadDialogOU() {
   auto gCutscene = Gothic::inst().nestedPath({u"_work",u"Data",u"Scripts",u"content",u"CUTSCENE"},Dir::FT_Dir);
-  static const char* names[] = {
-    "OU.DAT",
-    "OU.BIN",
-    };
+  std::string prefix = std::string(Gothic::inst().settingsGetS("FILES","OutputUnits"));
+  std::vector<std::string> names;
+  if (prefix == "") {
+    names.emplace_back("OU.DAT");
+    names.emplace_back("OU.BIN");
+    } else {
+    names.emplace_back(prefix + ".DAT");
+    names.emplace_back(prefix + ".BIN");
+    }
 
   for(auto OU:names) {
     if(Resources::hasFile(OU)) {
@@ -429,7 +434,7 @@ void GameScript::loadDialogOU() {
       // loop to next possible path
       }
     }
-  Log::e("unable to load Zen-file: \"OU.DAT\" or \"OU.BIN\"");
+  Log::e("none of Zen-files for OU could be loaded");
   }
 
 void GameScript::initializeInstanceNpc(const std::shared_ptr<phoenix::c_npc>& npc, size_t instance) {

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -150,6 +150,9 @@ Gothic::Gothic() {
   if(plDef.empty())
     plDef = "PC_HERO";
 
+  if(gameDef.empty())
+    gameDef = "GOTHIC.DAT";
+
   onSettingsChanged.bind(this,&Gothic::setupSettings);
   setupSettings();
   }
@@ -575,6 +578,15 @@ std::string_view Gothic::defaultSave() const {
   return CommandLine::inst().defaultSave();
   }
 
+std::string Gothic::getGameDatName() {
+  if (settingsGetS("FILES","Game") != "") {
+    std::string datFile = std::string(settingsGetS("FILES","Game")) + ".DAT";
+    return datFile;
+    } else {
+    return gameDef;
+    }
+  }
+
 std::unique_ptr<phoenix::vm> Gothic::createPhoenixVm(std::string_view datFile) {
   auto byte = loadPhoenixScriptCode(datFile);
   phoenix::register_all_script_classes(byte);
@@ -615,6 +627,8 @@ phoenix::script Gothic::loadPhoenixScriptCode(std::string_view datFile) {
   }
 
 bool Gothic::settingsHasSection(std::string_view sec) {
+  if(instance->modFile != nullptr && instance->modFile->has(sec))
+    return true;
   if(instance->iniFile->has(sec))
     return true;
   if(instance->baseIniFile->has(sec))
@@ -626,6 +640,8 @@ bool Gothic::settingsHasSection(std::string_view sec) {
 int Gothic::settingsGetI(std::string_view sec, std::string_view name) {
   if(name.empty())
     return 0;
+  if(instance->modFile != nullptr && instance->modFile->has(sec,name))
+    return instance->modFile->getI(sec,name);
   if(instance->iniFile->has(sec,name))
     return instance->iniFile->getI(sec,name);
   if(instance->baseIniFile->has(sec,name))
@@ -643,6 +659,8 @@ void Gothic::settingsSetI(std::string_view sec, std::string_view name, int val) 
 std::string_view Gothic::settingsGetS(std::string_view sec, std::string_view name) {
   if(name.empty())
     return "";
+  if(instance->modFile != nullptr && instance->modFile->has(sec,name))
+    return instance->modFile->getS(sec,name);
   if(instance->iniFile->has(sec,name))
     return instance->iniFile->getS(sec,name);
   if(instance->baseIniFile->has(sec,name))
@@ -660,6 +678,8 @@ void Gothic::settingsSetS(std::string_view sec, std::string_view name, std::stri
 float Gothic::settingsGetF(std::string_view sec, std::string_view name) {
   if(name.empty())
     return 0;
+  if(instance->modFile != nullptr && instance->modFile->has(sec,name))
+    return instance->modFile->getF(sec,name);
   if(instance->iniFile->has(sec,name))
     return instance->iniFile->getF(sec,name);
   if(instance->baseIniFile->has(sec,name))

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -155,9 +155,10 @@ Gothic::Gothic() {
   if(gameDatDef.empty())
     gameDatDef = "GOTHIC.DAT";
 
-  if(ouDef.empty())
+  if(ouDef.empty()) {
     // suffixes added later in GameScript::loadDialogOU()
     ouDef = "OU";
+    }
 
   onSettingsChanged.bind(this,&Gothic::setupSettings);
   setupSettings();

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -129,6 +129,8 @@ Gothic::Gothic() {
     if(split!=std::string::npos)
       wrldDef = wrldDef.substr(split+1);
     plDef = modFile->getS("SETTINGS","PLAYER");
+    gameDatDef = std::string(modFile->getS("FILES","GAME")) + ".DAT";
+    ouDef = modFile->getS("FILES","OUTPUTUNITS");
 
     std::u16string vdf = TextCodec::toUtf16(std::string(modFile->getS("FILES","VDF")));
     modFilter = modFile->has("FILES","VDF");
@@ -150,8 +152,12 @@ Gothic::Gothic() {
   if(plDef.empty())
     plDef = "PC_HERO";
 
-  if(gameDef.empty())
-    gameDef = "GOTHIC.DAT";
+  if(gameDatDef.empty())
+    gameDatDef = "GOTHIC.DAT";
+
+  if(ouDef.empty())
+    // suffixes added later in GameScript::loadDialogOU()
+    ouDef = "OU";
 
   onSettingsChanged.bind(this,&Gothic::setupSettings);
   setupSettings();
@@ -578,13 +584,12 @@ std::string_view Gothic::defaultSave() const {
   return CommandLine::inst().defaultSave();
   }
 
-std::string Gothic::getGameDatName() {
-  if (settingsGetS("FILES","Game") != "") {
-    std::string datFile = std::string(settingsGetS("FILES","Game")) + ".DAT";
-    return datFile;
-    } else {
-    return gameDef;
-    }
+std::string_view Gothic::defaultGameDatFile() const {
+  return gameDatDef;
+  }
+
+std::string_view Gothic::defaultOutputUnits() const {
+  return ouDef;
   }
 
 std::unique_ptr<phoenix::vm> Gothic::createPhoenixVm(std::string_view datFile) {
@@ -627,8 +632,6 @@ phoenix::script Gothic::loadPhoenixScriptCode(std::string_view datFile) {
   }
 
 bool Gothic::settingsHasSection(std::string_view sec) {
-  if(instance->modFile != nullptr && instance->modFile->has(sec))
-    return true;
   if(instance->iniFile->has(sec))
     return true;
   if(instance->baseIniFile->has(sec))
@@ -640,8 +643,6 @@ bool Gothic::settingsHasSection(std::string_view sec) {
 int Gothic::settingsGetI(std::string_view sec, std::string_view name) {
   if(name.empty())
     return 0;
-  if(instance->modFile != nullptr && instance->modFile->has(sec,name))
-    return instance->modFile->getI(sec,name);
   if(instance->iniFile->has(sec,name))
     return instance->iniFile->getI(sec,name);
   if(instance->baseIniFile->has(sec,name))
@@ -659,8 +660,6 @@ void Gothic::settingsSetI(std::string_view sec, std::string_view name, int val) 
 std::string_view Gothic::settingsGetS(std::string_view sec, std::string_view name) {
   if(name.empty())
     return "";
-  if(instance->modFile != nullptr && instance->modFile->has(sec,name))
-    return instance->modFile->getS(sec,name);
   if(instance->iniFile->has(sec,name))
     return instance->iniFile->getS(sec,name);
   if(instance->baseIniFile->has(sec,name))
@@ -678,8 +677,6 @@ void Gothic::settingsSetS(std::string_view sec, std::string_view name, std::stri
 float Gothic::settingsGetF(std::string_view sec, std::string_view name) {
   if(name.empty())
     return 0;
-  if(instance->modFile != nullptr && instance->modFile->has(sec,name))
-    return instance->modFile->getF(sec,name);
   if(instance->iniFile->has(sec,name))
     return instance->iniFile->getF(sec,name);
   if(instance->baseIniFile->has(sec,name))

--- a/game/gothic.h
+++ b/game/gothic.h
@@ -48,6 +48,8 @@ class Gothic final {
     std::string_view defaultPlayer() const;
     std::string_view defaultSave()   const;
 
+    std::string  getGameDatName();
+
     void         setGame(std::unique_ptr<GameSession> &&w);
     auto         clearGame() -> std::unique_ptr<GameSession>;
 
@@ -175,7 +177,7 @@ class Gothic final {
     bool                                    showTime       = false;
     bool                                    hideFocus      = false;
     bool                                    isMeshSh       = false;
-    std::string                             wrldDef, plDef;
+    std::string                             wrldDef, plDef, gameDef;
 
     std::unique_ptr<IniFile>                defaults;
     std::unique_ptr<IniFile>                baseIniFile;

--- a/game/gothic.h
+++ b/game/gothic.h
@@ -44,11 +44,11 @@ class Gothic final {
     bool         isInGame() const;
     bool         isInGameAndAlive() const;
 
-    std::string_view defaultWorld()  const;
-    std::string_view defaultPlayer() const;
-    std::string_view defaultSave()   const;
-
-    std::string  getGameDatName();
+    std::string_view defaultWorld()       const;
+    std::string_view defaultPlayer()      const;
+    std::string_view defaultSave()        const;
+    std::string_view defaultGameDatFile() const;
+    std::string_view defaultOutputUnits() const;
 
     void         setGame(std::unique_ptr<GameSession> &&w);
     auto         clearGame() -> std::unique_ptr<GameSession>;
@@ -177,7 +177,7 @@ class Gothic final {
     bool                                    showTime       = false;
     bool                                    hideFocus      = false;
     bool                                    isMeshSh       = false;
-    std::string                             wrldDef, plDef, gameDef;
+    std::string                             wrldDef, plDef, gameDatDef, ouDef;
 
     std::unique_ptr<IniFile>                defaults;
     std::unique_ptr<IniFile>                baseIniFile;


### PR DESCRIPTION
fixes #473

Tested that running with the G2Classic mod in `-game` switches language depending on whether I've chosen the `_EN` or suffix-less values. The standard experience without mods also works. Didn't test with G1 but the related defaults of `GOTHIC.DAT` and `OU.*` are supposed to be the same.