### PR TITLE
Trigger improvements

### DIFF
--- a/game/world/triggers/abstracttrigger.cpp
+++ b/game/world/triggers/abstracttrigger.cpp
@@ -82,7 +82,7 @@ void AbstractTrigger::processEvent(const TriggerEvent& evt) {
   if(fireDelay>0) {
     TriggerEvent ex(evt.target, evt.emitter, world.tickCount() + fireDelay, evt.type);
     delayedEvent = std::move(ex);
-    world.addDefTrigger(*this);
+    world.enableDefTrigger(*this);
     return;
     }
   implProcessEvent(evt);
@@ -173,8 +173,11 @@ void AbstractTrigger::load(Serialize& fin) {
   fin.read(emitCount,disabled);
   fin.read(emitTimeLast);
 
-  if(fin.version()>=47)
+  if(fin.version()>=47) {
     delayedEvent.load(fin);
+    if(hasDelayedEvents())
+      world.enableDefTrigger(*this);
+    }
   if(fin.version()>=48) {
     fin.read(ticksEnabled);
     if(ticksEnabled)

--- a/game/world/triggers/abstracttrigger.cpp
+++ b/game/world/triggers/abstracttrigger.cpp
@@ -30,12 +30,16 @@ AbstractTrigger::AbstractTrigger(Vob* parent, World &world, const zenkit::Virtua
      data.type == VirtualObjectType::oCTriggerScript      || data.type == VirtualObjectType::zCMover ||
      data.type == VirtualObjectType::oCTriggerChangeLevel || data.type == VirtualObjectType::oCCSTrigger) {
     auto& trigger = reinterpret_cast<const zenkit::VTrigger&>(data);
-    fireDelay          = uint64_t(trigger.fire_delay_sec*1000.f);
-    retriggerDelay     = uint64_t(trigger.retrigger_delay_sec*1000.f);
-    maxActivationCount = (data.type==VirtualObjectType::zCMover && trigger.max_activation_count!=0) ? uint32_t(-1) : uint32_t(trigger.max_activation_count);
+    if(data.type == VirtualObjectType::zCMover) {
+      maxActivationCount = (trigger.max_activation_count==0) ? 0 : uint32_t(-1);
+      } else {
+      fireDelay          = uint64_t(trigger.fire_delay_sec*1000.f);
+      retriggerDelay     = uint64_t(trigger.retrigger_delay_sec*1000.f);
+      maxActivationCount = uint32_t(trigger.max_activation_count);
+      sendUntrigger      = trigger.send_untrigger;
+      }
     target             = trigger.target;
     disabled           = !trigger.start_enabled;
-    sendUntrigger      = trigger.send_untrigger;
     reactToOnTrigger   = trigger.react_to_on_trigger;
     reactToOnTouch     = trigger.react_to_on_touch;
     respondToNpc       = trigger.respond_to_npc;
@@ -78,6 +82,7 @@ void AbstractTrigger::processEvent(const TriggerEvent& evt) {
   if(fireDelay>0) {
     TriggerEvent ex(evt.target, evt.emitter, world.tickCount() + fireDelay, evt.type);
     delayedEvent = std::move(ex);
+    world.addDefTrigger(*this);
     return;
     }
   implProcessEvent(evt);
@@ -136,15 +141,15 @@ void AbstractTrigger::moveEvent() {
   }
 
 void AbstractTrigger::onIntersect(Npc& n) {
+  if(vobType==zenkit::VirtualObjectType::zCMover || vobType==zenkit::VirtualObjectType::zCCSCamera)
+    return;
   if((n.isPlayer() ? !respondToPlayer : !respondToNpc) || !reactToOnTouch)
     return;
-
   if(!isEnabled())
     return;
-
-  if(boxNpc.intersections().size()==1) {
+  if(boxNpc.intersections().size()>0) {
     // enableTicks();
-    TriggerEvent e("","",TriggerEvent::T_Touch);
+    TriggerEvent e(target,vobName,TriggerEvent::T_Touch);
     processEvent(e);
     }
   }
@@ -204,7 +209,7 @@ void AbstractTrigger::Cb::onCollide(DynamicWorld::BulletBody& b) {
     return;
   if(b.isSpell())
     return;
-  TriggerEvent ex(tg->vobName,tg->vobName,tg->world.tickCount(),TriggerEvent::T_Touch);
+  TriggerEvent ex(tg->target,tg->vobName,tg->world.tickCount(),TriggerEvent::T_Touch);
   tg->processEvent(ex);
   }
 

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -507,6 +507,10 @@ void World::execTriggerEvent(const TriggerEvent& e) {
     }
   }
 
+void World::addDefTrigger(AbstractTrigger& t) {
+  wobj.addDefTrigger(t);
+  }
+
 void World::enableTicks(AbstractTrigger& t) {
   wobj.enableTicks(t);
   }

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -507,8 +507,8 @@ void World::execTriggerEvent(const TriggerEvent& e) {
     }
   }
 
-void World::addDefTrigger(AbstractTrigger& t) {
-  wobj.addDefTrigger(t);
+void World::enableDefTrigger(AbstractTrigger& t) {
+  wobj.enableDefTrigger(t);
   }
 
 void World::enableTicks(AbstractTrigger& t) {

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -123,6 +123,7 @@ class World final {
     void                 triggerEvent(const TriggerEvent& e);
     void                 triggerChangeWorld(std::string_view world, std::string_view wayPoint);
     void                 execTriggerEvent(const TriggerEvent& e);
+    void                 addDefTrigger(AbstractTrigger& t);
     void                 enableTicks (AbstractTrigger& t);
     void                 disableTicks(AbstractTrigger& t);
     void                 setCurrentCs(CsCamera* cs);

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -123,7 +123,7 @@ class World final {
     void                 triggerEvent(const TriggerEvent& e);
     void                 triggerChangeWorld(std::string_view world, std::string_view wayPoint);
     void                 execTriggerEvent(const TriggerEvent& e);
-    void                 addDefTrigger(AbstractTrigger& t);
+    void                 enableDefTrigger(AbstractTrigger& t);
     void                 enableTicks (AbstractTrigger& t);
     void                 disableTicks(AbstractTrigger& t);
     void                 setCurrentCs(CsCamera* cs);

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -94,10 +94,6 @@ void WorldObjects::load(Serialize &fin) {
   for(auto& i:rootVobs)
     i->loadVobTree(fin);
 
-  for(auto& i:triggers)
-    if(i->hasDelayedEvents())
-      triggersDef.push_back(i);
-
   fin.setEntry("worlds/",fin.worldName(),"/triggerEvents");
   fin.read(sz);
   triggerEvents.resize(sz);
@@ -499,7 +495,10 @@ void WorldObjects::addTrigger(AbstractTrigger* tg) {
   triggers.emplace_back(tg);
   }
 
-void WorldObjects::addDefTrigger(AbstractTrigger& t) {
+void WorldObjects::enableDefTrigger(AbstractTrigger& t) {
+  for(auto& i:triggersDef)
+    if(i==&t)
+      return;
   triggersDef.push_back(&t);
   }
 

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -400,11 +400,7 @@ bool WorldObjects::execTriggerEvent(const TriggerEvent& e) {
     auto& t = *i;
     if(t.name()!=e.target)
       continue; // NOTE: trigger name is not unique - more then one trigger can be activated
-
-    const bool hadDelayedEvt = t.hasDelayedEvents();
     t.processEvent(e);
-    if(!hadDelayedEvt && t.hasDelayedEvents())
-      triggersDef.push_back(&t);
     emitted = true;
     }
 
@@ -501,6 +497,10 @@ void WorldObjects::detectItem(const float x, const float y, const float z,
 
 void WorldObjects::addTrigger(AbstractTrigger* tg) {
   triggers.emplace_back(tg);
+  }
+
+void WorldObjects::addDefTrigger(AbstractTrigger& t) {
+  triggersDef.push_back(&t);
   }
 
 bool WorldObjects::triggerOnStart(bool firstTime) {

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -83,7 +83,7 @@ class WorldObjects final {
     CsCamera*      currentCs() const;
 
     void           addTrigger(AbstractTrigger* trigger);
-    void           addDefTrigger(AbstractTrigger& trigger);
+    void           enableDefTrigger(AbstractTrigger& trigger);
     void           triggerEvent(const TriggerEvent& e);
     bool           triggerOnStart(bool firstTime);
     void           execDelayedEvents();

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -83,6 +83,7 @@ class WorldObjects final {
     CsCamera*      currentCs() const;
 
     void           addTrigger(AbstractTrigger* trigger);
+    void           addDefTrigger(AbstractTrigger& trigger);
     void           triggerEvent(const TriggerEvent& e);
     bool           triggerOnStart(bool firstTime);
     void           execDelayedEvents();


### PR DESCRIPTION
This aims at fixing some more trigger quirks.

Apparently movers ignore `fireDelay` and `sendUntrigger`. In https://github.com/Try/OpenGothic/discussions/622 issues13.1 the stone gate opens immediately instead of respecting delay and the metal gate doesn't have `sendUntrigger` set to true, blocking it from opening. I added `retriggerDelay` here  as well without testing.

Same goes for collision. Part of code in https://github.com/Try/OpenGothic/pull/635 suggests movers can't have it and I confirmed it by testing. CsCamera behave the same way. In sleeper temple are some that could be wrongly triggered by normal walking.
I changed the test for number of npcs in a trigger zone to be any positive number instead of exactly one. There was a case where a number of skeletons following the player would prevent the trigger.

In another case a trigger activated by intersection had a `fireDelay`. Because it was not called by `WorldObjects::execTriggerEvent` it did not work. This made it necessary to move the call for population of `triggersDef` object inside `AbstractTrigger` class.

