### PR TITLE
Don't use a time limit for non-daily routine states

### DIFF
--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -2245,7 +2245,7 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
         }
       break;
     case AI_StartState:
-      if(startState(act.func,act.s0,aiState.eTime,act.i0==0)) {
+      if(startState(act.func,act.s0,gtime::endOfTime(),act.i0==0)) {
         setOther(act.target);
         setVictum(act.victum);
         }
@@ -2699,11 +2699,9 @@ void Npc::tickRoutine() {
         loop = owner.version().hasZSStateLoop() ? 1 : 0;
         }
 
-      if(aiState.eTime<=owner.time()) {
-        if(!isTalk()) {
-          loop = LOOP_END; // have to hack ZS_Talk bugs
-          }
-        }
+      if(aiState.eTime<=owner.time())
+        loop = LOOP_END;
+
       if(loop!=LOOP_CONTINUE) {
         clearState(false);
         currentOther  = nullptr;

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -2245,6 +2245,7 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
         }
       break;
     case AI_StartState:
+      // only daily routine states have a scheduled end time
       if(startState(act.func,act.s0,gtime::endOfTime(),act.i0==0)) {
         setOther(act.target);
         setVictum(act.victum);


### PR DESCRIPTION
If a new state is started the end time is not set to infinite but the current daily routine end time is kept instead. So if a npc is fighting but a new daily routine begins the npc would quit the fight and go home. There's already code that excludes `zs_talk` from early ending.

This has been changed in https://github.com/Try/OpenGothic/commit/7af7f0ce28f53532d5fab29e0524e73f8556bedc to avoid daily routines breaking. In my testing everything worked correctly with the pr change, likely code change over time made daily routines  more robust. 