### PR TITLE
Fix abnormal weapon damage

### DIFF
--- a/game/game/inventory.cpp
+++ b/game/game/inventory.cpp
@@ -636,6 +636,8 @@ void Inventory::switchActiveWeapon(Npc& owner,uint8_t slot) {
     next=&range;
   if(3<=slot && slot<=10)
     next=&numslot[slot-3];
+  if(next==active)
+    return;
   if(next!=nullptr && *next!=nullptr)
     active=next;
 

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -3262,7 +3262,7 @@ bool Npc::drawWeaponBow() {
   if(!visual.startAnim(*this,st))
     return false;
   invent.switchActiveWeapon(*this,2);
-  hnpc->weapon = (st==WeaponState::W1H ? 5:6);
+  hnpc->weapon = (st==WeaponState::Bow ? 5:6);
   return true;
   }
 


### PR DESCRIPTION
I made additional change that `hnpc->weapon` in `drawWeaponBow` is set depending on weapon state `Bow` instead of `W1H`

fixes https://github.com/Try/OpenGothic/issues/497