### PR TITLE
Add firedelay to triggers

### DIFF
--- a/game/game/serialize.h
+++ b/game/game/serialize.h
@@ -32,7 +32,7 @@ class SaveGameHeader;
 class Serialize {
   public:
     enum Version : uint16_t {
-      Current = 46
+      Current = 47
       };
     Serialize(Tempest::ODevice& fout);
     Serialize(Tempest::IDevice&  fin);

--- a/game/world/triggers/abstracttrigger.h
+++ b/game/world/triggers/abstracttrigger.h
@@ -50,10 +50,12 @@ class AbstractTrigger : public Vob {
 
     std::string_view             name() const;
     bool                         isEnabled() const;
-
+    bool                         isDeferred() const;
     void                         processEvent(const TriggerEvent& evt);
+    void                         execEvent(const TriggerEvent& evt);
     virtual void                 onIntersect(Npc& n);
     virtual void                 tick(uint64_t dt);
+    void                         tickDeferred(uint64_t dt);
 
     virtual bool                 hasVolume() const;
     bool                         checkPos(const Tempest::Vec3& pos) const;
@@ -89,16 +91,20 @@ class AbstractTrigger : public Vob {
     void                         disableTicks();
     const std::vector<Npc*>&     intersections() const;
 
+    void                         triggerDeferred();
+
   private:
     Cb                           callback;
     DynamicWorld::BBoxBody       box;
     CollisionZone                boxNpc;
     Tempest::Vec3                bboxSize, bboxOrigin;
 
-    float                        fireDelaySec = 0;
+    uint64_t                     fireDelaySec = 0;
+    uint64_t                     reTriggerDelaySec = 0;
     uint32_t                     maxActivationCount = 0;
     uint32_t                     triggerFlags = 0;
     uint32_t                     filterFlags = 0;
+    TriggerEvent                 evtDeferred = {};
 
     uint32_t                     emitCount = 0;
     bool                         disabled  = false;

--- a/game/world/triggers/codemaster.cpp
+++ b/game/world/triggers/codemaster.cpp
@@ -38,7 +38,7 @@ void CodeMaster::onTrigger(const TriggerEvent &evt) {
       }
 
   zeroState();
-  TriggerEvent e(target,vobName,TriggerEvent::T_Activate);
+  TriggerEvent e(target,vobName,world.tickCount(),TriggerEvent::T_Activate);
   world.triggerEvent(e);
   }
 
@@ -54,7 +54,7 @@ void CodeMaster::load(Serialize& fin) {
 
 void CodeMaster::onFailure() {
   if(!failureTarget.empty()) {
-    TriggerEvent e(failureTarget,vobName,TriggerEvent::T_Activate);
+    TriggerEvent e(failureTarget,vobName,world.tickCount(),TriggerEvent::T_Activate);
     world.triggerEvent(e);
     }
   }

--- a/game/world/triggers/messagefilter.cpp
+++ b/game/world/triggers/messagefilter.cpp
@@ -22,27 +22,27 @@ void MessageFilter::exec(zenkit::MessageFilterAction eval) {
     case zenkit::MessageFilterAction::none:
       break;
     case zenkit::MessageFilterAction::trigger: {
-      TriggerEvent e(target,vobName,TriggerEvent::T_Trigger);
+      TriggerEvent e(target,vobName,world.tickCount(),TriggerEvent::T_Trigger);
       world.execTriggerEvent(e);
       break;
       }
     case zenkit::MessageFilterAction::untrigger: {
-      TriggerEvent e(target,vobName,TriggerEvent::T_Untrigger);
+      TriggerEvent e(target,vobName,world.tickCount(),TriggerEvent::T_Untrigger);
       world.execTriggerEvent(e);
       break;
       }
     case zenkit::MessageFilterAction::enable: {
-      TriggerEvent e(target,vobName,TriggerEvent::T_Enable);
+      TriggerEvent e(target,vobName,world.tickCount(),TriggerEvent::T_Enable);
       world.execTriggerEvent(e);
       break;
       }
     case zenkit::MessageFilterAction::disable:{
-      TriggerEvent e(target,vobName,TriggerEvent::T_Disable);
+      TriggerEvent e(target,vobName,world.tickCount(),TriggerEvent::T_Disable);
       world.execTriggerEvent(e);
       break;
       }
     case zenkit::MessageFilterAction::toggle:{
-      TriggerEvent e(target,vobName,TriggerEvent::T_ToggleEnable);
+      TriggerEvent e(target,vobName,world.tickCount(),TriggerEvent::T_ToggleEnable);
       world.execTriggerEvent(e);
       break;
       }

--- a/game/world/triggers/movetrigger.cpp
+++ b/game/world/triggers/movetrigger.cpp
@@ -258,7 +258,7 @@ void MoveTrigger::tick(uint64_t /*dt*/) {
     disableTicks();
 
     if(!target.empty()) {
-      TriggerEvent e(target,vobName,TriggerEvent::T_Activate);
+      TriggerEvent e(target,vobName,world.tickCount(),TriggerEvent::T_Activate);
       world.triggerEvent(e);
       }
 

--- a/game/world/triggers/trigger.cpp
+++ b/game/world/triggers/trigger.cpp
@@ -11,6 +11,6 @@ Trigger::Trigger(Vob* parent, World &world, const zenkit::VirtualObject& d, Flag
   }
 
 void Trigger::onTrigger(const TriggerEvent&) {
-  TriggerEvent e(target,vobName,TriggerEvent::T_Trigger);
+  TriggerEvent e(target,vobName,world.tickCount(),TriggerEvent::T_Trigger);
   world.triggerEvent(e);
   }

--- a/game/world/triggers/triggerworldstart.cpp
+++ b/game/world/triggers/triggerworldstart.cpp
@@ -14,6 +14,6 @@ void TriggerWorldStart::onTrigger(const TriggerEvent &ev) {
   if(fireOnlyFirstTime && ev.type!=TriggerEvent::T_StartupFirstTime)
     return;
 
-  TriggerEvent e(target,vobName,TriggerEvent::T_Trigger);
+  TriggerEvent e(target,vobName,world.tickCount(),TriggerEvent::T_Trigger);
   world.execTriggerEvent(e);
   }

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -475,6 +475,10 @@ Interactive* World::findInteractive(const Npc& pl) {
   return wobj.findInteractive(pl,nullptr,optMvMob);
   }
 
+void World::triggerDeferred(AbstractTrigger& t) {
+  wobj.triggerDeferred(t);
+  }
+
 void World::triggerEvent(const TriggerEvent &e) {
   wobj.triggerEvent(e);
   }

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -120,6 +120,7 @@ class World final {
 
     void                 triggerOnStart(bool firstTime);
     void                 triggerEvent(const TriggerEvent& e);
+    void                 triggerDeferred(AbstractTrigger& t);
     void                 triggerChangeWorld(std::string_view world, std::string_view wayPoint);
     void                 execTriggerEvent(const TriggerEvent& e);
     void                 enableTicks (AbstractTrigger& t);

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -80,6 +80,7 @@ class WorldObjects final {
 
     void           addTrigger(AbstractTrigger* trigger);
     void           triggerEvent(const TriggerEvent& e);
+    void           triggerDeferred(AbstractTrigger& t);
     bool           triggerOnStart(bool firstTime);
     bool           execTriggerEvent(const TriggerEvent& e);
     void           enableTicks (AbstractTrigger& t);
@@ -170,6 +171,7 @@ class WorldObjects final {
     std::vector<AbstractTrigger*>      triggers;
     std::vector<AbstractTrigger*>      triggersZn;
     std::vector<AbstractTrigger*>      triggersTk;
+    std::vector<AbstractTrigger*>      triggersDeferredTk;
     std::vector<PerceptionMsg>         sndPerc;
     std::vector<TriggerEvent>          triggerEvents;
     CsCamera*                          currentCsCamera = nullptr;


### PR DESCRIPTION
Trigger attribute `fireDelay` determines how much time should pass between trigger call and start. Currently only the time between calls is checked leading to erroneous behavior, e.g. the first call never waits.