### PR TITLE
Align npcs to their freepoint once it's reached

### DIFF
--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1370,8 +1370,11 @@ bool Npc::implGoTo(uint64_t dt, float destDist) {
         finished = false;
         }
       }
-    if(finished)
+    if(finished) {
+      if(go2.flag==Npc::GT_NextFp && implTurnTo(go2.wp->dirX,go2.wp->dirZ,false,dt))
+        return true;
       clearGoTo();
+      }
     } else {
     if(setGoToLadder()) {
       mvAlgo.tick(dt);

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -464,7 +464,6 @@ Npc *WorldObjects::findNpcByInstance(size_t instance, size_t n) {
   }
 
 Item* WorldObjects::findItemByInstance(size_t instance, size_t n) {
-
   for(auto& i:itemArr) {
     if(i->handle().symbol_index()==instance) {
       if(n==0)


### PR DESCRIPTION
Basically the code is copied from `AI_AlignToWp`. I left out the non-zero check for readability because it's checked later again down the function chain.
Test npc: `goto vob GUR_1208_BaalCadar`.

Removed empty line accidentally made from the gotoVob PR. 

Fixes https://github.com/Try/OpenGothic/issues/640