### PR TITLE
Some script functions for G1

### DIFF
--- a/game/game/gamescript.h
+++ b/game/game/gamescript.h
@@ -233,6 +233,7 @@ class GameScript final {
     int  wld_getformerplayerportalguild();
     void wld_setguildattitude (int gil1, int att, int gil2);
     int  wld_getguildattitude (int g1, int g0);
+    void wld_exchangeguildattitudes (std::string_view name);
     bool wld_istime           (int hour0, int min0, int hour1, int min1);
     bool wld_isfpavailable    (std::shared_ptr<phoenix::c_npc> self, std::string_view name);
     bool wld_isnextfpavailable(std::shared_ptr<phoenix::c_npc> self, std::string_view name);
@@ -276,6 +277,7 @@ class GameScript final {
     void npc_setrefusetalk   (std::shared_ptr<phoenix::c_npc> npcRef, int timeSec);
     bool npc_refusetalk      (std::shared_ptr<phoenix::c_npc> npcRef);
     int  npc_hasitems        (std::shared_ptr<phoenix::c_npc> npcRef, int itemId);
+    bool npc_hasspell        (std::shared_ptr<phoenix::c_npc> npcRef, int splId);
     int  npc_getinvitem      (std::shared_ptr<phoenix::c_npc> npcRef, int itemId);
     int  npc_removeinvitem   (std::shared_ptr<phoenix::c_npc> npcRef, int itemId);
     int  npc_removeinvitems  (std::shared_ptr<phoenix::c_npc> npcRef, int itemId, int amount);
@@ -316,7 +318,10 @@ class GameScript final {
     int  npc_getportalguild  (std::shared_ptr<phoenix::c_npc> npcRef);
     bool npc_isinplayersroom (std::shared_ptr<phoenix::c_npc> npcRef);
     std::shared_ptr<phoenix::c_item> npc_getreadiedweapon(std::shared_ptr<phoenix::c_npc> npcRef);
+    bool npc_hasreadiedweapon(std::shared_ptr<phoenix::c_npc> npcRef);
     bool npc_hasreadiedmeleeweapon(std::shared_ptr<phoenix::c_npc> npcRef);
+    bool npc_hasreadiedrangedweapon(std::shared_ptr<phoenix::c_npc> npcRef);
+    bool npc_hasrangedweaponwithammo(std::shared_ptr<phoenix::c_npc> npcRef);
     int  npc_isdrawingspell  (std::shared_ptr<phoenix::c_npc> npcRef);
     int  npc_isdrawingweapon (std::shared_ptr<phoenix::c_npc> npcRef);
     void npc_perceiveall     (std::shared_ptr<phoenix::c_npc> npcRef);
@@ -351,6 +356,7 @@ class GameScript final {
     void ai_lookat           (std::shared_ptr<phoenix::c_npc> selfRef, std::string_view waypoint);
     void ai_lookatnpc        (std::shared_ptr<phoenix::c_npc> selfRef, std::shared_ptr<phoenix::c_npc> npcRef);
     void ai_removeweapon     (std::shared_ptr<phoenix::c_npc> npcRef);
+    void ai_unreadyspell     (std::shared_ptr<phoenix::c_npc> npcRef);
     void ai_turntonpc        (std::shared_ptr<phoenix::c_npc> selfRef, std::shared_ptr<phoenix::c_npc> npcRef);
     void ai_outputsvm        (std::shared_ptr<phoenix::c_npc> selfRef, std::shared_ptr<phoenix::c_npc> targetRef, std::string_view name);
     void ai_outputsvm_overlay(std::shared_ptr<phoenix::c_npc> selfRef, std::shared_ptr<phoenix::c_npc> targetRef, std::string_view name);
@@ -448,6 +454,7 @@ class GameScript final {
     float                                                       viewTimePerChar = 0.5;
     int32_t                                                     damCriticalMultiplier = 2;
     mutable std::unordered_map<std::string,uint32_t>            msgTimings;
+    size_t                                                      gilTblSize=0;
     size_t                                                      gilCount=0;
     std::vector<int32_t>                                        gilAttitudes;
     int                                                         aiOutOrderId=0;

--- a/game/game/inventory.cpp
+++ b/game/game/inventory.cpp
@@ -575,6 +575,13 @@ void Inventory::clear(GameScript& vm, Interactive& owner, bool includeMissionItm
   items = std::move(used); // Gothic don't clear items, which are in use
   }
 
+bool Inventory::hasSpell(int32_t splId) const {
+  for(auto& i:items)
+    if(i->spellId()==splId)
+      return true;
+  return false;
+  }
+
 bool Inventory::hasMissionItems() const {
   for(auto& i:items)
     if(i->isMission())
@@ -586,6 +593,20 @@ const Item *Inventory::activeWeapon() const {
   if(active!=nullptr)
     return *active;
   return nullptr;
+  }
+
+bool Inventory::hasRangedWeaponWithAmmo() const {
+  uint32_t munition = 0;
+  for(auto& i:items) {
+    uint32_t cls = uint32_t(i->handle().munition);
+    if(cls>0 && cls!=munition) {
+      for(auto& it:items)
+        if(it->clsId()==cls)
+          return true;
+      munition = cls;
+      }
+    }
+  return false;
   }
 
 Item *Inventory::activeWeapon() {
@@ -639,14 +660,6 @@ void Inventory::switchActiveSpell(int32_t spell, Npc& owner) {
       updateRuneView(owner);
       return;
       }
-  }
-
-Item* Inventory::spellById(int32_t splId) {
-  for(auto& i:items)
-    if(i->spellId()==splId){
-      return i.get();
-      }
-  return nullptr;
   }
 
 uint8_t Inventory::currentSpellSlot() const {

--- a/game/game/inventory.h
+++ b/game/game/inventory.h
@@ -86,7 +86,9 @@ class Inventory final {
     void   unequipArmour(GameScript &vm, Npc &owner);
     void   clear(GameScript &vm, Npc &owner, bool includeMissionItm = false);
     void   clear(GameScript &vm, Interactive &owner, bool includeMissionItm = false);
+    bool   hasSpell(int32_t spl) const;
     bool   hasMissionItems() const;
+    bool   hasRangedWeaponWithAmmo() const;
 
     void   updateArmourView(Npc& owner);
     void   updateSwordView (Npc& owner);
@@ -100,7 +102,6 @@ class Inventory final {
     void   switchActiveWeaponFist();
     void   switchActiveWeapon(Npc &owner, uint8_t slot);
     void   switchActiveSpell (int32_t spell, Npc &owner);
-    Item*  spellById(int32_t splId);
 
     Item*  currentArmour()         { return armour;     }
     Item*  currentMeleeWeapon()    { return melee;      }


### PR DESCRIPTION
`wld_exchangeguildattitudes`
Replaces the guild table. Needed to change guild attitudes after attack of new mine.

`npc_hasspell`
Checks if a spell is present in inventory. Needed to let npc use spells.

`npc_hasreadiedweapon` and  `npc_hasreadiedrangedweapon`
Checks if npc has drawn any weapon/ranged weapon. Used to react if player wields a weapon.

`npc_hasrangedweaponwithammo`
Checks if npc has ranged weapon and corresponding ammo. Needed for npc's to draw ranged weapons.

`ai_unreadyspell`
Opposite of `ai_readyspell`. Puts spell away.

I removed `spellById` because it's not used anywhere and intoduced `hasSpell` instead.



