### PR TITLE
Move godmode damage negation to `changeAttribute`

### DIFF
--- a/game/game/damagecalculator.cpp
+++ b/game/game/damagecalculator.cpp
@@ -27,7 +27,7 @@ DamageCalculator::Val DamageCalculator::damageValue(Npc& src, Npc& other, const 
 
   if(ret.hasHit && !ret.invincible && Gothic::inst().version().game==2)
     ret.value = std::max<int32_t>(ret.value,MinDamage);
-  if(other.isImmortal() || (other.isPlayer() && Gothic::inst().isGodMode()))
+  if(other.isImmortal())
     ret.value = 0;
   return ret;
   }
@@ -44,7 +44,7 @@ DamageCalculator::Val DamageCalculator::damageFall(Npc& npc, float speed) {
   int32_t prot        = npc.protection(::PROT_FALL);
 
   Val ret;
-  ret.invincible = (prot<0 || npc.isImmortal() || (npc.isPlayer() && Gothic::inst().isGodMode()));
+  ret.invincible = (prot<0 || npc.isImmortal());
   ret.value      = int32_t(dmgPerMeter*(height-h0)/100.f - float(prot));
   if(ret.value<=0 || ret.invincible) {
     ret.value = 0;

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1150,6 +1150,8 @@ int32_t Npc::attribute(Attribute a) const {
 void Npc::changeAttribute(Attribute a, int32_t val, bool allowUnconscious) {
   if(a>=ATR_MAX || val==0)
     return;
+  if(isPlayer() && Gothic::inst().isGodMode() && val<0 && a==ATR_HITPOINTS)
+    return;
 
   hnpc->attribute[a]+=val;
   if(hnpc->attribute[a]<0)
@@ -2073,7 +2075,7 @@ void Npc::tick(uint64_t dt) {
   if(!visual.pose().hasAnim())
     setAnim(AnimationSolver::Idle);
 
-  if(isDive() && !(isPlayer() && Gothic::inst().isGodMode())) {
+  if(isDive()) {
     uint32_t gl = guild();
     int32_t  v  = world().script().guildVal().dive_time[gl]*1000;
     int32_t  t  = diveTime();


### PR DESCRIPTION
Damage could still be applied by script if `changeAttribue` function was used. Because all other cases where damage is calculated in OpenGothic use this function too, former checks for godmode became redundant. Script can still access `hnpc` directly like in swamp drone explosion which makes full damage negation impossible.

For now I opted to only check for lifepoints. Vanilla prevents reduction of other attributes as well. Equip-/unequipping strength belt is an infinite strength source.