### PR TITLE
Draw weapon if attacking

### DIFF
--- a/game/game/fightalgo.cpp
+++ b/game/game/fightalgo.cpp
@@ -28,9 +28,6 @@ void FightAlgo::fillQueue(Npc &npc, Npc &tg, GameScript& owner) {
   auto& ai = Gothic::fai()[size_t(npc.handle().fight_tactic)];
   auto  ws = npc.weaponState();
 
-  if(ws==WeaponState::NoWeapon)
-    return;
-
   if(hitFlg) {
     hitFlg = false;
     if(fillQueue(owner,ai.my_w_strafe))

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1430,9 +1430,10 @@ bool Npc::implAttack(uint64_t dt) {
 
   auto ws = weaponState();
   // vanilla behavior, required for orcs in G1 orcgraveyard
-  if(ws==WeaponState::NoWeapon)
-    drawWeaponMelee();
-  ws = weaponState();
+  if(ws==WeaponState::NoWeapon) {
+    if(drawWeaponMelee())
+      return true;
+    }
 
   FightAlgo::Action act = fghAlgo.nextFromQueue(*this,*currentTarget,owner.script());
 

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1414,8 +1414,7 @@ bool Npc::implAttack(uint64_t dt) {
     return false;
     }
 
-  auto ws = weaponState();
-  if(ws==WeaponState::NoWeapon)
+  if(!fghAlgo.hasInstructions())
     return false;
 
   if(bodyStateMasked()==BS_STUMBLE) {
@@ -1429,9 +1428,7 @@ bool Npc::implAttack(uint64_t dt) {
     return true;
     }
 
-  if(!fghAlgo.hasInstructions()) {
-    return false;
-    }
+  auto ws = weaponState();
 
   FightAlgo::Action act = fghAlgo.nextFromQueue(*this,*currentTarget,owner.script());
 
@@ -2357,7 +2354,7 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
       break;
       }
     case AI_Attack:
-      if(currentTarget!=nullptr && weaponState()!=WeaponState::NoWeapon){
+      if(currentTarget!=nullptr) {
         if(!fghAlgo.fetchInstructions(*this,*currentTarget,owner.script()))
           queue.pushFront(std::move(act));
         }

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1429,6 +1429,10 @@ bool Npc::implAttack(uint64_t dt) {
     }
 
   auto ws = weaponState();
+  // vanilla behavior, required for orcs in G1 orcgraveyard
+  if(ws==WeaponState::NoWeapon)
+    drawWeaponMelee();
+  ws = weaponState();
 
   FightAlgo::Action act = fghAlgo.nextFromQueue(*this,*currentTarget,owner.script());
 


### PR DESCRIPTION
Edit: As pointed out vanilla engine issues a draw weapon command if npc is in attack mode and no weapon has been drawn. The only npc's relying on this are orcs in G1 orc graveyard because script doesn't take care in that case.

Orcs in G1 orc-graveyard are in `ZS_MM_ATTACK` state when attacking. G2 script has this check for weapon draw:

`if(C_NpcIsMonsterMage(self) || (self.guild == GIL_SKELETON) || (self.guild == GIL_SUMMONED_SKELETON) || (self.guild > GIL_SEPERATOR_ORC))`

G1 script only checks for MonsterMage. Since skeletons have their weapon already drawn only the orc case has to be handled.