### PR TITLE
Add attributes for triggers

### DIFF
--- a/game/world/triggers/abstracttrigger.cpp
+++ b/game/world/triggers/abstracttrigger.cpp
@@ -32,7 +32,7 @@ AbstractTrigger::AbstractTrigger(Vob* parent, World &world, const zenkit::Virtua
     auto& trigger = reinterpret_cast<const zenkit::VTrigger&>(data);
     fireDelay          = uint64_t(trigger.fire_delay_sec*1000.f);
     retriggerDelay     = uint64_t(trigger.retrigger_delay_sec*1000.f);
-    maxActivationCount = uint32_t(trigger.max_activation_count);
+    maxActivationCount = (data.type==VirtualObjectType::zCMover && trigger.max_activation_count!=0) ? uint32_t(-1) : uint32_t(trigger.max_activation_count);
     target             = trigger.target;
     disabled           = !trigger.start_enabled;
     sendUntrigger      = trigger.send_untrigger;

--- a/game/world/triggers/abstracttrigger.cpp
+++ b/game/world/triggers/abstracttrigger.cpp
@@ -33,10 +33,14 @@ AbstractTrigger::AbstractTrigger(Vob* parent, World &world, const zenkit::Virtua
     fireDelay          = uint64_t(trigger.fire_delay_sec*1000.f);
     retriggerDelay     = uint64_t(trigger.retrigger_delay_sec*1000.f);
     maxActivationCount = uint32_t(trigger.max_activation_count);
-    filterFlags        = trigger.filter_flags;
-    triggerFlags       = trigger.flags;
     target             = trigger.target;
     disabled           = !trigger.start_enabled;
+    sendUntrigger      = trigger.send_untrigger;
+    reactToOnTrigger   = trigger.react_to_on_trigger;
+    reactToOnTouch     = trigger.react_to_on_touch;
+    respondToNpc       = trigger.respond_to_npc;
+    respondToPlayer    = trigger.respond_to_pc;
+    respondToObject    = trigger.respond_to_object;
     }
 
   world.addTrigger(this);
@@ -82,18 +86,20 @@ void AbstractTrigger::processEvent(const TriggerEvent& evt) {
 void AbstractTrigger::implProcessEvent(const TriggerEvent& evt) {
   emitTimeLast = world.tickCount();
   switch(evt.type) {
+    case TriggerEvent::T_Activate:
     case TriggerEvent::T_Startup:
     case TriggerEvent::T_StartupFirstTime:
     case TriggerEvent::T_Trigger:
-      if(disabled) {
+      if(disabled || !reactToOnTrigger)
         return;
-        }
+      if(emitCount>=maxActivationCount)
+        return;
+      ++emitCount;
       onTrigger(evt);
       break;
     case TriggerEvent::T_Untrigger:
-      if(disabled) {
+      if(disabled || !sendUntrigger)
         return;
-        }
       onUntrigger(evt);
       break;
     case TriggerEvent::T_Enable:
@@ -105,17 +111,6 @@ void AbstractTrigger::implProcessEvent(const TriggerEvent& evt) {
     case TriggerEvent::T_ToggleEnable:
       disabled = !disabled;
       break;
-    case TriggerEvent::T_Activate: {
-      const bool canActivate = (maxActivationCount<=0 ||
-                                emitCount<maxActivationCount);
-      if(canActivate) {
-        ++emitCount;
-        onTrigger(evt);
-        } else {
-        //Log::d("skip trigger: ",evt.target," [emitCount]");
-        }
-      break;
-      }
     case TriggerEvent::T_Move: {
       onGotoMsg(evt);
       };
@@ -136,11 +131,6 @@ void AbstractTrigger::moveEvent() {
   boxNpc.setPosition(position()+bboxOrigin);
   }
 
-bool AbstractTrigger::hasFlag(ReactFlg flg) const {
-  ReactFlg filter = ReactFlg(triggerFlags & filterFlags);
-  return (filter&flg)==flg;
-  }
-
 void AbstractTrigger::onIntersect(Npc& n) {
   /* NOTE:
    *
@@ -152,7 +142,7 @@ void AbstractTrigger::onIntersect(Npc& n) {
    *  flags       = 0b00000011
    *  filterFlags = 0b00110011
    */
-  if(!hasFlag(n.isPlayer() ? RespondToPC : RespondToNPC) && !hasFlag(ReactToOnTouch))
+  if((n.isPlayer() ? !respondToPlayer : !respondToNpc) || !reactToOnTouch)
     return;
 
   if(!isEnabled())
@@ -227,8 +217,10 @@ const std::vector<Npc*>& AbstractTrigger::intersections() const {
   return boxNpc.intersections();
   }
 
-void AbstractTrigger::Cb::onCollide(DynamicWorld::BulletBody&) {
-  if(!tg->hasFlag(ReactToOnTouch))
+void AbstractTrigger::Cb::onCollide(DynamicWorld::BulletBody& b) {
+  if(!tg->respondToObject || !tg->reactToOnTouch)
+    return;
+  if(b.isSpell())
     return;
   TriggerEvent ex(tg->vobName,tg->vobName,tg->world.tickCount(),TriggerEvent::T_Activate);
   tg->processEvent(ex);

--- a/game/world/triggers/abstracttrigger.cpp
+++ b/game/world/triggers/abstracttrigger.cpp
@@ -12,8 +12,6 @@ using namespace Tempest;
 
 AbstractTrigger::AbstractTrigger(Vob* parent, World &world, const zenkit::VirtualObject& data, Flags flags)
   : Vob(parent,world,data,flags & (~Flags::Static)), callback(this), vobName(data.vob_name) {
-  if(!hasFlag(StartEnabled))
-    ;//disabled = true;
   bboxSize   = Vec3(data.bbox.max.x-data.bbox.min.x,data.bbox.max.y-data.bbox.min.y,data.bbox.max.z-data.bbox.min.z)*0.5f;
   bboxOrigin = Vec3(data.bbox.max.x+data.bbox.min.x,data.bbox.max.y+data.bbox.min.y,data.bbox.max.z+data.bbox.min.z)*0.5f;
   bboxOrigin = bboxOrigin - position();
@@ -38,6 +36,7 @@ AbstractTrigger::AbstractTrigger(Vob* parent, World &world, const zenkit::Virtua
     filterFlags        = trigger.filter_flags;
     triggerFlags       = trigger.flags;
     target             = trigger.target;
+    disabled           = !trigger.start_enabled;
     }
 
   world.addTrigger(this);

--- a/game/world/triggers/abstracttrigger.h
+++ b/game/world/triggers/abstracttrigger.h
@@ -64,16 +64,6 @@ class AbstractTrigger : public Vob {
     void                         load(Serialize &fin) override;
 
   protected:
-    enum ReactFlg:uint8_t {
-      ReactToOnTrigger = 1,
-      ReactToOnTouch   = 1<<1,
-      ReactToOnDamage  = 1<<2,
-      RespondToObject  = 1<<3,
-      RespondToPC      = 1<<4,
-      RespondToNPC     = 1<<5,
-      StartEnabled     = 1<<6,
-      };
-
     struct Cb : DynamicWorld::BBoxCallback {
       Cb(AbstractTrigger* tg):tg(tg) {}
       void onCollide(DynamicWorld::BulletBody &other) override;
@@ -84,8 +74,6 @@ class AbstractTrigger : public Vob {
     virtual void                 onUntrigger(const TriggerEvent& evt);
     virtual void                 onGotoMsg(const TriggerEvent& evt);
     void                         moveEvent() override;
-
-    bool                         hasFlag(ReactFlg flg) const;
 
     void                         enableTicks();
     void                         disableTicks();
@@ -101,9 +89,14 @@ class AbstractTrigger : public Vob {
 
     uint64_t                     fireDelay          = 0;
     uint64_t                     retriggerDelay     = 0;
-    uint32_t                     maxActivationCount = 0;
-    uint32_t                     triggerFlags       = 0;
-    uint32_t                     filterFlags        = 0;
+    uint32_t                     maxActivationCount = uint32_t(-1);
+    bool                         reactToOnTrigger   = true;
+    bool                         sendUntrigger      = true;
+    bool                         reactToOnDamage    = true;
+    bool                         reactToOnTouch     = true;
+    bool                         respondToNpc       = true;
+    bool                         respondToPlayer    = true;
+    bool                         respondToObject    = true;
 
     uint32_t                     emitCount = 0;
     bool                         disabled  = false;

--- a/game/world/triggers/abstracttrigger.h
+++ b/game/world/triggers/abstracttrigger.h
@@ -92,7 +92,6 @@ class AbstractTrigger : public Vob {
     uint32_t                     maxActivationCount = uint32_t(-1);
     bool                         reactToOnTrigger   = true;
     bool                         sendUntrigger      = true;
-    bool                         reactToOnDamage    = true;
     bool                         reactToOnTouch     = true;
     bool                         respondToNpc       = true;
     bool                         respondToPlayer    = true;

--- a/game/world/triggers/cscamera.cpp
+++ b/game/world/triggers/cscamera.cpp
@@ -103,12 +103,8 @@ void CsCamera::onTrigger(const TriggerEvent& evt) {
   if(active || posSpline.size()==0)
     return;
 
-  if(auto cs = world.currentCs()) {
-    // NOTE: Halls of Idorath has confusing camera trigger overlaps, this code is approximation of how it is in vanilla
-    if(cs->time!=0)
-      cs->onUntrigger(evt); else
-      return;
-    }
+  if(auto cs = world.currentCs())
+    cs->onUntrigger(evt);
 
   auto& camera = world.gameSession().camera();
   if(!camera.isCutscene()) {

--- a/game/world/triggers/cscamera.cpp
+++ b/game/world/triggers/cscamera.cpp
@@ -19,6 +19,7 @@ CsCamera::CsCamera(Vob* parent, World& world, const zenkit::VCutsceneCamera& cam
   durationF     = cam.total_duration;
   duration      = uint64_t(cam.total_duration * 1000.f);
   delay         = uint64_t(cam.auto_untrigger_last_delay * 1000.f);
+  autoUntrigger = cam.auto_untrigger_last;
   playerMovable = cam.auto_player_movable;
 
   for(auto& f : cam.trajectory_frames) {
@@ -144,7 +145,7 @@ void CsCamera::onUntrigger(const TriggerEvent& evt) {
 void CsCamera::tick(uint64_t dt) {
   time += dt;
 
-  if(time>duration+delay) {
+  if(time>duration+delay && (autoUntrigger || vobName=="TIMEDEMO")) {
     TriggerEvent e("","",TriggerEvent::T_Untrigger);
     onUntrigger(e);
     return;

--- a/game/world/triggers/cscamera.h
+++ b/game/world/triggers/cscamera.h
@@ -38,6 +38,7 @@ class CsCamera : public AbstractTrigger {
     bool     active        = false;
     bool     godMode       = false;
     bool     playerMovable = false;
+    bool     autoUntrigger = false;
     float    durationF     = 0;
     uint64_t duration      = 0;
     uint64_t delay         = 0;

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -415,6 +415,7 @@ void WorldObjects::tickTriggers(uint64_t /*dt*/) {
 
 void WorldObjects::execDelayedEvents() {
   auto def = std::move(triggersDef);
+  triggersDef.clear();
   for(auto i:def) {
     i->processDelayedEvents();
     if(i->hasDelayedEvents())


### PR DESCRIPTION
Of the two triggers that open the gate to get to the 4 rooms with switch riddles in Irdorath only one is enabled. Both are activated at the same time and their enable status is toggled afterwards. 

Setting both to enabled on first load lead to the bug that both gate up and down animations were played on first activation but none on second. This change fixes those cases. https://github.com/Try/OpenGothic/commit/20af3701522cf0141f37e8f6d1a707d0b06dc48e had a fix for first case but second one was still open.

Also added a missing clear command reported by static analyzer for deferred triggers.