### PR TITLE
CsCamera initial

### DIFF
--- a/game/camera.cpp
+++ b/game/camera.cpp
@@ -182,6 +182,14 @@ bool Camera::isInWater() const {
   return inWater;
   }
 
+bool Camera::hasCsEvent() const {
+  return csEvent;
+  }
+
+void Camera::setCsEvent(bool e) {
+  csEvent = e;
+  }
+
 void Camera::setToggleEnable(bool e) {
   tgEnable = e;
   }
@@ -624,6 +632,11 @@ void Camera::calcControlPoints(float dtF) {
     rotBest      = Vec3();
     //spin.y += def.bestAzimuth;
     }
+  if(hasCsEvent()) {
+    range        = 0;
+    rotOffset    = Vec3();
+    rotOffsetDef = Vec3();
+    }
 
   followAng(src.spin,  dst.spin+rotBest, dtF);
   if(!isMarvin())
@@ -645,7 +658,7 @@ void Camera::calcControlPoints(float dtF) {
   followCamera(cameraPos,src.target,dtF);
 
   origin = cameraPos - dir*range;
-  if(camMarvinMod==M_Free) {
+  if(camMarvinMod==M_Free || hasCsEvent()) {
     return;
     }
 
@@ -827,6 +840,10 @@ PointF Camera::spin() const {
 
 PointF Camera::destSpin() const {
   return PointF(dst.spin.x,dst.spin.y);
+  }
+
+Vec3 Camera::destPosition() const {
+  return dst.target;
   }
 
 Matrix4x4 Camera::viewProj() const {

--- a/game/camera.cpp
+++ b/game/camera.cpp
@@ -182,14 +182,6 @@ bool Camera::isInWater() const {
   return inWater;
   }
 
-bool Camera::hasCsEvent() const {
-  return csEvent;
-  }
-
-void Camera::setCsEvent(bool e) {
-  csEvent = e;
-  }
-
 void Camera::setToggleEnable(bool e) {
   tgEnable = e;
   }
@@ -632,7 +624,8 @@ void Camera::calcControlPoints(float dtF) {
     rotBest      = Vec3();
     //spin.y += def.bestAzimuth;
     }
-  if(hasCsEvent()) {
+  auto world = Gothic::inst().world();
+  if(world!=nullptr && world->currentCs()!=nullptr) {
     range        = 0;
     rotOffset    = Vec3();
     rotOffsetDef = Vec3();
@@ -658,7 +651,7 @@ void Camera::calcControlPoints(float dtF) {
   followCamera(cameraPos,src.target,dtF);
 
   origin = cameraPos - dir*range;
-  if(camMarvinMod==M_Free || hasCsEvent()) {
+  if(camMarvinMod==M_Free || (world!=nullptr && world->currentCs()!=nullptr)) {
     return;
     }
 

--- a/game/camera.h
+++ b/game/camera.h
@@ -68,9 +68,6 @@ class Camera final {
     bool isFree() const;
     bool isInWater() const;
 
-    void setCsEvent(bool e);
-    bool hasCsEvent() const;
-
     void setToggleEnable(bool e);
     bool isToggleEnabled() const;
 
@@ -146,7 +143,6 @@ class Camera final {
     uint32_t              vpWidth=0;
     uint32_t              vpHeight=0;
 
-    bool                  csEvent       = false;
     bool                  dbg           = false;
     bool                  tgEnable      = true;
     bool                  fpEnable      = false;

--- a/game/camera.h
+++ b/game/camera.h
@@ -68,6 +68,9 @@ class Camera final {
     bool isFree() const;
     bool isInWater() const;
 
+    void setCsEvent(bool e);
+    bool hasCsEvent() const;
+
     void setToggleEnable(bool e);
     bool isToggleEnabled() const;
 
@@ -86,6 +89,8 @@ class Camera final {
 
     Tempest::PointF    spin()     const;
     Tempest::PointF    destSpin() const;
+
+    Tempest::Vec3      destPosition() const;
 
     void               setSpin(const Tempest::PointF& p);
     void               setDestSpin(const Tempest::PointF& p);
@@ -141,6 +146,7 @@ class Camera final {
     uint32_t              vpWidth=0;
     uint32_t              vpHeight=0;
 
+    bool                  csEvent       = false;
     bool                  dbg           = false;
     bool                  tgEnable      = true;
     bool                  fpEnable      = false;

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -52,6 +52,9 @@ void PlayerControl::onKeyPressed(KeyCodec::Action a, Tempest::KeyEvent::KeyType 
   auto       ws   = pl ? pl->weaponState() : WeaponState::NoWeapon;
   uint8_t    slot = pl ? pl->inventory().currentSpellSlot() : Item::NSLOT;
 
+  if(c!=nullptr && c->hasCsEvent())
+    return;
+
   handleMovementAction(KeyCodec::ActionMapping{a,mapping}, true);
 
   if(pl!=nullptr && pl->interactive()!=nullptr && c!=nullptr && !c->isFree()) {
@@ -513,6 +516,9 @@ bool PlayerControl::tickMove(uint64_t dt) {
 
   Npc*  pl     = w->player();
   auto  camera = Gothic::inst().camera();
+
+  if(camera!=nullptr && camera->hasCsEvent())
+    return true;
 
   if(camera!=nullptr && (camera->isFree() || pl==nullptr)) {
     rotMouse = 0;

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -52,7 +52,7 @@ void PlayerControl::onKeyPressed(KeyCodec::Action a, Tempest::KeyEvent::KeyType 
   auto       ws   = pl ? pl->weaponState() : WeaponState::NoWeapon;
   uint8_t    slot = pl ? pl->inventory().currentSpellSlot() : Item::NSLOT;
 
-  if(c!=nullptr && c->hasCsEvent())
+  if(w!=nullptr && w->currentCs()!=nullptr)
     return;
 
   handleMovementAction(KeyCodec::ActionMapping{a,mapping}, true);
@@ -517,7 +517,7 @@ bool PlayerControl::tickMove(uint64_t dt) {
   Npc*  pl     = w->player();
   auto  camera = Gothic::inst().camera();
 
-  if(camera!=nullptr && camera->hasCsEvent())
+  if(w->currentCs()!=nullptr)
     return true;
 
   if(camera!=nullptr && (camera->isFree() || pl==nullptr)) {

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -204,8 +204,7 @@ void MainWindow::paintEvent(PaintEvent& event) {
       p.setBrush(Color(1.0));
 
       auto focus = world->validateFocus(player.focus());
-      if(!camera.hasCsEvent())
-        paintFocus(p,focus,vp);
+      paintFocus(p,focus,vp);
 
       if(auto pl = Gothic::inst().player()){
         if (!Gothic::inst().isDesktop()) {
@@ -315,7 +314,8 @@ void MainWindow::processMouse(MouseEvent& event, bool enable) {
   }
 
 void MainWindow::tickMouse() {
-  if(dialogs.hasContent() || Gothic::inst().isPause()) {
+  auto world = Gothic::inst().world();
+  if(dialogs.hasContent() || Gothic::inst().isPause() || (world!=nullptr && world->currentCs()!=nullptr)) {
     dMouse = Point();
     return;
     }
@@ -337,7 +337,8 @@ void MainWindow::tickMouse() {
   if(camLookaroundInverse)
     dpScaled.y *= -1.f;
 
-  if(auto camera = Gothic::inst().camera(); !camera->hasCsEvent())
+  auto camera = Gothic::inst().camera();
+  if(camera!=nullptr)
     camera->onRotateMouse(PointF(dpScaled.y,-dpScaled.x));
   if(!inventory.isActive()) {
     player.onRotateMouse  (-dpScaled.x);
@@ -532,7 +533,7 @@ void MainWindow::paintFocus(Painter& p, const Focus& focus, const Matrix4x4& vp)
 
   auto world = Gothic::inst().world();
   auto pl    = world==nullptr ? nullptr : world->player();
-  if(pl==nullptr)
+  if(pl==nullptr || world->currentCs()!=nullptr)
     return;
 
   auto pos = focus.displayPosition();
@@ -852,9 +853,10 @@ void MainWindow::updateAnimation(uint64_t dt) {
   }
 
 void MainWindow::tickCamera(uint64_t dt) {
+  auto world   = Gothic::inst().world();
   auto pcamera = Gothic::inst().camera();
   auto pl      = Gothic::inst().player();
-  if(pcamera==nullptr || pl==nullptr)
+  if(world==nullptr || pcamera==nullptr || pl==nullptr)
     return;
 
   auto&      camera       = *pcamera;
@@ -864,7 +866,7 @@ void MainWindow::tickCamera(uint64_t dt) {
                              ws==WeaponState::W2H);
   auto       pos          = pl->cameraBone(camera.isFirstPerson());
 
-  if(!camera.hasCsEvent()) {
+  if(world->currentCs()==nullptr) {
     const bool fs = SystemApi::isFullscreen(hwnd());
     if(!fs && mouseP[Event::ButtonLeft]) {
       camera.setSpin(camera.destSpin());
@@ -895,7 +897,7 @@ void MainWindow::tickCamera(uint64_t dt) {
 
   if(dt==0)
     return;
-  if(camera.isToggleEnabled() && !camera.hasCsEvent())
+  if(camera.isToggleEnabled() && world->currentCs()==nullptr)
     camera.setMode(solveCameraMode());
   camera.tick(dt);
   }
@@ -980,7 +982,7 @@ void MainWindow::saveGame(std::string_view slot, std::string_view name) {
 
   if(dialogs.isActive())
     return;
-  if(auto c = Gothic::inst().camera(); c!=nullptr && c->hasCsEvent())
+  if(auto w = Gothic::inst().world(); w!=nullptr && w->currentCs()!=nullptr)
     return;
 
   Gothic::inst().startSave(std::move(textureCast(tex)),[slot=std::string(slot),name=std::string(name),pm](std::unique_ptr<GameSession>&& game){

--- a/game/marvin.cpp
+++ b/game/marvin.cpp
@@ -7,6 +7,7 @@
 
 #include "utils/string_frm.h"
 #include "world/objects/npc.h"
+#include "world/triggers/abstracttrigger.h"
 #include "camera.h"
 #include "gothic.h"
 
@@ -125,6 +126,7 @@ Marvin::Marvin() {
     {"toggle camdebug",            C_ToggleCamDebug},
     {"toggle camera",              C_ToggleCamera},
     {"toggle inertiatarget",       C_ToggleInertia},
+    {"ztoggle timedemo",           C_ZToggleTimeDemo},
     {"insert %c",                  C_Insert},
 
     {"toggle gi",                  C_ToggleGI},
@@ -328,6 +330,14 @@ bool Marvin::exec(std::string_view v) {
     case C_ToggleInertia: {
       if(auto c = Gothic::inst().camera())
         c->setInertiaTargetEnable(!c->isInertiaTargetEnabled());
+      return true;
+      }
+    case C_ZToggleTimeDemo: {
+      World* world = Gothic::inst().world();
+      if(world==nullptr)
+        return false;
+      const TriggerEvent evt("TIMEDEMO","",world->tickCount(),TriggerEvent::T_Trigger);
+      world->triggerEvent(evt);
       return true;
       }
     case C_ToggleDesktop: {

--- a/game/marvin.h
+++ b/game/marvin.h
@@ -38,6 +38,7 @@ class Marvin {
       C_ToggleCamDebug,
       C_ToggleCamera,
       C_ToggleInertia,
+      C_ZToggleTimeDemo,
 
       C_AiGoTo,
       C_GoToPos,

--- a/game/world/triggers/cscamera.cpp
+++ b/game/world/triggers/cscamera.cpp
@@ -1,13 +1,307 @@
 #include "cscamera.h"
 
-#include <Tempest/Log>
+#include "gothic.h"
 
 using namespace Tempest;
 
 CsCamera::CsCamera(Vob* parent, World& world, const phoenix::vobs::cs_camera& cam, Flags flags)
   :AbstractTrigger(parent,world,cam,flags) {
+
+  if(cam.position_count<1 || cam.total_duration<0)
+    return;
+
+  if(cam.trajectory_for==phoenix::camera_trajectory::object || cam.target_trajectory_for==phoenix::camera_trajectory::object)
+    return;
+
+  duration = cam.total_duration;
+  delay    = cam.auto_untrigger_last_delay;
+
+  for(uint32_t i=0;i<cam.frames.size();++i) {
+    auto&    f   = cam.frames[i];
+    KeyFrame kF;
+    kF.c[3]  = Vec3(f->original_pose[3][0],f->original_pose[3][1],f->original_pose[3][2]);
+    kF.time  = f->time;
+    if(i<uint32_t(cam.position_count))
+      posSpline.keyframe.push_back(std::move(kF)); else
+      targetSpline.keyframe.push_back(std::move(kF));
+    }
+
+  init(cam);
   }
 
 void CsCamera::onTrigger(const TriggerEvent& evt) {
-  Log::d("TODO: cs-camera, \"", name() , "\"");
+  if(active || posSpline.size()==0)
+    return;
+  active = true;
+  time   = 0;
+  for(auto spl : {&posSpline,&targetSpline}) {
+    spl->t    = 0;
+    spl->dist = 0;
+    }
+  if(auto camera = Gothic::inst().camera();activeEvents==0) {
+    camera->reset();
+    camera->setCsEvent(true);
+    camera->setMode(Camera::Mode::Normal);
+    godMode = Gothic::inst().isGodMode();
+    Gothic::inst().setGodMode(true);
+    }
+  activeEvents++;
+  enableTicks();
+  }
+
+void CsCamera::onUntrigger(const TriggerEvent& evt) {
+  clear();
+  }
+
+void CsCamera::clear() {
+  if(!active)
+    return;
+  active = false;
+  activeEvents--;
+  disableTicks();
+  if(auto camera = Gothic::inst().camera();activeEvents==0) {
+    camera->setCsEvent(false);
+    camera->reset();
+    Gothic::inst().setGodMode(godMode);
+    }
+  }
+
+void CsCamera::tick(uint64_t dt) {
+  time += float(dt)/1000.f;
+
+  if(time>duration+delay) {
+    clear();
+    return;
+    }
+
+  if(time>duration)
+    return;
+
+  Vec3 cPos,cSpin;
+  if(posSpline.size()==1)
+    cPos = posSpline[0].c[3];
+  else if(posSpline.size()>1)
+    cPos = position(posSpline);
+
+  auto camera = Gothic::inst().camera();
+  if(targetSpline.size()==0)
+    cSpin = cPos - camera->destPosition();
+  else if(targetSpline.size()==1)
+    cSpin = targetSpline[0].c[3] - cPos;
+  else if(targetSpline.size()>1)
+    cSpin = position(targetSpline) - cPos;
+
+  camera->setPosition(cPos);
+  camera->setSpin(spin(cSpin));
+  }
+
+void CsCamera::init(const phoenix::vobs::cs_camera& cam) {
+  for(auto spl : {&posSpline,&targetSpline}) {
+    uint32_t size = spl->size();
+    float    len  = 0;
+    for(uint32_t i=0;i+1<size;++i) {
+      uint32_t k = i;
+      if(spl==&targetSpline)
+        k += uint32_t(cam.position_count);
+      auto& f   = cam.frames[k];
+      auto& kF  = spl->keyframe[i];
+      float a1  = (1+f->cam_bias) * (1-f->tension) * (1+f->continuity) * 0.5f;
+      float a2  = (1-f->cam_bias) * (1-f->tension) * (1-f->continuity) * 0.5f;
+      float a3  = (1+f->cam_bias) * (1-f->tension) * (1-f->continuity) * 0.5f;
+      float a4  = (1-f->cam_bias) * (1-f->tension) * (1+f->continuity) * 0.5f;
+      Vec3  p0  = i==0 ? kF.c[3] : spl->keyframe[i-1].c[3];
+      Vec3  p1  = kF.c[3];
+      Vec3  p2  = spl->keyframe[i+1].c[3];
+      Vec3  p3  = i+2==size ? kF.c[3] : spl->keyframe[i+2].c[3];
+      Vec3  dd  = (p1-p0)*a1 + (p2-p1)*a2;
+      Vec3  sd  = (p2-p1)*a3 + (p3-p2)*a4;
+      kF.c[0] =  2 * p1 - 2*p2 +   dd + sd;
+      kF.c[1] = -3 * p1 + 3*p2 - 2*dd - sd;
+      kF.c[2] = std::move(dd);
+      len    += kF.arcLength();
+      }
+
+    if(size<2)
+      continue;
+    assert(spl->keyframe.front().time==0);
+    assert(spl->keyframe.back().time==duration);
+    const float    vSlow  = 0;
+    const float    vMean  = len/duration;
+          uint32_t start  = spl==&posSpline ? 0 : uint32_t(cam.position_count);
+          uint32_t end    = spl==&posSpline ? uint32_t(cam.position_count-1) : uint32_t(cam.frames.size()-1);
+          auto     mType0 = cam.frames[start]->motion_type;
+          auto     mType1 = cam.frames[end]->motion_type;
+          float    d0     = mType0==phoenix::camera_motion::slow ? vSlow : vMean * duration;
+          float    d1     = mType1==phoenix::camera_motion::slow ? vSlow : vMean * duration;
+
+    spl->c[0] = - 2*len +     d0 + d1;
+    spl->c[1] = + 3*len - 2*d0 - d1;
+    spl->c[2] = d0;
+    }
+  }
+
+ float CsCamera::KeyFrame::arcLength(float t0,float t1) {
+  // based on https://www.gnu.org/software/gsl/doc/html/integration.html#qag-adaptive-integration
+  auto qGK = [this](float t0, float t1,float& area, float& error) {
+    auto f = [this](float t) {
+    Vec3 b = c[0]*t*t*3.f + c[1]*t*2.f + c[2];
+    return b.length();
+    };
+
+    static const float x[7] = {
+      0.991455371120812639206854697526329f,
+      0.949107912342758524526189684047851f,
+      0.864864423359769072789712788640926f,
+      0.741531185599394439863864773280788f,
+      0.586087235467691130294144838258730f,
+      0.405845151377397166906606412076961f,
+      0.207784955007898467600689403773245f
+      };
+    static const float wg[4] = {
+      0.129484966168869693270611432679082f,
+      0.279705391489276667901467771423780f,
+      0.381830050505118944950369775488975f,
+      0.417959183673469387755102040816327f
+      };
+    static const float wgk[8] = {
+      0.022935322010529224963732008058970f,
+      0.063092092629978553290700663189204f,
+      0.104790010322250183839876322541518f,
+      0.140653259715525918745189590510238f,
+      0.169004726639267902826583426598550f,
+      0.190350578064785409913256402421014f,
+      0.204432940075298892414161999234649f,
+      0.209482141084727828012999174891714f
+      };
+
+    float mid     = 0.5f * (t0+t1);
+    float len     = 0.5f * (t1-t0);
+    float fMid    = f(mid);
+    float gauss   = fMid * wg[3];
+    float kronrod = fMid * wgk[7];
+    for(int i=0;i<3;i++) {
+      int   k    = 2*i + 1;
+      float xTr  = len * x[k];
+      float fSum = f(mid+xTr) + f(mid-xTr);
+      gauss   += wg[i]  * fSum;
+      kronrod += wgk[k] * fSum;
+      }
+    for(int k=0;k<8;k+=2) {
+      float xTr = len * x[k];
+      kronrod += wgk[k] * (f(mid+xTr) + f(mid-xTr));
+      };
+
+    area  = kronrod * len;
+    error = std::abs(kronrod-gauss) * len;
+    };
+
+  const float              tol   = 1e-6f;
+        float              area  = 0,  errsum = 0;
+        std::vector<float> alist = {t0}, blist  = {t1}, rlist, elist;
+        uint32_t           imax  = 0;
+        uint32_t           n     = 0;
+
+  qGK(t0,t1,area,errsum);
+  if((errsum<=tol) || errsum == 0)
+    return area;
+  rlist.push_back(area);
+  elist.push_back(errsum);
+
+  for(;;) {
+    float area1  = 0, area2  = 0;
+    float error1 = 0, error2 = 0, error12 = 0;
+    float e  = elist[imax];
+    float tMid;
+
+    n++;
+    t0   = alist[imax];
+    t1   = blist[imax];
+    tMid = 0.5f * (t0+t1);
+    qGK(t0,tMid,area1,error1);
+    qGK(tMid,t1,area2,error2);
+    error12   = error1 + error2;
+    errsum   += (error12-e);
+    if(errsum<=tol || (error12>=e && n>10))
+      break;
+    if(error2>error1) {
+      alist[imax] = tMid;
+      rlist[imax] = area2;
+      elist[imax] = error2;
+      alist.push_back(t0);
+      blist.push_back(tMid);
+      rlist.push_back(area1);
+      elist.push_back(error1);
+      } else {
+      blist[imax] = tMid;
+      rlist[imax] = area1;
+      elist[imax] = error1;
+      alist.push_back(tMid);
+      blist.push_back(t1);
+      rlist.push_back(area2);
+      elist.push_back(error2);
+      }
+    for(uint32_t j=0;j<elist.size();++j)
+      if(elist[j]>elist[imax])
+        imax = j;
+    }
+
+  area = 0.f;
+  for(float r:rlist)
+    area += r;
+  return area;
+  }
+
+Tempest::Vec3 CsCamera::position(CamSpline& spl) {
+  float n, lB, uB, tNew;
+  float t                = std::modf(spl.t,&n);
+  auto  s                = &spl[uint32_t(n)];
+  float d                = spl.nextDist(time/duration);
+
+  const float step = 0.005f;
+  uB = t + step;
+  while(d>s->arcLength(t,uB))
+    uB += step;
+  lB   = uB - step;
+  tNew = 0.5f * (lB+uB);
+
+  for(;;) {
+    if(lB>=1) {
+      d      -= s->arcLength(t,1);
+      spl.t   = std::ceil(spl.t);
+      n       = spl.t;
+      s       = &spl[uint32_t(n)];
+      uB      = step;
+      t       = 0;
+      assert(uint32_t(n)+1<spl.size());
+      while(d>s->arcLength(t,uB))
+        uB += step;
+      lB   = uB - step;
+      tNew = 0.5f * (lB+uB);
+      }
+    if(tNew==lB || tNew==uB)
+      break;
+    if(s->arcLength(t,tNew)>d)
+      uB = tNew; else
+      lB = tNew;
+    tNew = 0.5f * (lB+uB);
+    }
+  // use lB instead of tNew to prevent overshoot
+  spl.t = n + lB;
+  return s->c[0]*lB*lB*lB + s->c[1]*lB*lB + s->c[2]*lB + s->c[3];
+  }
+
+PointF CsCamera::spin(const Tempest::Vec3& d) {
+  float k     = 180.f/float(M_PI);
+  float spinX = k * std::asin(d.y/d.length());
+  float spinY = -90;
+  if(d.x!=0.f || d.z!=0.f)
+    spinY = 90 + k * std::atan2(d.z,d.x);
+  return {-spinX,spinY};
+  }
+
+float CsCamera::CamSpline::nextDist(float t) {
+  float d = dist;
+  dist = c[0]*t*t*t + c[1]*t*t + c[2]*t;
+  assert(dist>d);
+  return dist - d;
   }

--- a/game/world/triggers/cscamera.h
+++ b/game/world/triggers/cscamera.h
@@ -9,8 +9,40 @@ class CsCamera : public AbstractTrigger {
   public:
     CsCamera(Vob* parent, World& world, const phoenix::vobs::cs_camera& data, Flags flags);
 
-    void onTrigger(const TriggerEvent& evt) override;
-
   private:
+    struct KeyFrame {
+      float         time  = 0;
+      Tempest::Vec3 c[4]  = {};
+      float arcLength(float t0 = 0, float t1 = 1);
+      };
 
+    struct CamSpline {
+      float                 t;
+      float                 dist;
+      float                 c[3]     = {};
+      std::vector<KeyFrame> keyframe = {};
+      uint32_t size() { return uint32_t(keyframe.size()); }
+      float    nextDist(float t);
+      KeyFrame& operator [](const size_t n) { return keyframe[n]; }
+      };
+
+    void onTrigger(const TriggerEvent& evt) override;
+    void onUntrigger(const TriggerEvent& evt) override;
+    void tick(uint64_t dt) override;
+
+    void init(const phoenix::vobs::cs_camera& cam);
+    void clear();
+
+    auto position(CamSpline& cs) -> Tempest::Vec3;
+    auto spin(const Tempest::Vec3& d) -> Tempest::PointF;
+
+    static inline uint8_t   activeEvents;
+                  bool      active       = false;
+                  bool      godMode;
+
+                  float     duration;
+                  float     delay;
+                  float     time;
+                  CamSpline posSpline    = {};
+                  CamSpline targetSpline = {};
   };

--- a/game/world/triggers/cscamera.h
+++ b/game/world/triggers/cscamera.h
@@ -11,38 +11,34 @@ class CsCamera : public AbstractTrigger {
 
   private:
     struct KeyFrame {
-      float         time  = 0;
-      Tempest::Vec3 c[4]  = {};
-      float arcLength(float t0 = 0, float t1 = 1);
+      float         time = 0;
+      Tempest::Vec3 c[4] = {};
       };
 
-    struct CamSpline {
-      float                 t;
-      float                 dist;
+    struct KbSpline {
       float                 c[3]     = {};
-      std::vector<KeyFrame> keyframe = {};
-      uint32_t size() { return uint32_t(keyframe.size()); }
-      float    nextDist(float t);
-      KeyFrame& operator [](const size_t n) { return keyframe[n]; }
+      float                 splTime  = 0;
+      std::vector<KeyFrame> keyframe;
+      size_t size() const { return keyframe.size(); }
+      auto   position() const -> Tempest::Vec3;
+      void   setSplTime(float t);
+      float  applyMotionScaling(float t) const;
       };
 
     void onTrigger(const TriggerEvent& evt) override;
     void onUntrigger(const TriggerEvent& evt) override;
     void tick(uint64_t dt) override;
 
-    void init(const phoenix::vobs::cs_camera& cam);
     void clear();
 
-    auto position(CamSpline& cs) -> Tempest::Vec3;
-    auto spin(const Tempest::Vec3& d) -> Tempest::PointF;
+    auto position() -> Tempest::Vec3;
+    auto spin(Tempest::Vec3& d) -> Tempest::PointF;
 
-    static inline uint8_t   activeEvents;
-                  bool      active       = false;
-                  bool      godMode;
-
-                  float     duration;
-                  float     delay;
-                  float     time;
-                  CamSpline posSpline    = {};
-                  CamSpline targetSpline = {};
+    bool     active       = false;
+    bool     godMode;
+    float    duration;
+    float    delay;
+    float    time;
+    KbSpline posSpline    = {};
+    KbSpline targetSpline = {};
   };

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -507,6 +507,14 @@ void World::disableTicks(AbstractTrigger& t) {
   wobj.disableTicks(t);
   }
 
+void World::setCurrentCs(CsCamera* cs) {
+  wobj.setCurrentCs(cs);
+  }
+
+CsCamera* World::currentCs() const {
+  return wobj.currentCs();
+  }
+
 void World::enableCollizionZone(CollisionZone& z) {
   wobj.enableCollizionZone(z);
   }

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -124,6 +124,8 @@ class World final {
     void                 execTriggerEvent(const TriggerEvent& e);
     void                 enableTicks (AbstractTrigger& t);
     void                 disableTicks(AbstractTrigger& t);
+    void                 setCurrentCs(CsCamera* cs);
+    CsCamera*            currentCs() const;
     void                 enableCollizionZone (CollisionZone& z);
     void                 disableCollizionZone(CollisionZone& z);
 

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -161,7 +161,8 @@ void WorldObjects::tick(uint64_t dt, uint64_t dtPlayer) {
       });
     }
 
-  const bool freeCam = (Gothic::inst().camera()!=nullptr && Gothic::inst().camera()->isFree());
+  auto       camera  = Gothic::inst().camera();
+  const bool freeCam = (camera!=nullptr && (camera->isFree() || camera->hasCsEvent()));
   const auto pl      = owner.player();
   for(size_t i=0; i<npcArr.size(); ++i) {
     auto& npc = *npcArr[i];

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -162,7 +162,7 @@ void WorldObjects::tick(uint64_t dt, uint64_t dtPlayer) {
     }
 
   auto       camera  = Gothic::inst().camera();
-  const bool freeCam = (camera!=nullptr && (camera->isFree() || camera->hasCsEvent()));
+  const bool freeCam = (camera!=nullptr && (camera->isFree() || currentCs()!=nullptr));
   const auto pl      = owner.player();
   for(size_t i=0; i<npcArr.size(); ++i) {
     auto& npc = *npcArr[i];
@@ -525,6 +525,14 @@ void WorldObjects::disableTicks(AbstractTrigger& t) {
       triggersTk.pop_back();
       return;
       }
+  }
+
+void WorldObjects::setCurrentCs(CsCamera* cs) {
+  currentCsCamera = cs;
+  }
+
+CsCamera* WorldObjects::currentCs() const {
+  return currentCsCamera;
   }
 
 void WorldObjects::enableCollizionZone(CollisionZone& z) {

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -20,6 +20,7 @@ class World;
 class Serialize;
 class TriggerEvent;
 class AbstractTrigger;
+class CsCamera;
 class CollisionZone;
 
 class WorldObjects final {
@@ -83,6 +84,8 @@ class WorldObjects final {
     bool           execTriggerEvent(const TriggerEvent& e);
     void           enableTicks (AbstractTrigger& t);
     void           disableTicks(AbstractTrigger& t);
+    void           setCurrentCs(CsCamera* cs);
+    CsCamera*      currentCs() const;
     void           enableCollizionZone (CollisionZone& z);
     void           disableCollizionZone(CollisionZone& z);
 
@@ -169,6 +172,7 @@ class WorldObjects final {
     std::vector<AbstractTrigger*>      triggersTk;
     std::vector<PerceptionMsg>         sndPerc;
     std::vector<TriggerEvent>          triggerEvents;
+    CsCamera*                          currentCsCamera = nullptr;
 
     template<class T>
     auto findObj(T &src, const Npc &pl, const SearchOpt& opt) -> typename std::remove_reference<decltype(src[0])>::type;


### PR DESCRIPTION
Camera position and target point the camera is looking at move on a trajectory which is represented by a spline. According to some doc in G1 modkit they're of Kochanek-Bartels type. The movement speed along those curves is defined by the attribute `motion_type` which itself is set for every point that is used to construct the splines. Those points together with other attributes that define the camera trajectory are called Keyframes.

Based on the  `motion_type` of all points a speed curve is constructed. I used a hermite spline which is fully defined by the speed and the distance traveled at each point (see below for a comparison between vanilla and OG).  I only considered type `slow` for start and end point because other types/points aren't used in Gothic (except default `smooth`)  and behavior in testing was partially buggy e.g. `fast` behaved like `step`. Other types can be added later in case there's some scene that uses those. 

For the position spline every frame we start with a parameter argument `t` which reflects the current position. The speed curve delivers a distance to move which results from the next frame time. Then a binary search is used to get the new argument `tNew` which matches the right distance. The length of the spline between these two points is computed numerically. In the end position is updated and applied to camera position. Spline for the target position is handled in the same way and used to compute camera spin.

I tested the produced values against a library implementation to confirm the spline is correctly implemented. But there's still some derivation to the vanilla spline.

A camera Event can be ended by time or by trigger. According to doc `duration `should be zero in those case but actually it's not. This made it necessary to use a variable to track the activity state of each event. Test case was the lever room for the gates in Irdorath at the switch riddle location. There's also a bug that lower and upper gate camera sequence are played at the same time, so a counter for total active events has been introduced.

For a quick test there's marvin command `ztoggle timedemo` available for a trip around Khorinis City.  If someone has a scene that doesn't work or has wrong behavior feel free to share so I can look into it.

<details>
<summary>Some comparisons between OpenGothic and vanilla for timedemo behavior:</summary>

 Start and endpoint have type `slow`, others `smooth`
- Blue is the measured speed for vanilla camera.
- Orange is an average of erratic blue curve.
- Green is OpenGothic spline.
- Red is measured OpenGothic speed, vertical lines are logging artifacts.

Green curve is covered by red one.

![normal](https://github.com/Try/OpenGothic/assets/100468436/e834c236-9ef3-4f21-8a30-5193a2e6fdf6)

Approximation is ok. Noticeable is  the drop of the orange curve shortly before 25s. This was visible in all tests. Unclear what's happening there.

Zoomed in:
![normal_zoomed](https://github.com/Try/OpenGothic/assets/100468436/6b9b426b-6472-4886-bf07-bae3ee6cb0f7)

Image is from an older implementation but current shouldn't look different.

----
Now all points `smooth`. OpoenGothic spline would  assume average speed, a horizontal line at `2000`.
![all_smooth](https://github.com/Try/OpenGothic/assets/100468436/00cf2c8d-5e76-43c4-83f4-cae4d5d38eac)
Sometimes straight line, sometimes sine like.

---
Start `slow`, others `smooth`
![slow_smooth](https://github.com/Try/OpenGothic/assets/100468436/a4ba87c8-00e7-4318-b591-c7314c48c6b4)
Here it looks like it should be a straight line with increasing speed from left to right.

---
Now mirrored. End `slow`, others `smooth`
![smooth_slow_correct](https://github.com/Try/OpenGothic/assets/100468436/aa0c1489-414c-4a7f-9a4d-63911ad13d21)

~~Looks identical to all `smooth` instead of mirrored to the previous image. I will retest this to make sure it isn't a copy paste issue.~~
Edit: new image, looks reasonable now. Speed at start seems to be doubled average. Resembles a straight decreasing line but pretty erratic micro movements. The oscillations were clearly noticeable ingame. My chosen approach seems to be wrong though.
</details>






