### PR TITLE
`changeAttribute`: don't reduce hitpoints of immortal npcs

### DIFF
--- a/game/game/damagecalculator.cpp
+++ b/game/game/damagecalculator.cpp
@@ -27,8 +27,6 @@ DamageCalculator::Val DamageCalculator::damageValue(Npc& src, Npc& other, const 
 
   if(ret.hasHit && !ret.invincible && Gothic::inst().version().game==2)
     ret.value = std::max<int32_t>(ret.value,MinDamage);
-  if(other.isImmortal())
-    ret.value = 0;
   return ret;
   }
 
@@ -44,7 +42,7 @@ DamageCalculator::Val DamageCalculator::damageFall(Npc& npc, float speed) {
   int32_t prot        = npc.protection(::PROT_FALL);
 
   Val ret;
-  ret.invincible = (prot<0 || npc.isImmortal());
+  ret.invincible = (prot<0);
   ret.value      = int32_t(dmgPerMeter*(height-h0)/100.f - float(prot));
   if(ret.value<=0 || ret.invincible) {
     ret.value = 0;

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1154,8 +1154,12 @@ int32_t Npc::attribute(Attribute a) const {
 void Npc::changeAttribute(Attribute a, int32_t val, bool allowUnconscious) {
   if(a>=ATR_MAX || val==0)
     return;
-  if(isPlayer() && Gothic::inst().isGodMode() && val<0 && a==ATR_HITPOINTS)
-    return;
+  if(val<0 && a==ATR_HITPOINTS) {
+    if(isPlayer() && Gothic::inst().isGodMode())
+      return;
+    if(isImmortal())
+      return;
+    }
 
   hnpc->attribute[a]+=val;
   if(hnpc->attribute[a]<0)


### PR DESCRIPTION
The orc in the new mine who makes the Ulu-Mulu would have his health reduced instead of increased when taking his medicine. This is due to a script bug giving him the wrong guild and making this check fail.
```
	if (C_NpcIsOrc(self))
	{
		self.attribute[ATR_HITPOINTS] = self.attribute[ATR_HITPOINTS_MAX];
	}
	else
	{
		Npc_ChangeAttribute	(self,ATR_HITPOINTS,-self.attribute[ATR_HITPOINTS_MAX]);
	};
```
 In vanilla death is prevented by immortality. OG checks immortality only when damage is dealt. This check is now moved to `Npc::changeAttribute` like it was done for godmode.