### PR TITLE
Interactive focus: consider `focOver` attribute only if a weapon is drawn

### DIFF
--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -934,7 +934,7 @@ static bool checkFlag(Npc& n,WorldObjects::SearchFlg f){
   }
 
 static bool checkFlag(Interactive& i,WorldObjects::SearchFlg f){
-  if(bool(f&WorldObjects::FcOverride)!=i.overrideFocus())
+  if(bool(f&WorldObjects::FcOverride) && !i.overrideFocus())
     return false;
   return true;
   }


### PR DESCRIPTION
`fovOver` is only used in combat mode otherwise normal interaction is always possible. I tested at Irdorath bridge switches. 

Reason for pr is a mod where a chest had this set to true, likely by accident.