### PR TITLE
Add missing failureTarget trigger for codemaster

### DIFF
--- a/game/game/serialize.h
+++ b/game/game/serialize.h
@@ -32,7 +32,7 @@ class SaveGameHeader;
 class Serialize {
   public:
     enum Version : uint16_t {
-      Current = 48
+      Current = 49
       };
     Serialize(Tempest::ODevice& fout);
     Serialize(Tempest::IDevice&  fin);

--- a/game/world/triggers/codemaster.cpp
+++ b/game/world/triggers/codemaster.cpp
@@ -18,26 +18,25 @@ CodeMaster::CodeMaster(Vob* parent, World &world, const zenkit::VCodeMaster& cm,
   }
 
 void CodeMaster::onTrigger(const TriggerEvent &evt) {
-  for(size_t i=0;i<keys.size();++i) {
-    if(slaves[i]==evt.emitter) {
-      if(!ordered || count==i)
-        keys[i] = true;
-      else if(firstFalseIsFailure) {
-        onFailure();
-        return;
-        }
-      ++count;
+  size_t i = 0;
+  for(i=0;i<keys.size();++i)
+    if(slaves[i]==evt.emitter)
       break;
-      }
+  if(i==keys.size())
+    return;
+  else if(!ordered || count==i)
+    keys[i] = true;
+  else if(firstFalseIsFailure) {
+    onFailure();
+    return;
     }
+  ++count;
   if(count<keys.size())
     return;
-  if(std::find(keys.begin(),keys.end(),false)!=keys.end()) {
-    if(ordered)
-      onFailure();
-    } else {
-      onSuccess();
-    }
+  else if(std::find(keys.begin(),keys.end(),false)==keys.end())
+    onSuccess();
+  else if(ordered)
+    onFailure();
   }
 
 void CodeMaster::save(Serialize& fout) const {

--- a/game/world/triggers/codemaster.h
+++ b/game/world/triggers/codemaster.h
@@ -15,13 +15,15 @@ class CodeMaster : public AbstractTrigger {
     void load(Serialize &fin) override;
 
     void onFailure();
+    void onSuccess();
     void zeroState();
 
     std::vector<bool>        keys;
     std::vector<std::string> slaves;
-    bool                     ordered = false;
+    size_t                   count               = 0;
+    bool                     ordered             = false;
     bool                     firstFalseIsFailure = false;
     std::string              failureTarget;
-    bool                     untriggeredCancels = false;
+    bool                     untriggeredCancels  = false;
   };
 

--- a/game/world/triggers/codemaster.h
+++ b/game/world/triggers/codemaster.h
@@ -20,7 +20,7 @@ class CodeMaster : public AbstractTrigger {
 
     std::vector<bool>        keys;
     std::vector<std::string> slaves;
-    size_t                   count               = 0;
+    uint32_t                 count               = 0;
     bool                     ordered             = false;
     bool                     firstFalseIsFailure = false;
     std::string              failureTarget;


### PR DESCRIPTION
If `ordered=true` and `firstFalseIsFailure=false` then `failureTarget` is triggered if number of codemaster ontrigger events matches the number of slaves and either not all slaves have sent trigger or order is wrong. 

Testcases are both upper rooms at switch riddle location. In the right room e.g. any wrong sequence of three activated switches causes a new spawn of shadow skeleton warriors.