### PR TITLE
Fix monster damage

### DIFF
--- a/game/game/damagecalculator.cpp
+++ b/game/game/damagecalculator.cpp
@@ -146,7 +146,7 @@ DamageCalculator::Val DamageCalculator::swordDamage(Npc& nsrc, Npc& nother) {
   if(Gothic::inst().version().game==2) {
     if(nsrc.isMonster() && tal==TALENT_UNKNOWN) {
       // regular monsters always do critical damage
-      critChance = 0;
+      critChance = -1;
       }
 
     bool invincible = true;


### PR DESCRIPTION
Fix a regression introduced in https://github.com/Try/OpenGothic/commit/b1f1b83b158d681771bfcb2bb1d8882bb4ebc33b. Change from `<` to `<=` in `if(src.hitchance[tal]<=critChance)` accidently made monster damage non critical. 

I took this opportunity to check monsters with a weapon and it seems they only do critical hits as well. If `Npc_SetToFightMode` is used in instance script like for goblins weapon damage is not considered. But skeletons have `EquipItem` instead which has makes damage include weapon damage.