### PR TITLE
update README for Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ There are ongoing efforts to support parts of it to make at least some popular m
 ## Build Instructions
 ### Linux
 Install dependencies:
-* Ubuntu 20.04
+* Ubuntu 20.04/22.04 and their derived distros
 ```bash
+source <(cat /etc/os-release | grep UBUNTU_CODENAME)
 # latest Vulkan SDK provided externally as Ubuntu packages are usually older
 wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list http://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list
+sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-${UBUNTU_CODENAME}.list http://packages.lunarg.com/vulkan/lunarg-vulkan-${UBUNTU_CODENAME}.list
 sudo apt update
 sudo apt install vulkan-sdk
 


### PR DESCRIPTION
Fix for #596

In addition to mentioning 22.04:
* LunarG repo also provides packages for Ubuntu 16.04 and 18.04 (but I don't know if it's possible to compile and run OPG there so I didn't mention it to stay safe) 
* in around two months' time the repo will also provide packages for Ubuntu 24.04, but there's some period of time between Ubuntu LTS releasing and LunarG adding support for it in the repo, so again to stay on the safe side I'm not mentioning it explicitly yet.

I've manually verified the /etc/os-release and its VERSION_CODENAME to be available on all of the LTS versions mentioned above (16.04-22.04).