### PR TITLE
Remove obsolete code

### DIFF
--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -168,9 +168,6 @@ Npc::Npc(World &owner, size_t instance, std::string_view waypoint)
 
   owner.script().initializeInstanceNpc(hnpc, instance);
   hnpc->wp       = std::string(waypoint);
-  if(hnpc->attribute[ATR_HITPOINTS]<=1 && hnpc->attribute[ATR_HITPOINTSMAX]<=1) {
-    onNoHealth(true,HS_NoSound);
-    }
   }
 
 Npc::~Npc(){
@@ -519,13 +516,6 @@ bool Npc::checkHealth(bool onChange,bool allowUnconscious) {
 
   const int minHp = isMonster() ? 0 : 1;
   if(hnpc->attribute[ATR_HITPOINTS]<=minHp) {
-    if(hnpc->attribute[ATR_HITPOINTSMAX]<=1) {
-      size_t fdead=owner.script().findSymbolIndex("ZS_Dead");
-      startState(fdead,"");
-      physic.setEnable(false);
-      return false;
-      }
-
     if(currentOther==nullptr ||
        !allowUnconscious ||
        owner.script().personAttitude(*this,*currentOther)==ATT_HOSTILE ||

--- a/game/world/triggers/abstracttrigger.cpp
+++ b/game/world/triggers/abstracttrigger.cpp
@@ -152,18 +152,6 @@ void AbstractTrigger::onIntersect(Npc& n) {
 void AbstractTrigger::tick(uint64_t) {
   }
 
-bool AbstractTrigger::hasVolume() const {
-  if( bboxSize.x>0 &&
-      bboxSize.y>0 &&
-      bboxSize.z>0 )
-    return true;
-  return false;
-  }
-
-bool AbstractTrigger::checkPos(const Tempest::Vec3& pos) const {
-  return boxNpc.checkPos(pos);
-  }
-
 void AbstractTrigger::save(Serialize& fout) const {
   Vob::save(fout);
   boxNpc.save(fout);

--- a/game/world/triggers/abstracttrigger.h
+++ b/game/world/triggers/abstracttrigger.h
@@ -57,9 +57,6 @@ class AbstractTrigger : public Vob {
     virtual void                 onIntersect(Npc& n);
     virtual void                 tick(uint64_t dt);
 
-    virtual bool                 hasVolume() const;
-    bool                         checkPos(const Tempest::Vec3& pos) const;
-
     void                         save(Serialize& fout) const override;
     void                         load(Serialize &fin) override;
 

--- a/game/world/triggers/movetrigger.cpp
+++ b/game/world/triggers/movetrigger.cpp
@@ -82,10 +82,6 @@ void MoveTrigger::load(Serialize& fin) {
     }
   }
 
-bool MoveTrigger::hasVolume() const {
-  return false;
-  }
-
 void MoveTrigger::setView(MeshObjects::Mesh &&m) {
   view = std::move(m);
   }

--- a/game/world/triggers/movetrigger.h
+++ b/game/world/triggers/movetrigger.h
@@ -17,7 +17,6 @@ class MoveTrigger : public AbstractTrigger {
     void onUntrigger(const TriggerEvent& evt) override;
     void onGotoMsg(const TriggerEvent& evt) override;
 
-    bool hasVolume() const override;
     void tick(uint64_t dt) override;
 
   private:

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -485,8 +485,6 @@ void WorldObjects::detectItem(const float x, const float y, const float z,
   }
 
 void WorldObjects::addTrigger(AbstractTrigger* tg) {
-  if(tg->hasVolume())
-    triggersZn.emplace_back(tg);
   triggers.emplace_back(tg);
   }
 

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -171,7 +171,6 @@ class WorldObjects final {
     std::vector<Npc*>                  npcNear;
 
     std::vector<AbstractTrigger*>      triggers;
-    std::vector<AbstractTrigger*>      triggersZn;
     std::vector<AbstractTrigger*>      triggersTk;
     std::vector<AbstractTrigger*>      triggersDef;
     std::vector<PerceptionMsg>         sndPerc;


### PR DESCRIPTION
When first entering Valley of Mines npc like militita Den are still alive and have 1hp max health. They are killed by script when the dragon attack video sequence is triggered. The npc code is probably some remains before trigger were added to make sure these npc are in fact dead.

Trigger code is only used for adding triggers to `triggersZn` but this vector is never used later again. Looks like a leftover when trigger collision was moved to collision zone object `collisionZn`.