### PR TITLE
Use key down and support key repeat in game menu

### DIFF
--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -446,6 +446,7 @@ void MainWindow::keyRepeatEvent(KeyEvent& event) {
       return;
     }
   if(uiKeyUp==&rootMenu){
+    rootMenu.keyRepeatEvent(event);
     if(event.isAccepted())
       return;
     }
@@ -475,7 +476,6 @@ void MainWindow::keyUpEvent(KeyEvent &event) {
       return;
     }
   if(uiKeyUp==&rootMenu){
-    rootMenu.keyUpEvent(event);
     if(event.isAccepted())
       return;
     }

--- a/game/ui/gamemenu.cpp
+++ b/game/ui/gamemenu.cpp
@@ -904,8 +904,7 @@ void GameMenu::execChgOption(Item &item, int slideDx) {
 
     item.value += slideDx; // next value
     if(cnt>0)
-      item.value = std::clamp(item.value,0,cnt-1);
-    else
+      item.value = std::clamp(item.value,0,cnt-1);  else
       item.value = 0;
     Gothic::settingsSetI(sec, opt, item.value);
     }

--- a/game/ui/gamemenu.cpp
+++ b/game/ui/gamemenu.cpp
@@ -5,6 +5,8 @@
 #include <Tempest/TextCodec>
 #include <Tempest/Dialog>
 
+#include <algorithm>
+
 #include "utils/string_frm.h"
 #include "world/objects/npc.h"
 #include "world/world.h"
@@ -897,7 +899,8 @@ void GameMenu::execChgOption(Item &item, int slideDx) {
 
     item.value += slideDx; // next value
     if(cnt>0)
-      item.value = (item.value+cnt) % cnt; else
+      item.value = std::clamp(item.value,0,cnt-1);
+    else
       item.value = 0;
     Gothic::settingsSetI(sec, opt, item.value);
     }

--- a/game/ui/menuroot.cpp
+++ b/game/ui/menuroot.cpp
@@ -161,7 +161,6 @@ void MenuRoot::keyRepeatEvent(Tempest::KeyEvent &e) {
   else if(e.key == Event::K_S || e.key == Event::K_Down)
     current->onKeyboard(KeyCodec::Back);
   }
-  
 
 void MenuRoot::keyDownEvent(KeyEvent &e) {
   size_t sz = std::extent_v<decltype(cheatCode)>;
@@ -203,4 +202,3 @@ void MenuRoot::keyDownEvent(KeyEvent &e) {
       popMenu();
     }
   }
-  

--- a/game/ui/menuroot.cpp
+++ b/game/ui/menuroot.cpp
@@ -151,12 +151,17 @@ void MenuRoot::mouseWheelEvent(MouseEvent &event) {
     }
   }
 
-void MenuRoot::keyRepeatEvent(Tempest::KeyEvent& e) {
-    if(e.key==Event::K_A || e.key==Event::K_Left)
-      current->onKeyboard(KeyCodec::Left);
-    else if(e.key==Event::K_D || e.key==Event::K_Right)
-      current->onKeyboard(KeyCodec::Right);
+void MenuRoot::keyRepeatEvent(Tempest::KeyEvent &e) {
+  if(e.key == Event::K_A || e.key == Event::K_Left)
+    current->onKeyboard(KeyCodec::Left);
+  else if(e.key == Event::K_D || e.key == Event::K_Right)
+    current->onKeyboard(KeyCodec::Right);
+  else if(e.key == Event::K_W || e.key == Event::K_Up)
+    current->onKeyboard(KeyCodec::Forward);
+  else if(e.key == Event::K_S || e.key == Event::K_Down)
+    current->onKeyboard(KeyCodec::Back);
   }
+  
 
 void MenuRoot::keyDownEvent(KeyEvent &e) {
   size_t sz = std::extent_v<decltype(cheatCode)>;

--- a/game/ui/menuroot.cpp
+++ b/game/ui/menuroot.cpp
@@ -151,6 +151,13 @@ void MenuRoot::mouseWheelEvent(MouseEvent &event) {
     }
   }
 
+void MenuRoot::keyRepeatEvent(Tempest::KeyEvent& e) {
+    if(e.key==Event::K_A || e.key==Event::K_Left)
+      current->onKeyboard(KeyCodec::Left);
+    else if(e.key==Event::K_D || e.key==Event::K_Right)
+      current->onKeyboard(KeyCodec::Right);
+  }
+
 void MenuRoot::keyDownEvent(KeyEvent &e) {
   size_t sz = std::extent_v<decltype(cheatCode)>;
   for(size_t i=1; i<sz; ++i)
@@ -173,9 +180,7 @@ void MenuRoot::keyDownEvent(KeyEvent &e) {
     auto& fnt = Resources::font();
     Gothic::inst().onPrintScreen("WHAT WAS THE QUESTION?",2,4, 1,fnt);
     }
-  }
 
-void MenuRoot::keyUpEvent(KeyEvent &e) {
   if(current!=nullptr) {
     if(e.key==Event::K_W || e.key==Event::K_Up)
       current->onKeyboard(KeyCodec::Forward);
@@ -193,3 +198,4 @@ void MenuRoot::keyUpEvent(KeyEvent &e) {
       popMenu();
     }
   }
+  

--- a/game/ui/menuroot.h
+++ b/game/ui/menuroot.h
@@ -29,8 +29,8 @@ class MenuRoot : public Tempest::Widget {
     bool hasVersionLine() const;
 
     void mouseWheelEvent(Tempest::MouseEvent& event) override;
+    void keyRepeatEvent (Tempest::KeyEvent&   event) override;
     void keyDownEvent   (Tempest::KeyEvent&   event) override;
-    void keyUpEvent     (Tempest::KeyEvent&   event) override;
 
   protected:
     void mouseDownEvent (Tempest::MouseEvent& event) override;


### PR DESCRIPTION
This PR includes two changes:

- Use `keyDown` instead of `keyUp` in game menu. In vanilla Gothic 2 NOTR it's actually key down that triggers the menu action (e.g., going through menu items with up/down arrows), so this change makes OpenGothic in line with vanilla.
- Add support for key repeat. In vanilla, it's possible to hold your key to decrease/increase value on the slider in the menu. For example, it's possible to hold left arrow key to decrease the music volume. It was previously not possible in OpenGothic.