### PR TITLE
Fix non-closing gates in Gothic 1

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1652,8 +1652,8 @@ int GameScript::wld_getmobstate(std::shared_ptr<zenkit::INpc> npcRef, std::strin
     return -1;
     }
 
-  auto mob = npc->detectedMob();
-  if(mob==nullptr || mob->schemeName()!=scheme) {
+  auto mob = world().availableMob(*npc,scheme);
+  if(mob==nullptr) {
     return -1;
     }
 


### PR DESCRIPTION
At start of chapter 4 gate guards change daily routine to `TA_GuardWheelClosed`. Then in function `ZS_GuardWheelClosed()` the state of the next mob with matching scheme name is checked.

```
	if (Wld_GetMobState	(self, 	"VWHEEL") == 0)						// Tor offen?
	{
		PrintDebugNpc 	(PD_TA_CHECK,	"...Tor offen!");	
		AI_UseMob		(self, 	"VWHEEL", 1);						// ...dann wieder zumachen!
		AI_UseMob		(self, 	"VWHEEL", -1);                      //und vom Mobsi abmelden
		AI_AlignToWP	(self);
	};
```
`Wld_GetMobState` internally checks only for mobs the npc has collided with while moving which makes the check fail. This is replaced by `World::findInteractive`, a search for all mobsis in close range. The default range has been increased slightly, otherwise only one gate could be opened.

Script comment for  `Wld_GetMobState` says it's looking for the next mob that matches the scheme name. This would be in line with the change.

Script also has a command to close the inner gate but this fails in vanilla. In OG with this PR it fails because the mob can't be found. A Problem could be that the responsible npc `GRD_280_Gardist` has wrong `id=230` but `GRD_230_Gardist` is the npc closing the main gate.

For testing you can use `insert sh` and use the first chapter 4 option.

Fixes https://github.com/Try/OpenGothic/issues/628