### PR TITLE
Correctly end interaction with `set time` command

### DIFF
--- a/game/world/objects/interactive.cpp
+++ b/game/world/objects/interactive.cpp
@@ -330,7 +330,7 @@ void Interactive::implTick(Pos& p) {
       }
     }
 
-  if((state==0 && !attach) || (isLadder() && (attach && state>=stepsCount-1))) {
+  if((state<=0 && !attach) || (isLadder() && (attach && state>=stepsCount-1))) {
     implQuitInteract(p);
     return;
     }


### PR DESCRIPTION
If an npc has an interact out animation `attachMode` is already false but `currentInteract` is not yet null. If `set time` is used interaction can't be ended because `state` is now -1 instead of 0, leading to stuck npc. 
This is fixed by including -1 in the quit check. There's still a delay befor npc is moving again caused by `waitAnim` but good enough for  practical purposes.