### PR TITLE
Slow save games - Solution proposal

### DIFF
--- a/game/game/serialize.cpp
+++ b/game/game/serialize.cpp
@@ -96,7 +96,7 @@ void Serialize::closeEntry() {
   if(entryBuf.empty())
     return;
 
-  mz_uint level  = entryBuf.size()>256 ? MZ_BEST_COMPRESSION : MZ_NO_COMPRESSION;
+  mz_uint level  = entryBuf.size()>256 ? MZ_BEST_SPEED : MZ_NO_COMPRESSION;
   mz_bool status = mz_zip_writer_add_mem(&impl, entryName.c_str(), entryBuf.data(), entryBuf.size(), level);
   entryBuf .clear();
   entryName.clear();

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -179,7 +179,6 @@ Npc::~Npc(){
   }
 
 void Npc::save(Serialize &fout, size_t id) {
-  fout.setEntry("worlds/",fout.worldName(),"/npc/",id,"/data");
   fout.write(*hnpc);
   fout.write(body,head,vHead,vTeeth,bdColor,vColor,bdFatness);
   fout.write(x,y,z,angle,sz);
@@ -216,16 +215,20 @@ void Npc::save(Serialize &fout, size_t id) {
   Vec3 phyPos = physic.position();
   fout.write(phyPos);
 
-  fout.setEntry("worlds/",fout.worldName(),"/npc/",id,"/visual");
   visual.save(fout,*this);
 
-  fout.setEntry("worlds/",fout.worldName(),"/npc/",id,"/inventory");
-  if(!invent.isEmpty() || id==size_t(-1))
+  bool hasInventory = false;
+  if(!invent.isEmpty() || id==size_t(-1)) {
+    hasInventory = true;
+    fout.write(hasInventory);
     invent.save(fout);
+    }
+    else {
+    fout.write(hasInventory);
+    }
   }
 
 void Npc::load(Serialize &fin, size_t id) {
-  fin.setEntry("worlds/",fin.worldName(),"/npc/",id,"/data");
 
   hnpc = std::make_shared<zenkit::INpc>();
   hnpc->user_ptr        = this;
@@ -281,14 +284,16 @@ void Npc::load(Serialize &fin, size_t id) {
   Vec3 phyPos = {};
   fin.read(phyPos);
 
-  fin.setEntry("worlds/",fin.worldName(),"/npc/",id,"/visual");
   visual.load(fin,*this);
   physic.setPosition(phyPos);
 
   setVisualBody(vHead,vTeeth,vColor,bdColor,body,head);
 
-  if(fin.setEntry("worlds/",fin.worldName(),"/npc/",id,"/inventory"))
+  bool hasInventory = false;
+  fin.read(hasInventory);
+  if(hasInventory) {
     invent.load(fin,*this);
+    }
 
   // post-alignment
   updateTransform();

--- a/game/world/objects/vob.cpp
+++ b/game/world/objects/vob.cpp
@@ -259,13 +259,10 @@ void Vob::loadVobTree(Serialize& fin) {
   }
 
 void Vob::save(Serialize& fout) const {
-  fout.setEntry("worlds/",fout.worldName(),"/mobsi/",vobObjectID,"/data");
   fout.write(uint8_t(vobType),pos,local);
   }
 
 void Vob::load(Serialize& fin) {
-  if(!fin.setEntry("worlds/",fin.worldName(),"/mobsi/",vobObjectID,"/data"))
-    return;
   auto type = uint8_t(vobType);
   uint8_t savValue;
   fin.read(savValue,pos,local);

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -75,7 +75,9 @@ void WorldObjects::load(Serialize &fin) {
   itemArr.clear();
   items.clear();
 
-  uint32_t sz = fin.directorySize("worlds/",fin.worldName(),"/npc/");
+  fin.setEntry("worlds/",fin.worldName(),"/npcs");
+  uint32_t sz = 0;
+  fin.read(sz);
   npcArr.resize(sz);
   for(size_t i=0; i<sz; ++i)
     npcArr[i] = std::make_unique<Npc>(owner,size_t(-1),"");
@@ -91,6 +93,7 @@ void WorldObjects::load(Serialize &fin) {
     items.add(itemArr.back().get());
     }
 
+  fin.setEntry("worlds/",fin.worldName(),"/mobsi");
   for(auto& i:rootVobs)
     i->loadVobTree(fin);
 
@@ -120,6 +123,8 @@ void WorldObjects::save(Serialize &fout) {
   fout.setEntry("worlds/",fout.worldName(),"/version");
   fout.write(Serialize::Version::Current);
 
+  fout.setEntry("worlds/",fout.worldName(),"/npcs");
+  fout.write((uint32_t)npcArr.size());
   for(size_t i=0; i<npcArr.size(); ++i) {
     npcArr[i]->save(fout,i);
     }


### PR DESCRIPTION
I found a few possibilities to speed up the save game process significantly.

In the serialize class, I changed the compression level from `Best Compression` to `Best Speed`. Files sizes are roughly the same, but without the attempts to perfect compression, the saving is a lot faster.

I also reduced the number of files created by collecting all npc and mob data in a respective single file. See npc and vob cpp.

### !! This breaks load/save game compatibility to previous versions of course !!

To me my changes look innocent, but I might have introduced bugs. 🐞

### Further thoughts
- interactive objects still end up as single files.. but they are way less, so don't have much impact in this world. In theory they could need the same improvement.
- The preview image is still a 4MB full screen image, which is unnecessary. (I've seen new commits regarding save game image size?)
