### PR TITLE
feat: also provide linux and macos images

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -150,4 +150,7 @@ deploy:
   on:
     branch: $(APPVEYOR_REPO_TAG_NAME)
     appveyor_repo_tag: true       # deploy on tag push only
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 # mingw is default for now
+    APPVEYOR_BUILD_WORKER_IMAGE:
+      - Visual Studio 2019 # mingw is default for now
+      - macos-bigsur
+      - Ubuntu2004


### PR DESCRIPTION
The current AppVeyor configuration doesn't seem to properly upload the mac and linux binaries to the github release.

Compare:
- https://ci.appveyor.com/project/Try/opengothic/builds/47410126/job/pp133xepeuuwvn9k
- https://ci.appveyor.com/project/Try/opengothic/builds/47410126/job/vj4fw25dwmn959k4
to
- https://ci.appveyor.com/project/Try/opengothic/builds/47410126/job/762vl1mg9o1d79by

The [appveyor documentation](https://www.appveyor.com/docs/deployment/github/) doesn't specify if they support a list for the `APPVEYOR_BUILD_WORKER_IMAGE` option, so this change needs to be tested.
