### PR TITLE
Workaround for npc teleport

### DIFF
--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -3919,6 +3919,10 @@ void Npc::excRoutine(size_t callback) {
   routines.clear();
   owner.script().invokeState(this,currentOther,currentVictum,callback);
   // aiState.eTime = gtime();
+
+  // imitate B_StartOtherRoutine's npc teleport behavior
+  if(aiPolicy>ProcessPolicy::AiNormal)
+    resetPositionToTA();
   }
 
 void Npc::multSpeed(float s) {


### PR DESCRIPTION
In vanilla `Npc_ExchangeRoutine` teleports npc's to new routine waypoint if they're offloaded from world. Examples are Greg-Dexter event and ring of water meeting. The idea is to imitate this by resetting far npc's if their routine is exchanged.



