### PR TITLE
fixed camera zooming out on repeated 0 value events

### DIFF
--- a/game/camera.cpp
+++ b/game/camera.cpp
@@ -73,7 +73,8 @@ void Camera::changeZoom(int delta) {
   if(fpEnable)
     return;
   if(delta>0)
-    userRange-=0.02f; else
+    userRange-=0.02f;
+  else if(delta<0)
     userRange+=0.02f;
   userRange = std::max(0.f,std::min(userRange,1.f));
   }


### PR DESCRIPTION
On macOS using trackpad system sends a lot of events with deltaY=0 and made it impossible to zoom back in after zooming out.