### PR TITLE
Add `goto vob` and `goto camera` marvin commands

### DIFF
--- a/game/marvin.cpp
+++ b/game/marvin.cpp
@@ -314,13 +314,13 @@ bool Marvin::exec(std::string_view v) {
       auto   c      = Gothic::inst().camera();
       if(world==nullptr || c==nullptr || player==nullptr)
         return false;
-      uint32_t n = 1;
+      size_t n = 1;
       if(!ret.argv[1].empty()) {
         auto err = std::from_chars(ret.argv[1].data(),ret.argv[1].data()+ret.argv[1].size(),n).ec;
         if(err!=std::errc())
           return false;
         }
-      return goToVob(*world,*player,*c,ret.argv[0],n);
+      return goToVob(*world,*player,*c,ret.argv[0],--n);
       }
     case C_GoToCamera: {
       auto c      = Gothic::inst().camera();
@@ -473,16 +473,16 @@ bool Marvin::setTime(World& world, std::string_view hh, std::string_view mm) {
   return true;
   }
 
-bool Marvin::goToVob(World& world, Npc& player, Camera& c, std::string_view name, uint32_t nr) {
+bool Marvin::goToVob(World& world, Npc& player, Camera& c, std::string_view name, size_t n) {
   auto&  sc = world.script();
   size_t id = sc.findSymbolIndex(name);
   if(id==size_t(-1))
     return false;
 
   Tempest::Vec3 pos;
-  if(auto npc = world.findNpcByInstance(id,nr))
+  if(auto npc = world.findNpcByInstance(id,n))
      pos = npc->position();
-  else if(auto it = world.findItemByInstance(id,nr))
+  else if(auto it = world.findItemByInstance(id,n))
      pos = it->position();
   else
     return false;

--- a/game/marvin.cpp
+++ b/game/marvin.cpp
@@ -6,6 +6,7 @@
 
 #include "utils/string_frm.h"
 #include "world/objects/npc.h"
+#include "world/objects/item.h"
 #include "world/triggers/abstracttrigger.h"
 #include "camera.h"
 #include "gothic.h"
@@ -118,6 +119,8 @@ Marvin::Marvin() {
     {"aigoto %s",                  C_AiGoTo},
     {"goto waypoint %s",           C_GoToWayPoint},
     {"goto pos %f %f %f",          C_GoToPos},
+    {"goto vob %c %d",             C_GoToVob},
+    {"goto camera",                C_GoToCamera},
 
 
     {"camera autoswitch",          C_CamAutoswitch},
@@ -305,6 +308,31 @@ bool Marvin::exec(std::string_view v) {
       Gothic::inst().camera()->reset(player);
       return true;
       }
+    case C_GoToVob: {
+      World* world  = Gothic::inst().world();
+      Npc*   player = Gothic::inst().player();
+      auto   c      = Gothic::inst().camera();
+      if(world==nullptr || c==nullptr || player==nullptr)
+        return false;
+      uint32_t n = 1;
+      if(!ret.argv[1].empty()) {
+        auto err = std::from_chars(ret.argv[1].data(),ret.argv[1].data()+ret.argv[1].size(),n).ec;
+        if(err!=std::errc())
+          return false;
+        }
+      return goToVob(*world,*player,*c,ret.argv[0],n);
+      }
+    case C_GoToCamera: {
+      auto c      = Gothic::inst().camera();
+      Npc* player = Gothic::inst().player();
+      if(c==nullptr || player==nullptr)
+        return false;
+      auto pos = c->destPosition();
+      player->setPosition(pos.x,pos.y,pos.z);
+      player->updateTransform();
+      c->reset();
+      return true;
+      }
     case C_ToggleFrame:{
       Gothic::inst().setFRate(!Gothic::inst().doFrate());
       return true;
@@ -442,6 +470,28 @@ bool Marvin::setTime(World& world, std::string_view hh, std::string_view mm) {
     return false;
 
   world.setDayTime(hv,mv);
+  return true;
+  }
+
+bool Marvin::goToVob(World& world, Npc& player, Camera& c, std::string_view name, uint32_t nr) {
+  auto&  sc = world.script();
+  size_t id = sc.findSymbolIndex(name);
+  if(id==size_t(-1))
+    return false;
+
+  Tempest::Vec3 pos;
+  if(auto npc = world.findNpcByInstance(id,nr))
+     pos = npc->position();
+  else if(auto it = world.findItemByInstance(id,nr))
+     pos = it->position();
+  else
+    return false;
+
+  if(!player.setInteraction(nullptr))
+    return false;
+  player.setPosition(pos);
+  player.updateTransform();
+  c.reset();
   return true;
   }
 

--- a/game/marvin.h
+++ b/game/marvin.h
@@ -43,7 +43,9 @@ class Marvin {
 
       C_AiGoTo,
       C_GoToPos,
+      C_GoToVob,
       C_GoToWayPoint,
+      C_GoToCamera,
 
       C_SetTime,
 
@@ -77,6 +79,7 @@ class Marvin {
     bool   addItemOrNpcBySymbolName(World* world, std::string_view name, const Tempest::Vec3& at);
     bool   printVariable           (World* world, std::string_view name);
     bool   setTime                 (World& world, std::string_view hh, std::string_view mm);
+    bool   goToVob                 (World& world, Npc& player, Camera& c, std::string_view name, uint32_t nr);
 
     std::vector<Cmd> cmd;
   };

--- a/game/marvin.h
+++ b/game/marvin.h
@@ -79,7 +79,7 @@ class Marvin {
     bool   addItemOrNpcBySymbolName(World* world, std::string_view name, const Tempest::Vec3& at);
     bool   printVariable           (World* world, std::string_view name);
     bool   setTime                 (World& world, std::string_view hh, std::string_view mm);
-    bool   goToVob                 (World& world, Npc& player, Camera& c, std::string_view name, uint32_t nr);
+    bool   goToVob                 (World& world, Npc& player, Camera& c, std::string_view name, size_t n);
 
     std::vector<Cmd> cmd;
   };

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -291,11 +291,11 @@ std::unique_ptr<Npc> World::takeHero() {
   return wobj.takeNpc(npcPlayer);
   }
 
-Item* World::findItemByInstance(size_t instance, uint32_t n) {
+Item* World::findItemByInstance(size_t instance, size_t n) {
   return wobj.findItemByInstance(instance,n);
   }
 
-Npc *World::findNpcByInstance(size_t instance, uint32_t n) {
+Npc *World::findNpcByInstance(size_t instance, size_t n) {
   return wobj.findNpcByInstance(instance,n);
   }
 

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -291,8 +291,12 @@ std::unique_ptr<Npc> World::takeHero() {
   return wobj.takeNpc(npcPlayer);
   }
 
-Npc *World::findNpcByInstance(size_t instance) {
-  return wobj.findNpcByInstance(instance);
+Item* World::findItemByInstance(size_t instance, uint32_t n) {
+  return wobj.findItemByInstance(instance,n);
+  }
+
+Npc *World::findNpcByInstance(size_t instance, uint32_t n) {
+  return wobj.findNpcByInstance(instance,n);
   }
 
 std::string_view World::roomAt(const Tempest::Vec3& p) {

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -104,8 +104,8 @@ class World final {
 
     auto                 takeHero() -> std::unique_ptr<Npc>;
     Npc*                 player() const { return npcPlayer; }
-    Npc*                 findNpcByInstance(size_t instance, uint32_t n = 1);
-    Item*                findItemByInstance(size_t instance, uint32_t n = 1);
+    Npc*                 findNpcByInstance(size_t instance, size_t n = 0);
+    Item*                findItemByInstance(size_t instance, size_t n = 0);
     std::string_view     roomAt(const Tempest::Vec3& arr);
 
     void                 scaleTime(uint64_t& dt);

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -104,7 +104,8 @@ class World final {
 
     auto                 takeHero() -> std::unique_ptr<Npc>;
     Npc*                 player() const { return npcPlayer; }
-    Npc*                 findNpcByInstance(size_t instance);
+    Npc*                 findNpcByInstance(size_t instance, uint32_t n = 1);
+    Item*                findItemByInstance(size_t instance, uint32_t n = 1);
     std::string_view     roomAt(const Tempest::Vec3& arr);
 
     void                 scaleTime(uint64_t& dt);

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -452,10 +452,29 @@ Npc *WorldObjects::findHero() {
   return nullptr;
   }
 
-Npc *WorldObjects::findNpcByInstance(size_t instance) {
-  for(auto& i:npcArr)
-    if(i->handle().symbol_index()==instance)
-      return i.get();
+Npc *WorldObjects::findNpcByInstance(size_t instance, uint32_t n) {
+  if(n==0)
+    return nullptr;
+  for(auto& i:npcArr) {
+    if(i->handle().symbol_index()==instance) {
+      if(n==1)
+        return i.get();
+      --n;
+      }
+    }
+  return nullptr;
+  }
+
+Item* WorldObjects::findItemByInstance(size_t instance, uint32_t n) {
+  if(n==0)
+    return nullptr;
+  for(auto& i:itemArr) {
+    if(i->handle().symbol_index()==instance) {
+      if(n==1)
+        return i.get();
+      --n;
+      }
+    }
   return nullptr;
   }
 

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -452,12 +452,10 @@ Npc *WorldObjects::findHero() {
   return nullptr;
   }
 
-Npc *WorldObjects::findNpcByInstance(size_t instance, uint32_t n) {
-  if(n==0)
-    return nullptr;
+Npc *WorldObjects::findNpcByInstance(size_t instance, size_t n) {
   for(auto& i:npcArr) {
     if(i->handle().symbol_index()==instance) {
-      if(n==1)
+      if(n==0)
         return i.get();
       --n;
       }
@@ -465,12 +463,11 @@ Npc *WorldObjects::findNpcByInstance(size_t instance, uint32_t n) {
   return nullptr;
   }
 
-Item* WorldObjects::findItemByInstance(size_t instance, uint32_t n) {
-  if(n==0)
-    return nullptr;
+Item* WorldObjects::findItemByInstance(size_t instance, size_t n) {
+
   for(auto& i:itemArr) {
     if(i->handle().symbol_index()==instance) {
-      if(n==1)
+      if(n==0)
         return i.get();
       --n;
       }

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -60,8 +60,8 @@ class WorldObjects final {
 
     bool           isTargeted(Npc& npc);
     Npc*           findHero();
-    Npc*           findNpcByInstance(size_t instance, uint32_t n = 1);
-    Item*          findItemByInstance(size_t instance, uint32_t n = 1);
+    Npc*           findNpcByInstance(size_t instance, size_t n = 0);
+    Item*          findItemByInstance(size_t instance, size_t n = 0);
     void           detectNpcNear(const std::function<void(Npc&)>& f);
     void           detectNpc (const float x, const float y, const float z, const float r, const std::function<void(Npc&)>&  f);
     void           detectItem(const float x, const float y, const float z, const float r, const std::function<void(Item&)>& f);

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -60,7 +60,8 @@ class WorldObjects final {
 
     bool           isTargeted(Npc& npc);
     Npc*           findHero();
-    Npc*           findNpcByInstance(size_t instance);
+    Npc*           findNpcByInstance(size_t instance, uint32_t n = 1);
+    Item*          findItemByInstance(size_t instance, uint32_t n = 1);
     void           detectNpcNear(const std::function<void(Npc&)>& f);
     void           detectNpc (const float x, const float y, const float z, const float r, const std::function<void(Npc&)>&  f);
     void           detectItem(const float x, const float y, const float z, const float r, const std::function<void(Item&)>& f);


### PR DESCRIPTION
`goto vob` teleports the player to a vob that matches the given name.  A index number can be added to teleport to the n_th vob in case there exist multiple, often the case for items. Only npcs and items are tested for now but in vanilla it works for all kind of vobs.

`goto camera` teleports the player to the camera position. I found this came in handy when I wanted to observe a npc without percs being triggered but then move quickly to the scene to look what would happen.