### PR TITLE
Rework `canSense` and `canSee` functions

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -2288,7 +2288,7 @@ bool GameScript::npc_getnexttarget(std::shared_ptr<zenkit::INpc> npcRef) {
     dist*=dist;
 
     world().detectNpc(npc->position(),float(npc->handle().senses_range),[&,npc](Npc& oth){
-      if(&oth!=npc && !oth.isDown() && oth.isEnemy(*npc) && npc->canSeeNpc(oth,true)){
+      if(&oth!=npc && !oth.isDown() && oth.isEnemy(*npc)) {
         float qd = oth.qDistTo(*npc);
         if(qd<dist){
           dist=qd;

--- a/game/world/objects/interactive.cpp
+++ b/game/world/objects/interactive.cpp
@@ -517,7 +517,7 @@ uint32_t Interactive::stateMask() const {
 bool Interactive::canSeeNpc(const Npc& npc, bool freeLos) const {
   for(auto& i:attPos){
     auto pos = nodePosition(npc,i);
-    if(npc.canSeeNpc(pos.x,pos.y,pos.z,freeLos))
+    if(npc.canSeePos(pos.x,pos.y,pos.z,freeLos))
       return true;
     }
 
@@ -528,7 +528,7 @@ bool Interactive::canSeeNpc(const Npc& npc, bool freeLos) const {
     float x = pos.x;
     float y = pos.y;
     float z = pos.z;
-    if(npc.canSeeNpc(x,y,z,freeLos))
+    if(npc.canSeePos(x,y,z,freeLos))
       return true;
     }
   return false;

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -374,9 +374,8 @@ class Npc final {
 
     bool      canSeeNpc(const Npc& oth,bool freeLos) const;
     bool      canSeeSource() const;
-    bool      canSeeNpc(float x,float y,float z,bool freeLos) const;
-    auto      canSenseNpc(const Npc& oth,bool freeLos, float extRange=0.f) const -> SensesBit;
-    auto      canSenseNpc(float x,float y,float z,bool freeLos,bool isNoisy,float extRange=0.f) const -> SensesBit;
+    bool      canSeePos(float x,float y,float z,bool freeLos) const;
+    bool      canSenseNpc(const Npc& oth,bool freeLos, float extRange=0.f) const;
 
     bool      canSeeItem(const Item& it,bool freeLos) const;
 

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -846,7 +846,7 @@ const WayPoint *World::findFreePoint(const Npc &npc, std::string_view name) cons
   return wmatrix->findFreePoint(pos,name,[&npc](const WayPoint& wp) -> bool {
     if(wp.isLocked())
       return false;
-    if(!npc.canSeeNpc(wp.x,wp.y+10,wp.z,true))
+    if(!npc.canSeePos(wp.x,wp.y+10,wp.z,true))
       return false;
     return true;
     });
@@ -869,7 +869,7 @@ const WayPoint *World::findNextFreePoint(const Npc &npc, std::string_view name) 
   auto wp  = wmatrix->findFreePoint(pos,name,[cur,&npc](const WayPoint& wp) -> bool {
     if(wp.isLocked() || &wp==cur)
       return false;
-    if(!npc.canSeeNpc(wp.x,wp.y+10,wp.z,true))
+    if(!npc.canSeePos(wp.x,wp.y+10,wp.z,true))
       return false;
     return true;
     });
@@ -911,7 +911,7 @@ WayPath World::wayTo(const Npc &npc, const WayPoint &end) const {
     return wmatrix->wayTo(&begin,1,p,end);
     }
   auto near = wmatrix->findWayPoint(p, [&npc](const WayPoint &wp) {
-    if(!npc.canSeeNpc(wp.x,wp.y+10,wp.z,true))
+    if(!npc.canSeePos(wp.x,wp.y+10,wp.z,true))
       return false;
     return true;
     });
@@ -925,7 +925,7 @@ WayPath World::wayTo(const Npc &npc, const WayPoint &end) const {
   wpoint.push_back(near);
   for(auto& i:near->connections()) {
     auto p = i.point->position();
-    if(npc.canSeeNpc(p.x,p.y+10,p.z,true))
+    if(npc.canSeePos(p.x,p.y+10,p.z,true))
       wpoint.push_back(i.point);
     }
 

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -253,7 +253,7 @@ void WorldObjects::tick(uint64_t dt, uint64_t dtPlayer) {
         if(distance > range*range)
           continue;
 
-        if(i.isDown() || i.isPlayer() || !i.isAiQueueEmpty())
+        if(i.isDown())
           continue;
 
         if((percNextTime>owner.tickCount()) &&
@@ -263,13 +263,6 @@ void WorldObjects::tick(uint64_t dt, uint64_t dtPlayer) {
           }
 
         if(r.other==nullptr)
-          continue;
-
-        if(i.canSenseNpc(*r.other, true)==SensesBit::SENSE_NONE)
-          continue;
-
-        // approximation of behavior of original G2
-        if(r.victum!=nullptr && i.canSenseNpc(*r.victum,true,float(r.other->handle().senses_range))==SensesBit::SENSE_NONE)
           continue;
 
         if(r.item!=size_t(-1) && r.other!=nullptr)


### PR DESCRIPTION
I reworked some functions based on testing:

- active perceptions are only perceived if npc has `SENSE_SMELL` or `SENSE_SEE` and `canSee` returns true, `SENSE_HEAR` does nothing
- passive perceptions only care for perc range and ignore senses and `canSee`
-  `canSee` only cares for senses range
- `npc_getnexttarget` doesn't need line of sight. 

~This fixes Lares not stopping if guiding the player and shattered golem not attacking~ was already fixed by https://github.com/Try/OpenGothic/commit/b4ee93d764738431bf77994b559450122a38398a.
The check for empty aiQueue causes problems with G1 percs because npcs have often some `AI_Wait` call in script loop. This has been introduced once to fix some sneaking issues. To compensate walkbit is now used instead of bodystate for sneak mode testing.