### PR TITLE
Update ZenKit (previously "phoenix")

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,5 +9,5 @@
 	url = https://github.com/schellingb/TinySoundFont.git
 [submodule "lib/phoenix"]
 	path = lib/phoenix
-	url = https://github.com/GothicKit/phoenix.git
+	url = https://github.com/GothicKit/ZenKit.git
 	branch = main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,11 +94,11 @@ endif()
 
 # phoenix
 set(BUILD_SQUISH_WITH_SSE2     OFF CACHE INTERNAL "")
-set(PHOENIX_DISABLE_SANITIZERS ON  CACHE INTERNAL "")
-set(PHOENIX_LOG_LEVEL "3")
+set(ZK_ENABLE_ASAN             OFF CACHE INTERNAL "")
+set(ZK_ENABLE_DEPRECATION      OFF CACHE INTERNAL "")
 
 add_subdirectory(lib/phoenix)
-target_link_libraries(${PROJECT_NAME} phoenix)
+target_link_libraries(${PROJECT_NAME} zenkit)
 
 # TinySoundFont
 add_definitions(-DTSF_NO_STDIO)

--- a/game/game/compatibility/ikarus.cpp
+++ b/game/game/compatibility/ikarus.cpp
@@ -34,7 +34,7 @@ void Ikarus::memory_instance::set_int(const phoenix::symbol &sym, uint16_t index
   owner.allocator.writeInt(addr, value);
   }
 
-int32_t Ikarus::memory_instance::get_int(const phoenix::symbol& sym, uint16_t index) {
+int32_t Ikarus::memory_instance::get_int(const phoenix::symbol& sym, uint16_t index) const {
   ptr32_t addr = address + ptr32_t(sym.offset_as_member()) + ptr32_t(index * sym.class_size());
   int32_t v = owner.allocator.readInt(addr);
   return v;
@@ -45,7 +45,7 @@ void Ikarus::memory_instance::set_float(const phoenix::symbol& sym, uint16_t ind
   owner.allocator.writeInt(addr, *reinterpret_cast<const int32_t*>(&value));
   }
 
-float Ikarus::memory_instance::get_float(const phoenix::symbol& sym, uint16_t index) {
+float Ikarus::memory_instance::get_float(const phoenix::symbol& sym, uint16_t index) const {
   ptr32_t addr = address + ptr32_t(sym.offset_as_member()) + ptr32_t(index * sym.class_size());
   int32_t v = owner.allocator.readInt(addr);
 
@@ -61,7 +61,7 @@ void Ikarus::memory_instance::set_string(const phoenix::symbol& sym, uint16_t in
   // allocator.writeInt(addr, 0);
   }
 
-const std::string& Ikarus::memory_instance::get_string(const phoenix::symbol& sym, uint16_t index) {
+const std::string& Ikarus::memory_instance::get_string(const phoenix::symbol& sym, uint16_t index) const {
   ptr32_t addr = address + ptr32_t(sym.offset_as_member()) + ptr32_t(index*sym.class_size());
 
   Log::d("memory_instance: ", sym.name());

--- a/game/game/compatibility/ikarus.h
+++ b/game/game/compatibility/ikarus.h
@@ -19,13 +19,13 @@ class Ikarus : public ScriptPlugin {
       explicit memory_instance(Ikarus &owner, ptr32_t address) : owner(owner), address(address) {}
 
       void set_int(phoenix::symbol const& sym, uint16_t index, std::int32_t value) override;
-      std::int32_t get_int(phoenix::symbol const& sym, uint16_t index) override;
+      std::int32_t get_int(phoenix::symbol const& sym, uint16_t index) const override;
 
       void set_float(phoenix::symbol const& sym, uint16_t index, float value) override;
-      float get_float(phoenix::symbol const& sym, uint16_t index) override;
+      float get_float(phoenix::symbol const& sym, uint16_t index) const override;
 
       void set_string(phoenix::symbol const& sym, uint16_t index, std::string_view value) override;
-      const std::string& get_string(phoenix::symbol const& sym, uint16_t index) override;
+      const std::string& get_string(phoenix::symbol const& sym, uint16_t index) const override;
 
       Ikarus &owner;
       ptr32_t address = 0;

--- a/game/game/definitions/svmdefinitions.cpp
+++ b/game/game/definitions/svmdefinitions.cpp
@@ -29,7 +29,7 @@ std::string_view SvmDefinitions::find(std::string_view speech, int intId) {
     auto* i = vm.find_symbol_by_name(name);
     if(i==nullptr)
       return "";
-    return i->get_string(0,svm[size_t(id)]);
+    return i->get_string(0,svm[size_t(id)].get());
     }
 
   return "";

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -539,7 +539,7 @@ void GameScript::loadVar(Serialize &fin) {
         for (unsigned j = 0; j < size; ++j) {
             fin.read(v);
             if (s != nullptr && !s->is_member() && !s->is_const()) {
-                s->set_int(v, j);
+                s->set_int(v, static_cast<uint16_t>(j));
             }
         }
 
@@ -556,7 +556,7 @@ void GameScript::loadVar(Serialize &fin) {
         for (unsigned j = 0; j < size; ++j) {
             fin.read(v);
             if (s != nullptr && !s->is_member() && !s->is_const()) {
-                s->set_float(v, j);
+                s->set_float(v, static_cast<uint16_t>(j));
             }
         }
 
@@ -573,7 +573,7 @@ void GameScript::loadVar(Serialize &fin) {
         for (unsigned j = 0; j < size; ++j) {
             fin.read(v);
             if (s != nullptr && !s->is_member() && !s->is_const()) {
-                s->set_string(v, j);
+                s->set_string(v, static_cast<uint16_t>(j));
             }
         }
 
@@ -634,7 +634,7 @@ void GameScript::saveSym(Serialize &fout, phoenix::symbol &i) {
         fout.write(i.type(), i.name(), i.count());
 
         for (unsigned j = 0; j < i.count(); ++j)
-          fout.write(i.get_int(j));
+          fout.write(i.get_int(static_cast<uint16_t>(j)));
         return;
         }
       break;
@@ -643,7 +643,7 @@ void GameScript::saveSym(Serialize &fout, phoenix::symbol &i) {
         fout.write(i.type(), i.name(), i.count());
 
         for (unsigned j = 0; j < i.count(); ++j)
-          fout.write(i.get_float(j));
+          fout.write(i.get_float(static_cast<uint16_t>(j)));
         return;
         }
       break;
@@ -652,7 +652,7 @@ void GameScript::saveSym(Serialize &fout, phoenix::symbol &i) {
         fout.write(i.type(), i.name(), i.count());
 
         for (unsigned j = 0; j < i.count(); ++j)
-          fout.write(i.get_string(j));
+          fout.write(i.get_string(static_cast<uint16_t>(j)));
         return;
         }
       break;
@@ -775,12 +775,12 @@ const AiState& GameScript::aiState(ScriptFn id) {
   }
 
 const phoenix::c_spell& GameScript::spellDesc(int32_t splId) {
-  auto& tag = spellFxInstanceNames->get_string(size_t(splId));
+  auto& tag = spellFxInstanceNames->get_string(static_cast<uint16_t>(splId));
   return spells->find(tag);
   }
 
 const VisualFx* GameScript::spellVfx(int32_t splId) {
-  auto& tag = spellFxInstanceNames->get_string(size_t(splId));
+  auto& tag = spellFxInstanceNames->get_string(static_cast<uint16_t>(splId));
   string_frm name("spellFX_",tag);
   return Gothic::inst().loadVisualFx(name);
   }
@@ -1052,7 +1052,7 @@ int GameScript::invokeManaRelease(Npc &npc, Npc* target, int mana) {
   }
 
 void GameScript::invokeSpell(Npc &npc, Npc* target, Item &it) {
-  auto&      tag = spellFxInstanceNames->get_string(size_t(it.spellId()));
+  auto&      tag = spellFxInstanceNames->get_string(static_cast<uint16_t>(it.spellId()));
   string_frm name("Spell_Cast_",tag);
   auto       fn = vm.find_symbol_by_name(name);
   if(fn==nullptr)
@@ -1144,7 +1144,7 @@ void GameScript::playerHotLameHeal(Npc& pl) {
 std::string_view GameScript::spellCastAnim(Npc&, Item &it) {
   if(spellFxAniLetters==nullptr)
     return "FIB";
-  return spellFxAniLetters->get_string(size_t(it.spellId()));
+  return spellFxAniLetters->get_string(static_cast<uint16_t>(it.spellId()));
   }
 
 bool GameScript::aiOutput(Npc &npc, std::string_view outputname, bool overlay) {
@@ -1558,8 +1558,8 @@ void GameScript::wld_exchangeguildattitudes(std::string_view name) {
     return;
   for(size_t i=0;i<gilTblSize;++i)
     for(size_t r=0;r<gilTblSize;++r) {
-      gilAttitudes[i*gilCount+r] = guilds->get_int(i*gilTblSize+r);
-      gilAttitudes[r*gilCount+i] = guilds->get_int(r*gilTblSize+i);
+      gilAttitudes[i*gilCount+r] = guilds->get_int(static_cast<uint16_t>(i * gilTblSize + r));
+      gilAttitudes[r*gilCount+i] = guilds->get_int(static_cast<uint16_t>(r * gilTblSize + i));
       }
   }
 

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -424,14 +424,14 @@ void GameScript::loadDialogOU() {
   for(auto OU:names) {
     if(Resources::hasFile(OU)) {
       auto buf = Resources::getFileBuffer(OU);
-      dialogs = phoenix::messages::parse(buf);
+      dialogs.load(buf.get());
       return;
       }
 
     const size_t segment = OU.find_last_of("\\/");
     if(segment!=std::string::npos && Resources::hasFile(OU.substr(segment+1))) {
       auto buf = Resources::getFileBuffer(OU.substr(segment+1));
-      dialogs = phoenix::messages::parse(buf);
+      dialogs.load(buf.get());
       return;
       }
 
@@ -447,8 +447,8 @@ void GameScript::loadDialogOU() {
       }
 
     try {
-      auto buf = phoenix::buffer::mmap(full);
-      dialogs = phoenix::messages::parse(buf);
+      auto buf = zenkit::Read::from(full);
+      dialogs.load(buf.get());
       return;
       }
     catch(...){

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -539,7 +539,7 @@ void GameScript::loadVar(Serialize &fin) {
         for (unsigned j = 0; j < size; ++j) {
             fin.read(v);
             if (s != nullptr && !s->is_member() && !s->is_const()) {
-                s->set_int(v, static_cast<uint16_t>(j));
+                s->set_int(v, uint16_t(j));
             }
         }
 
@@ -556,7 +556,7 @@ void GameScript::loadVar(Serialize &fin) {
         for (unsigned j = 0; j < size; ++j) {
             fin.read(v);
             if (s != nullptr && !s->is_member() && !s->is_const()) {
-                s->set_float(v, static_cast<uint16_t>(j));
+                s->set_float(v, uint16_t(j));
             }
         }
 
@@ -573,7 +573,7 @@ void GameScript::loadVar(Serialize &fin) {
         for (unsigned j = 0; j < size; ++j) {
             fin.read(v);
             if (s != nullptr && !s->is_member() && !s->is_const()) {
-                s->set_string(v, static_cast<uint16_t>(j));
+                s->set_string(v, uint16_t(j));
             }
         }
 
@@ -634,7 +634,7 @@ void GameScript::saveSym(Serialize &fout, phoenix::symbol &i) {
         fout.write(i.type(), i.name(), i.count());
 
         for (unsigned j = 0; j < i.count(); ++j)
-          fout.write(i.get_int(static_cast<uint16_t>(j)));
+          fout.write(i.get_int(uint16_t(j)));
         return;
         }
       break;
@@ -643,7 +643,7 @@ void GameScript::saveSym(Serialize &fout, phoenix::symbol &i) {
         fout.write(i.type(), i.name(), i.count());
 
         for (unsigned j = 0; j < i.count(); ++j)
-          fout.write(i.get_float(static_cast<uint16_t>(j)));
+          fout.write(i.get_float(uint16_t(j)));
         return;
         }
       break;
@@ -652,7 +652,7 @@ void GameScript::saveSym(Serialize &fout, phoenix::symbol &i) {
         fout.write(i.type(), i.name(), i.count());
 
         for (unsigned j = 0; j < i.count(); ++j)
-          fout.write(i.get_string(static_cast<uint16_t>(j)));
+          fout.write(i.get_string(uint16_t(j)));
         return;
         }
       break;
@@ -775,12 +775,12 @@ const AiState& GameScript::aiState(ScriptFn id) {
   }
 
 const phoenix::c_spell& GameScript::spellDesc(int32_t splId) {
-  auto& tag = spellFxInstanceNames->get_string(static_cast<uint16_t>(splId));
+  auto& tag = spellFxInstanceNames->get_string(uint16_t(splId));
   return spells->find(tag);
   }
 
 const VisualFx* GameScript::spellVfx(int32_t splId) {
-  auto& tag = spellFxInstanceNames->get_string(static_cast<uint16_t>(splId));
+  auto& tag = spellFxInstanceNames->get_string(uint16_t(splId));
   string_frm name("spellFX_",tag);
   return Gothic::inst().loadVisualFx(name);
   }
@@ -1052,7 +1052,7 @@ int GameScript::invokeManaRelease(Npc &npc, Npc* target, int mana) {
   }
 
 void GameScript::invokeSpell(Npc &npc, Npc* target, Item &it) {
-  auto&      tag = spellFxInstanceNames->get_string(static_cast<uint16_t>(it.spellId()));
+  auto&      tag = spellFxInstanceNames->get_string(uint16_t(it.spellId()));
   string_frm name("Spell_Cast_",tag);
   auto       fn = vm.find_symbol_by_name(name);
   if(fn==nullptr)
@@ -1144,7 +1144,7 @@ void GameScript::playerHotLameHeal(Npc& pl) {
 std::string_view GameScript::spellCastAnim(Npc&, Item &it) {
   if(spellFxAniLetters==nullptr)
     return "FIB";
-  return spellFxAniLetters->get_string(static_cast<uint16_t>(it.spellId()));
+  return spellFxAniLetters->get_string(uint16_t(it.spellId()));
   }
 
 bool GameScript::aiOutput(Npc &npc, std::string_view outputname, bool overlay) {
@@ -1558,8 +1558,8 @@ void GameScript::wld_exchangeguildattitudes(std::string_view name) {
     return;
   for(size_t i=0;i<gilTblSize;++i)
     for(size_t r=0;r<gilTblSize;++r) {
-      gilAttitudes[i*gilCount+r] = guilds->get_int(static_cast<uint16_t>(i * gilTblSize + r));
-      gilAttitudes[r*gilCount+i] = guilds->get_int(static_cast<uint16_t>(r * gilTblSize + i));
+      gilAttitudes[i*gilCount+r] = guilds->get_int(uint16_t(i * gilTblSize + r));
+      gilAttitudes[r*gilCount+i] = guilds->get_int(uint16_t(r * gilTblSize + i));
       }
   }
 

--- a/game/gothic.cpp
+++ b/game/gothic.cpp
@@ -635,13 +635,17 @@ std::unique_ptr<phoenix::vm> Gothic::createPhoenixVm(std::string_view datFile, c
 phoenix::script Gothic::loadScript(std::string_view datFile, const ScriptLang lang) {
   if(Resources::hasFile(datFile)) {
     auto buf = Resources::getFileBuffer(datFile);
-    return phoenix::script::parse(buf);
+    zenkit::DaedalusScript script;
+    script.load(buf.get());
+    return script;
     }
 
   const size_t segment = datFile.find_last_of("\\/");
   if(segment!=std::string::npos && Resources::hasFile(datFile.substr(segment+1))) {
     auto buf = Resources::getFileBuffer(datFile.substr(segment+1));
-    return phoenix::script::parse(buf);
+    zenkit::DaedalusScript script;
+    script.load(buf.get());
+    return script;
     }
 
   char16_t str16[256] = {};
@@ -663,8 +667,10 @@ phoenix::script Gothic::loadScript(std::string_view datFile, const ScriptLang la
     path    = caseInsensitiveSegment(gscript,str16,Dir::FT_File);
     }
 
-  auto buf = phoenix::buffer::mmap(path);
-  return phoenix::script::parse(buf);
+  auto buf = zenkit::Read::from(path);
+  zenkit::DaedalusScript script;
+  script.load(buf.get());
+  return script;
   }
 
 bool Gothic::settingsHasSection(std::string_view sec) {

--- a/game/graphics/lightgroup.cpp
+++ b/game/graphics/lightgroup.cpp
@@ -3,6 +3,8 @@
 #include <Tempest/Dir>
 #include <Tempest/Log>
 
+#include <phoenix/archive.hh>
+
 #include "graphics/shaders.h"
 #include "graphics/sceneglobals.h"
 #include "utils/string_frm.h"

--- a/game/graphics/lightgroup.cpp
+++ b/game/graphics/lightgroup.cpp
@@ -215,10 +215,10 @@ LightGroup::LightGroup(const SceneGlobals& scene)
 
   try {
     auto filename = Gothic::nestedPath({u"_work", u"Data", u"Presets", u"LIGHTPRESETS.ZEN"}, Dir::FT_File);
-    auto buf = phoenix::buffer::mmap(filename);
-    auto zen = phoenix::archive_reader::open(buf);
+    auto buf = zenkit::Read::from(filename);
+    auto zen = zenkit::ReadArchive::from(buf.get());
 
-    phoenix::archive_object obj {};
+    zenkit::ArchiveObject obj {};
     auto count = zen->read_int();
     for(int i = 0; i < count; ++i) {
       zen->read_object_begin(obj);

--- a/game/graphics/mesh/animation.cpp
+++ b/game/graphics/mesh/animation.cpp
@@ -193,8 +193,9 @@ Animation::Sequence::Sequence(const phoenix::mds::animation& hdr, std::string_vi
   if(entry==nullptr)
     return;
 
-  phoenix::buffer reader = entry->open();
-  auto p                 = phoenix::animation::parse(reader);
+  auto reader = entry->open_read();
+  zenkit::ModelAnimation p;
+  p.load(reader.get());
 
   data = std::make_shared<AnimData>();
   askName    = hdr.name;

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -94,6 +94,7 @@ int main(int argc,const char** argv) {
           Tempest::Log::i("[phoenix] ", message);
           break;
         case phoenix::logging::level::debug:
+        case phoenix::logging::level::TRACE:
           Tempest::Log::d("[phoenix] ", message);
           break;
         }

--- a/game/resources.cpp
+++ b/game/resources.cpp
@@ -690,7 +690,7 @@ GthFont &Resources::implLoadFont(std::string_view name, FontType type) {
     return *f;
     }
 
-  auto ptr   = std::make_unique<GthFont>(entry->open_read().get(),tex,color);
+  auto ptr   = std::make_unique<GthFont>(*entry->open_read(),tex,color);
   ptr->setScale(Gothic::options().interfaceScale);
   GthFont* f = ptr.get();
   gothicFnt[std::make_pair(std::move(cname),type)] = std::move(ptr);

--- a/game/resources.cpp
+++ b/game/resources.cpp
@@ -120,13 +120,7 @@ void Resources::loadVdfs(const std::vector<std::u16string>& modvdfs, bool modFil
 
   for(auto& i:archives) {
     try {
-      const uint32_t UNION_VDF_VERSION = 160;
       auto in     = phoenix::buffer::mmap(i.name);
-      auto header = phoenix::vdf_header::read(in);
-      if(header.version==UNION_VDF_VERSION) {
-        Log::e("skip compressed archive: \"", TextCodec::toUtf8(i.name), "\"");
-        continue;
-        }
 #ifdef __IOS__
       // causes OOM on iPhone7
       if(i.name.find(u"Speech")!=std::string::npos)
@@ -135,7 +129,7 @@ void Resources::loadVdfs(const std::vector<std::u16string>& modvdfs, bool modFil
       in.rewind();
       inst->gothicAssets.mount_disk(in, phoenix::VfsOverwriteBehavior::OLDER);
       }
-    catch(const phoenix::vdfs_signature_error& err) {
+    catch(const zenkit::VfsBrokenDiskError& err) {
       Log::e("unable to load archive: \"", TextCodec::toUtf8(i.name), "\", reason: ", err.what());
       }
     catch(const std::exception& err) {
@@ -856,7 +850,7 @@ const Resources::VobTree* Resources::implLoadVobBundle(std::string_view filename
   if(i!=zenCache.end())
     return i->second.get();
 
-  std::vector<std::unique_ptr<phoenix::vob>> bundle;
+  std::vector<std::shared_ptr<phoenix::vob>> bundle;
   try {
     const auto* entry = Resources::vdfsIndex().find(cname);
     if(entry == nullptr)

--- a/game/resources.cpp
+++ b/game/resources.cpp
@@ -431,13 +431,14 @@ std::unique_ptr<ProtoMesh> Resources::implLoadMeshMain(std::string name) {
     FileExt::exchangeExt(mesh,nullptr,"MDM") ||
     FileExt::exchangeExt(mesh,"ASC",  "MDM");
 
-    if(anim->defaultMesh().empty())
-      mesh = name;
-    FileExt::assignExt(mesh,"MDH");
+    auto mdhName = std::string(anim->defaultMesh());
+    if(mdhName.empty())
+      mdhName = name;
+    FileExt::assignExt(mdhName,"MDH");
 
-    const auto* entry = Resources::vdfsIndex().find(mesh);
+    const auto* entry = Resources::vdfsIndex().find(mdhName);
     if(entry==nullptr)
-      throw std::runtime_error("failed to open resource: " + mesh);
+      throw std::runtime_error("failed to open resource: " + mdhName);
 
     zenkit::ModelHierarchy mdh;
     auto reader = entry->open_read();

--- a/game/resources.h
+++ b/game/resources.h
@@ -135,7 +135,7 @@ class Resources final {
 
     static std::vector<uint8_t>      getFileData(std::string_view name);
     static bool                      getFileData(std::string_view name, std::vector<uint8_t>& dat);
-    static phoenix::buffer           getFileBuffer(std::string_view name);
+    static std::unique_ptr<zenkit::Read> getFileBuffer(std::string_view name);
     static bool                      hasFile    (std::string_view fname);
 
     static const phoenix::Vfs&       vdfsIndex();
@@ -171,7 +171,7 @@ class Resources final {
     void                  detectVdf(std::vector<Archive>& ret, const std::u16string& root);
 
     Tempest::Texture2d*   implLoadTexture(TextureCache& cache, std::string_view cname);
-    Tempest::Texture2d*   implLoadTexture(TextureCache& cache, std::string &&name, const phoenix::buffer& data);
+    Tempest::Texture2d*   implLoadTexture(TextureCache& cache, std::string &&name, zenkit::Read* data);
     ProtoMesh*            implLoadMesh(std::string_view name);
     std::unique_ptr<ProtoMesh> implLoadMeshMain(std::string name);
     std::unique_ptr<Animation> implLoadAnimation(std::string name);

--- a/game/resources.h
+++ b/game/resources.h
@@ -171,7 +171,7 @@ class Resources final {
     void                  detectVdf(std::vector<Archive>& ret, const std::u16string& root);
 
     Tempest::Texture2d*   implLoadTexture(TextureCache& cache, std::string_view cname);
-    Tempest::Texture2d*   implLoadTexture(TextureCache& cache, std::string &&name, zenkit::Read* data);
+    Tempest::Texture2d*   implLoadTexture(TextureCache& cache, std::string &&name, zenkit::Read& data);
     ProtoMesh*            implLoadMesh(std::string_view name);
     std::unique_ptr<ProtoMesh> implLoadMeshMain(std::string name);
     std::unique_ptr<Animation> implLoadAnimation(std::string name);

--- a/game/resources.h
+++ b/game/resources.h
@@ -5,7 +5,7 @@
 #include <Tempest/Device>
 #include <Tempest/SoundDevice>
 
-#include <phoenix/vdfs.hh>
+#include <phoenix/Vfs.hh>
 #include <phoenix/world/vob_tree.hh>
 
 #include <tuple>
@@ -13,7 +13,6 @@
 #include <map>
 
 #include "graphics/material.h"
-#include "phoenix/Vfs.hh"
 #include "sound/soundfx.h"
 
 class StaticMesh;
@@ -77,7 +76,7 @@ class Resources final {
       Tempest::Vec3 color;
       };
 
-    using VobTree = std::vector<std::unique_ptr<phoenix::vob>>;
+    using VobTree = std::vector<std::shared_ptr<phoenix::vob>>;
 
     static Tempest::Device&          device() { return inst->dev; }
     static const char*               renderer();

--- a/game/ui/gamemenu.cpp
+++ b/game/ui/gamemenu.cpp
@@ -1197,7 +1197,7 @@ void GameMenu::setPlayer(const Npc &pl) {
     return;
     }
 
-  set("MENU_ITEM_PLAYERGUILD", gilds->get_string(static_cast<uint16_t>(pl.guild())));
+  set("MENU_ITEM_PLAYERGUILD", gilds->get_string(uint16_t(pl.guild())));
 
   set("MENU_ITEM_LEVEL",       pl.level());
   set("MENU_ITEM_EXP",         pl.experience());
@@ -1216,7 +1216,7 @@ void GameMenu::setPlayer(const Npc &pl) {
 
   const bool g2        = Gothic::inst().version().game==2;
   const int  talentMax = g2 ? TALENT_MAX_G2 : TALENT_MAX_G1;
-  for(unsigned short i=0; i<talentMax; ++i) {
+  for(uint16_t i=0; i<talentMax; ++i) {
     auto& str = tal->get_string(i);
     if(str.empty())
       continue;

--- a/game/ui/gamemenu.cpp
+++ b/game/ui/gamemenu.cpp
@@ -1197,7 +1197,7 @@ void GameMenu::setPlayer(const Npc &pl) {
     return;
     }
 
-  set("MENU_ITEM_PLAYERGUILD", gilds->get_string(pl.guild()));
+  set("MENU_ITEM_PLAYERGUILD", gilds->get_string(static_cast<uint16_t>(pl.guild())));
 
   set("MENU_ITEM_LEVEL",       pl.level());
   set("MENU_ITEM_EXP",         pl.experience());
@@ -1216,8 +1216,8 @@ void GameMenu::setPlayer(const Npc &pl) {
 
   const bool g2        = Gothic::inst().version().game==2;
   const int  talentMax = g2 ? TALENT_MAX_G2 : TALENT_MAX_G1;
-  for(int i=0; i<talentMax; ++i) {
-    auto& str = tal->get_string(size_t(i));
+  for(unsigned short i=0; i<talentMax; ++i) {
+    auto& str = tal->get_string(i);
     if(str.empty())
       continue;
 
@@ -1225,7 +1225,7 @@ void GameMenu::setPlayer(const Npc &pl) {
     const int val = g2 ? pl.hitChance(Talent(i)) : pl.talentValue(Talent(i));
 
     set(string_frm("MENU_ITEM_TALENT_",i,"_TITLE"), str);
-    set(string_frm("MENU_ITEM_TALENT_",i,"_SKILL"), strEnum(talV->get_string(size_t(i)),sk,textBuf));
+    set(string_frm("MENU_ITEM_TALENT_",i,"_SKILL"), strEnum(talV->get_string(i),sk,textBuf));
     set(string_frm("MENU_ITEM_TALENT_",i),          string_frm(val,"%"));
     }
   }

--- a/game/utils/gthfont.cpp
+++ b/game/utils/gthfont.cpp
@@ -8,9 +8,9 @@ using namespace Tempest;
 GthFont::GthFont():pfnt(new phoenix::font("", 16, {})) {
   }
 
-GthFont::GthFont(zenkit::Read* data, std::string_view ftex, const Color &cl)
+GthFont::GthFont(zenkit::Read& data, std::string_view ftex, const Color &cl)
   :pfnt(std::make_shared<zenkit::Font>()), color(cl) {
-  pfnt->load(data);
+  pfnt->load(&data);
   tex = Resources::loadTexture(ftex);
   setScale(1);
   }

--- a/game/utils/gthfont.cpp
+++ b/game/utils/gthfont.cpp
@@ -8,8 +8,9 @@ using namespace Tempest;
 GthFont::GthFont():pfnt(new phoenix::font("", 16, {})) {
   }
 
-GthFont::GthFont(phoenix::buffer data, std::string_view ftex, const Color &cl)
-  :pfnt(new phoenix::font(phoenix::font::parse(data))), color(cl) {
+GthFont::GthFont(zenkit::Read* data, std::string_view ftex, const Color &cl)
+  :pfnt(std::make_shared<zenkit::Font>()), color(cl) {
+  pfnt->load(data);
   tex = Resources::loadTexture(ftex);
   setScale(1);
   }

--- a/game/utils/gthfont.h
+++ b/game/utils/gthfont.h
@@ -6,7 +6,7 @@
 class GthFont final {
   public:
     GthFont();
-    GthFont(zenkit::Read* data, std::string_view ftex, const Tempest::Color &cl);
+    GthFont(zenkit::Read& data, std::string_view ftex, const Tempest::Color &cl);
     GthFont(const GthFont&) = default;
     GthFont(GthFont&&)      = default;
 

--- a/game/utils/gthfont.h
+++ b/game/utils/gthfont.h
@@ -6,7 +6,7 @@
 class GthFont final {
   public:
     GthFont();
-    GthFont(phoenix::buffer data, std::string_view ftex, const Tempest::Color &cl);
+    GthFont(zenkit::Read* data, std::string_view ftex, const Tempest::Color &cl);
     GthFont(const GthFont&) = default;
     GthFont(GthFont&&)      = default;
 

--- a/game/utils/gthfont.h
+++ b/game/utils/gthfont.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <phoenix/vdfs.hh>
 #include <phoenix/font.hh>
 
 #include <Tempest/Painter>

--- a/game/world/objects/vob.cpp
+++ b/game/world/objects/vob.cpp
@@ -231,7 +231,6 @@ std::unique_ptr<Vob> Vob::load(Vob* parent, World& world, const phoenix::vob& vo
       break;
     case phoenix::vob_type::oCNpc:
     case phoenix::vob_type::oCCSTrigger:
-    case phoenix::vob_type::ignored:
       break;
     }
 

--- a/game/world/triggers/cscamera.cpp
+++ b/game/world/triggers/cscamera.cpp
@@ -27,7 +27,7 @@ CsCamera::CsCamera(Vob* parent, World& world, const phoenix::vobs::cs_camera& ca
       posSpline.keyframe.push_back(kF);
   }
 
-  for (auto& f : cam.trajectory_frames) {
+  for (auto& f : cam.target_frames) {
       KeyFrame kF;
       kF.c[3]  = Vec3(f->original_pose[3][0],f->original_pose[3][1],f->original_pose[3][2]);
       kF.time  = f->time;

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -686,7 +686,7 @@ void WorldObjects::addStatic(StaticObj* obj) {
   objStatic.push_back(obj);
   }
 
-void WorldObjects::addRoot(const std::unique_ptr<phoenix::vob>& vob, bool startup) {
+void WorldObjects::addRoot(const std::shared_ptr<phoenix::vob>& vob, bool startup) {
   auto p = Vob::load(nullptr,owner,*vob,(startup ? Vob::Startup : Vob::None) | Vob::Static);
   if(p==nullptr)
     return;

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -106,7 +106,7 @@ class WorldObjects final {
 
     void           addInteractive(Interactive*         obj);
     void           addStatic     (StaticObj*           obj);
-    void           addRoot       (const std::unique_ptr<phoenix::vob>& vob, bool startup);
+    void           addRoot       (const std::shared_ptr<phoenix::vob>& vob, bool startup);
     void           invalidateVobIndex();
 
     Interactive*   validateInteractive(Interactive *def);


### PR DESCRIPTION
This patch upgrades [ZenKit](https://github.com/GothicKit/ZenKit) to the newest commit. There are a lot of changes which will be released in version 1.3 soon, but I'd like to get this patch in before I release it to catch any issues I might have overlooked.

Version 1.3 adds a lot of features to ZenKit, including an improved I/O system which allows ZenKit to finally create assets, an overhauled ZEN archiver which now correctly handles object references and in tandem with that, a better VOb-tree implementation.

In addition, version 1.3 features a re-designed API: most classes, enums and constants have been re-named and updated to be more intuitively understood. A full list of changes and a migration guide can be found at https://zk.gothickit.dev/library/misc/v1.2-to-v1.3/.

Everything, except the [Recommended Migrations](https://zk.gothickit.dev/library/misc/v1.2-to-v1.3/#recommended-migrations) has been implemented by this patch.

**Note: This patch also disables deprecation warnings so we don't run into `-Werror` issues. You might want to disable them at some point after migration is fully done.**