### PR TITLE
Revert `npc_isdead : return false if npc is null`

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1875,7 +1875,7 @@ void GameScript::npc_exchangeroutine(std::shared_ptr<phoenix::c_npc> npcRef, std
 
 bool GameScript::npc_isdead(std::shared_ptr<phoenix::c_npc> npcRef) {
   auto npc = findNpc(npcRef);
-  return npc==nullptr ? false : isDead(*npc);
+  return npc==nullptr || isDead(*npc);
   }
 
 bool GameScript::npc_knowsinfo(std::shared_ptr<phoenix::c_npc> npcRef, int infoinstance) {


### PR DESCRIPTION
The change was wrong. Testing shows that original engine indeed returns true in that case. I played some mod and two quests couldn't be completed due to this. I also can't reproduce the G1 behavior that was the reason for the change.