### PR TITLE
Allow exit from load menu after trying to load empty save

### DIFF
--- a/game/ui/gamemenu.cpp
+++ b/game/ui/gamemenu.cpp
@@ -5,8 +5,6 @@
 #include <Tempest/TextCodec>
 #include <Tempest/Dialog>
 
-#include <format>
-
 #include "utils/string_frm.h"
 #include "world/objects/npc.h"
 #include "world/world.h"
@@ -919,10 +917,10 @@ bool GameMenu::execLoadGame(const GameMenu::Item &item) {
   if(id==size_t(-1))
     return false;
 
-  const std::string fileName = std::format("save_slot_{}.sav",int(id));
-  if(!FileUtil::exists(TextCodec::toUtf16(fileName)))
+  string_frm fname("save_slot_",int(id),".sav");
+  if(!FileUtil::exists(TextCodec::toUtf16(fname.c_str())))
     return false;
-  Gothic::inst().load(fileName);
+  Gothic::inst().load(fname);
   return true;
   }
 

--- a/game/ui/gamemenu.cpp
+++ b/game/ui/gamemenu.cpp
@@ -5,6 +5,8 @@
 #include <Tempest/TextCodec>
 #include <Tempest/Dialog>
 
+#include <format>
+
 #include "utils/string_frm.h"
 #include "world/objects/npc.h"
 #include "world/world.h"
@@ -842,15 +844,19 @@ void GameMenu::execSingle(Item &it, int slideDx, KeyCodec::Action hint) {
         break;
       case zenkit::MenuItemSelectAction::CLOSE:
         Gothic::inst().emitGlobalSound(Gothic::inst().loadSoundFx("MENU_ESC"));
-        closeFlag = true;
+
         if(onSelAction_S[i]=="NEW_GAME")
           Gothic::inst().onStartGame(Gothic::inst().defaultWorld());
         else if(onSelAction_S[i]=="LEAVE_GAME")
           Tempest::SystemApi::exit();
         else if(onSelAction_S[i]=="SAVEGAME_SAVE")
           execSaveGame(it);
-        else if(onSelAction_S[i]=="SAVEGAME_LOAD")
-          execLoadGame(it);
+        else if(onSelAction_S[i]=="SAVEGAME_LOAD"){
+          if (!execLoadGame(it)){
+            break;
+          }
+        }
+        closeFlag = true;
         break;
       case zenkit::MenuItemSelectAction::CON_COMMANDS:
         // TODO: inline marvin commands
@@ -908,17 +914,16 @@ void GameMenu::execSaveGame(const GameMenu::Item& item) {
   Gothic::inst().save(fname,item.handle->text[0]);
   }
 
-void GameMenu::execLoadGame(const GameMenu::Item &item) {
+bool GameMenu::execLoadGame(const GameMenu::Item &item) {
   const size_t id = saveSlotId(item);
   if(id==size_t(-1))
-    return;
+    return false;
 
-  //string_frm fname("save_slot_",int(id),".sav");
-  char fname[64]={};
-  std::snprintf(fname,sizeof(fname)-1,"save_slot_%d.sav",int(id));
-  if(!FileUtil::exists(TextCodec::toUtf16(fname)))
-    return;
-  Gothic::inst().load(fname);
+  const std::string fileName = std::format("save_slot_{}.sav",int(id));
+  if(!FileUtil::exists(TextCodec::toUtf16(fileName)))
+    return false;
+  Gothic::inst().load(fileName);
+  return true;
   }
 
 void GameMenu::execCommands(std::string str, bool isClick, KeyCodec::Action hint) {

--- a/game/ui/gamemenu.h
+++ b/game/ui/gamemenu.h
@@ -103,7 +103,7 @@ class GameMenu : public Tempest::Widget {
     void                                  execSingle   (Item &it,   int slideDx, KeyCodec::Action hint);
     void                                  execChgOption(Item &item, int slideDx);
     void                                  execSaveGame (const Item& item);
-    void                                  execLoadGame (const Item& item);
+    bool                                  execLoadGame (const Item& item);
     void                                  execCommands (std::string str, bool isClick, KeyCodec::Action hint);
 
     bool                                  implUpdateSavThumb(Item& sel);


### PR DESCRIPTION
It's not possible to exit the load menu if you try to load an empty save game slot (stumbled upon this accidentally). 

This PR fixes it. In case loading save failed, the `closeFlag` is not set to true.
Also minor refactor to use `string_frm` instead of `std::snprintf`.