### PR TITLE
Fix weapon undraw sound not being played

### DIFF
--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1673,7 +1673,6 @@ void Npc::implSetFightMode(const Animation::EvCount& ev) {
   if(!visual.setFightMode(ev.weaponCh))
     return;
 
-  auto ws = visual.fightMode();
   if(ev.weaponCh==zenkit::MdsFightMode::NONE && (oldWs==WeaponState::W1H || oldWs==WeaponState::W2H)) {
     if(auto melee = invent.currentMeleeWeapon()) {
       if(melee->handle().material==ItemMaterial::MAT_METAL)

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1669,11 +1669,11 @@ void Npc::implFaiWait(uint64_t dt) {
   }
 
 void Npc::implSetFightMode(const Animation::EvCount& ev) {
-  const auto oldWs = visual.fightMode();
+  const auto ws = visual.fightMode();
   if(!visual.setFightMode(ev.weaponCh))
     return;
 
-  if(ev.weaponCh==zenkit::MdsFightMode::NONE && (oldWs==WeaponState::W1H || oldWs==WeaponState::W2H)) {
+  if(ev.weaponCh==zenkit::MdsFightMode::NONE && (ws==WeaponState::W1H || ws==WeaponState::W2H)) {
     if(auto melee = invent.currentMeleeWeapon()) {
       if(melee->handle().material==ItemMaterial::MAT_METAL)
         sfxWeapon = ::Sound(owner,::Sound::T_Regular,"UNDRAWSOUND_ME.WAV",{x,y+translateY(),z},2500,false); else

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1669,11 +1669,12 @@ void Npc::implFaiWait(uint64_t dt) {
   }
 
 void Npc::implSetFightMode(const Animation::EvCount& ev) {
+  const auto oldWs = visual.fightMode();
   if(!visual.setFightMode(ev.weaponCh))
     return;
 
   auto ws = visual.fightMode();
-  if(ev.weaponCh==zenkit::MdsFightMode::NONE && (ws==WeaponState::W1H || ws==WeaponState::W2H)) {
+  if(ev.weaponCh==zenkit::MdsFightMode::NONE && (oldWs==WeaponState::W1H || oldWs==WeaponState::W2H)) {
     if(auto melee = invent.currentMeleeWeapon()) {
       if(melee->handle().material==ItemMaterial::MAT_METAL)
         sfxWeapon = ::Sound(owner,::Sound::T_Regular,"UNDRAWSOUND_ME.WAV",{x,y+translateY(),z},2500,false); else


### PR DESCRIPTION
Seems to be a regression introduced in https://github.com/Try/OpenGothic/commit/488b607ad42856c34ef19a478069f39ed59cd270

The `auto ws = visual.fightMode();` variable was already set to `NoWeapon` after `visual.setFightMode` call, so no undraw sound was played.