### PR TITLE
feat: deploy in extra job that runs when all builds are finished

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,8 @@ environment:
       job_depends_on: Builds
 
 for:
-  - matrix:
+  -
+    matrix:
     only:
       - job_group: Builds
 
@@ -156,7 +157,8 @@ for:
       - path: build/opengothic/opengothic_osx.zip
         name: archive_osx
   
-  - matrix:
+  -
+    matrix:
       only:
         - job_name: Deploy
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,147 +7,170 @@ environment:
       GENERATOR: "Ninja"
       CC:         C:/msys64/mingw64/bin/gcc.exe
       CXX:        C:/msys64/mingw64/bin/g++.exe
+      job_group: Builds
+      WIN_RELEASE: true
 
     - APPVEYOR_BUILD_WORKER_IMAGE: macos-bigsur
       GENERATOR: "Ninja"
+      job_group: Builds
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Ninja"
       VCVARSALL: "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build/vcvarsall.bat"
       PLATFORM:  x64
+      job_group: Builds
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       GENERATOR: ""
+      job_group: Builds
 
-install:
-- ps: >-
-    $VK_SDK = '1.3.231.1'
+    - job_name: Deploy
+      job_depends_on: Builds
 
-    if($IsLinux) {
-      sudo apt-get update
-      sudo apt-get --yes install libvulkan-dev libasound2-dev libx11-dev libxcursor-dev
-      # Vulkan SDK
-      $env:VULKAN_SDK      = "$env:APPVEYOR_BUILD_FOLDER/VulkanSDK/$VK_SDK/x86_64"
-      $env:VK_LAYER_PATH   = "$env:VULKAN_SDK/etc/vulkan/explicit_layers.d"
-      $env:LD_LIBRARY_PATH = "$env:VULKAN_SDK/lib"
-      Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/$VK_SDK/linux/vulkansdk-linux-x86_64-$VK_SDK.tar.gz -OutFile VulkanSDK.tar.gz
-      mkdir VulkanSDK
-      tar -xzf VulkanSDK.tar.gz -C ./VulkanSDK
-      }
+for:
+  - matrix:
+    only:
+      - job_group: Builds
 
-    if($IsWindows) {
-      # debug
-      # $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+    install:
+    - ps: >-
+        $VK_SDK = '1.3.231.1'
 
-      # Vulkan SDK
-      $env:VULKAN_SDK = "C:/VulkanSDK/$VK_SDK"
-      Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/$VK_SDK/windows/VulkanSDK-$VK_SDK-Installer.exe -OutFile VulkanSDK.exe
-      ./VulkanSDK.exe --accept-licenses --default-answer --confirm-command install
-      }
+        if($IsLinux) {
+          sudo apt-get update
+          sudo apt-get --yes install libvulkan-dev libasound2-dev libx11-dev libxcursor-dev
+          # Vulkan SDK
+          $env:VULKAN_SDK      = "$env:APPVEYOR_BUILD_FOLDER/VulkanSDK/$VK_SDK/x86_64"
+          $env:VK_LAYER_PATH   = "$env:VULKAN_SDK/etc/vulkan/explicit_layers.d"
+          $env:LD_LIBRARY_PATH = "$env:VULKAN_SDK/lib"
+          Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/$VK_SDK/linux/vulkansdk-linux-x86_64-$VK_SDK.tar.gz -OutFile VulkanSDK.tar.gz
+          mkdir VulkanSDK
+          tar -xzf VulkanSDK.tar.gz -C ./VulkanSDK
+          }
 
-    if($IsLinux) {
-      # GLSL compiller
-      mkdir glslang
-      cd glslang
-      Invoke-WebRequest -Uri https://github.com/KhronosGroup/glslang/releases/download/master-tot/glslang-master-linux-Release.zip -OutFile glslang-master.zip
-      7z x glslang-master.zip
-      cd ..
-      $env:PATH += ":$env:APPVEYOR_BUILD_FOLDER/glslang/bin"
-      }
+        if($IsWindows) {
+          # debug
+          # $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
-    if($IsWindows) {
-      mkdir glslang
-      cd glslang
-      Invoke-WebRequest -Uri https://github.com/KhronosGroup/glslang/releases/download/master-tot/glslang-master-windows-x64-Release.zip -OutFile glslang-master.zip
-      7z x glslang-master.zip
-      cd ..
-      $env:PATH += ";$env:APPVEYOR_BUILD_FOLDER\glslang\bin"
-      }
+          # Vulkan SDK
+          $env:VULKAN_SDK = "C:/VulkanSDK/$VK_SDK"
+          Invoke-WebRequest -Uri https://sdk.lunarg.com/sdk/download/$VK_SDK/windows/VulkanSDK-$VK_SDK-Installer.exe -OutFile VulkanSDK.exe
+          ./VulkanSDK.exe --accept-licenses --default-answer --confirm-command install
+          }
 
-    if($IsMacOS) {
-      brew install glslang
-      }
+        if($IsLinux) {
+          # GLSL compiller
+          mkdir glslang
+          cd glslang
+          Invoke-WebRequest -Uri https://github.com/KhronosGroup/glslang/releases/download/master-tot/glslang-master-linux-Release.zip -OutFile glslang-master.zip
+          7z x glslang-master.zip
+          cd ..
+          $env:PATH += ":$env:APPVEYOR_BUILD_FOLDER/glslang/bin"
+          }
 
-before_build:
-- ps: >-
-    git submodule -q update --init --recursive
+        if($IsWindows) {
+          mkdir glslang
+          cd glslang
+          Invoke-WebRequest -Uri https://github.com/KhronosGroup/glslang/releases/download/master-tot/glslang-master-windows-x64-Release.zip -OutFile glslang-master.zip
+          7z x glslang-master.zip
+          cd ..
+          $env:PATH += ";$env:APPVEYOR_BUILD_FOLDER\glslang\bin"
+          }
 
-    mkdir build
+        if($IsMacOS) {
+          brew install glslang
+          }
 
-    if($IsWindows) {
-      $env:PATH += ";C:/msys64/mingw64/bin;C:/Qt/Tools/QtCreator/bin"
-      }
+    before_build:
+    - ps: >-
+        git submodule -q update --init --recursive
 
-    echo '#pragma once'                                                               | Out-File "game/build.h" -Encoding utf8
+        mkdir build
 
-    echo "static const char* appBuild = `"OpenGothic v$env:appveyor_build_version`";" | Out-File "game/build.h" -Encoding utf8 -Append
+        if($IsWindows) {
+          $env:PATH += ";C:/msys64/mingw64/bin;C:/Qt/Tools/QtCreator/bin"
+          }
 
-build_script:
-  - cmake --version
-  - cmd: if NOT "%VCVARSALL%" == "" call "%VCVARSALL%" %PLATFORM%
-  - cmd: cmake -H. -Bbuild -G "%GENERATOR%" -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo -DCMAKE_SH=CMAKE_SH-NOTFOUND
-  - sh:  cmake -H. -Bbuild                  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo
-  - cmake --build ./build --target Gothic2Notr
+        echo '#pragma once'                                                               | Out-File "game/build.h" -Encoding utf8
 
-after_build:
-- ps: >-
-    cd build
+        echo "static const char* appBuild = `"OpenGothic v$env:appveyor_build_version`";" | Out-File "game/build.h" -Encoding utf8 -Append
 
-    cd opengothic
+    build_script:
+      - cmake --version
+      - cmd: if NOT "%VCVARSALL%" == "" call "%VCVARSALL%" %PLATFORM%
+      - cmd: cmake -H. -Bbuild -G "%GENERATOR%" -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo -DCMAKE_SH=CMAKE_SH-NOTFOUND
+      - sh:  cmake -H. -Bbuild                  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo
+      - cmake --build ./build --target Gothic2Notr
 
-    if($IsWindows) {
-      echo gothic-win64-v$env:appveyor_build_version | Out-File "VERSION" -Encoding utf8
-      cp "C:\msys64\mingw64\bin\libgcc_s_seh-1.dll"   "libgcc_s_seh-1.dll"
-      cp "C:\msys64\mingw64\bin\libstdc++-6.dll"      "libstdc++-6.dll"
-      cp "C:\msys64\mingw64\bin\libwinpthread-1.dll"  "libwinpthread-1.dll"
+    after_build:
+    - ps: >-
+        cd build
 
-      $NAME = 'opengothic_win.zip'
-      7z a $NAME    VERSION
-      7z a $NAME -r "*.exe"
-      7z a $NAME -r "*.dll"
-      7z a $NAME -r "*.bat"
-      }
+        cd opengothic
 
-    if($IsLinux) {
-      echo gothic-linux-v$env:appveyor_build_version | Out-File "VERSION" -Encoding utf8
+        if($IsWindows) {
+          echo gothic-win64-v$env:appveyor_build_version | Out-File "VERSION" -Encoding utf8
+          cp "C:\msys64\mingw64\bin\libgcc_s_seh-1.dll"   "libgcc_s_seh-1.dll"
+          cp "C:\msys64\mingw64\bin\libstdc++-6.dll"      "libstdc++-6.dll"
+          cp "C:\msys64\mingw64\bin\libwinpthread-1.dll"  "libwinpthread-1.dll"
 
-      $NAME = 'opengothic_linux.zip'
-      7z a $NAME    VERSION
-      7z a $NAME    "*.so"
-      7z a $NAME    "Gothic2Notr"
-      7z a $NAME    "Gothic2Notr.sh"
-      }
+          if ($WIN_RELEASE) {
+            $NAME = 'opengothic_win.zip'
+            } else {
+            $NAME = 'opengothic_win_vs2022.zip'
+            }
 
-    if($IsMacOS) {
-      echo gothic-osx-v$env:appveyor_build_version | Out-File "VERSION" -Encoding utf8
+          7z a $NAME    VERSION
+          7z a $NAME -r "*.exe"
+          7z a $NAME -r "*.dll"
+          7z a $NAME -r "*.bat"
+          }
 
-      $NAME = 'opengothic_osx.zip'
-      7z a $NAME    VERSION
-      7z a $NAME    "*.dylib"
-      7z a $NAME    "Gothic2Notr"
-      7z a $NAME    "Gothic2Notr.sh"
-      }
+        if($IsLinux) {
+          echo gothic-linux-v$env:appveyor_build_version | Out-File "VERSION" -Encoding utf8
 
-artifacts:
-  - path: build/opengothic/opengothic_win.zip
-    name: archive_win
-  - path: build/opengothic/opengothic_linux.zip
-    name: archive_linux
-  - path: build/opengothic/opengothic_osx.zip
-    name: archive_osx
+          $NAME = 'opengothic_linux.zip'
+          7z a $NAME    VERSION
+          7z a $NAME    "*.so"
+          7z a $NAME    "Gothic2Notr"
+          7z a $NAME    "Gothic2Notr.sh"
+          }
 
-deploy:
-  release: opengothic-v$(appveyor_build_version)
-  description: 'no release description'
-  provider: GitHub
-  auth_token:
-    secure: YLdtUMsAcc8FUr3kgwhQW7nkl5jDpLKbelvzWzzTWUfAiDd92Kd15rjlDJVEEFzo
-  artifact: /archive.*/
-  draft: true
-  force_update: false
-  prerelease: true
-  tag: opengothic-v$(appveyor_build_version)
-  on:
-    branch: $(APPVEYOR_REPO_TAG_NAME)
-    appveyor_repo_tag: true       # deploy on tag push only
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019 # mingw is default for now
+        if($IsMacOS) {
+          echo gothic-osx-v$env:appveyor_build_version | Out-File "VERSION" -Encoding utf8
+
+          $NAME = 'opengothic_osx.zip'
+          7z a $NAME    VERSION
+          7z a $NAME    "*.dylib"
+          7z a $NAME    "Gothic2Notr"
+          7z a $NAME    "Gothic2Notr.sh"
+          }
+
+    artifacts:
+      - path: build/opengothic/opengothic_win_vs2022.zip
+        name: vs2022_win
+      - path: build/opengothic/opengothic_win.zip
+        name: archive_win
+      - path: build/opengothic/opengothic_linux.zip
+        name: archive_linux
+      - path: build/opengothic/opengothic_osx.zip
+        name: archive_osx
+  
+  - matrix:
+      only:
+        - job_name: Deploy
+
+    deploy:
+      release: opengothic-v$(appveyor_build_version)
+      description: 'no release description'
+      provider: GitHub
+      auth_token:
+        secure: YLdtUMsAcc8FUr3kgwhQW7nkl5jDpLKbelvzWzzTWUfAiDd92Kd15rjlDJVEEFzo
+      artifact: /archive.*/
+      draft: true
+      force_update: false
+      prerelease: true
+      tag: opengothic-v$(appveyor_build_version)
+      on:
+        branch: $(APPVEYOR_REPO_TAG_NAME)
+        appveyor_repo_tag: true # deploy on tag push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,8 @@ environment:
 for:
   -
     matrix:
-    only:
-      - job_group: Builds
+      only:
+        - job_group: Builds
 
     install:
     - ps: >-


### PR DESCRIPTION
I read through the [AppVeyor documentation](https://www.appveyor.com/docs), specifically https://www.appveyor.com/docs/job-workflows/, and I think could be a solution how to provide binaries for every platform on release.

I added the Build Jobs to their own group and only let those Jobs run the build scripts. There is a new artifact for the Win VS2022 configuration, so that is doesn't overwrite the VS2019 one.

Only Mac, Linux and VS2019 will be deployed by a new deploy job, which runs after the build jobs terminate (and only on tagged commits like before)