### PR TITLE
Adjust fall camera

### DIFF
--- a/game/camera.cpp
+++ b/game/camera.cpp
@@ -132,7 +132,7 @@ void Camera::setMode(Camera::Mode m) {
   if(camMod==m)
     return;
 
-  const bool reset = (m==Inventory || camMod==Inventory || camMod==Dialog || camMod==Dive || m==Fall);
+  const bool reset = (m==Inventory || camMod==Inventory || camMod==Dialog || camMod==Dive || m==Fall || camMod==Fall);
   camMod = m;
 
   if(camMarvinMod==M_Freeze)

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -940,7 +940,7 @@ Camera::Mode MainWindow::solveCameraMode() const {
       return Camera::Dive;
     if(pl->isSwim())
       return Camera::Swim;
-    if(pl->isFalling())
+    if(pl->isFallingDeep())
       return Camera::Fall;
     bool g2 = Gothic::inst().version().game==2;
     switch(pl->weaponState()){


### PR DESCRIPTION
Vanilla testing showed that `fallCam`is only activated once the deep fall animation is used. This is useful because otherwise the camera was not reset to the normal behind the player perspective when F8 flying around.

The second change makes sure bird perspective is left on landing.