### PR TITLE
Fix npcs not standing up on player interaction

### DIFF
--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -2616,8 +2616,8 @@ bool Npc::startState(ScriptFn id, std::string_view wp, gtime endTime, bool noFin
     return true;
     }
 
-  clearState(noFinalize);
   clearAiQueue();
+  clearState(noFinalize);
   if(!wp.empty())
     hnpc->wp = wp;
 


### PR DESCRIPTION
Praying/Sitting npcs who can't see the player when interacted with are made stand up by their script state end function. In `Npc::startState` aiQueue is cleared after calling the end function so stand up never happens. This is resolved by swapping `clearAiQueue` and `clearState`.