### PR TITLE
Add some vanilla behavior for npcs

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1128,6 +1128,14 @@ void GameScript::invokePickLock(Npc& npc, int bSuccess, int bBrokenOpen) {
   vm.call_function<void>(fn, bSuccess, bBrokenOpen);
   }
 
+void GameScript::invokeRefreshAtInsert(Npc& npc) {
+  auto fn = vm.find_symbol_by_name("B_RefreshAtInsert");
+  if(fn==nullptr)
+    return;
+  ScopeVar self(*vm.global_self(), npc.handlePtr());
+  vm.call_function<void>(fn);
+  }
+
 CollideMask GameScript::canNpcCollideWithSpell(Npc& npc, Npc* shooter, int32_t spellId) {
   auto fn   = vm.find_symbol_by_name("C_CanNpcCollideWithSpell");
   if(fn==nullptr)

--- a/game/game/gamescript.h
+++ b/game/game/gamescript.h
@@ -137,6 +137,7 @@ class GameScript final {
     void invokeSpell(Npc& npc, Npc *target, Item&  fn);
     int  invokeCond (Npc& npc, std::string_view func);
     void invokePickLock(Npc& npc, int bSuccess, int bBrokenOpen);
+    void invokeRefreshAtInsert(Npc& npc);
     auto canNpcCollideWithSpell(Npc& npc, Npc* shooter, int32_t spellId) -> CollideMask;
 
     int  playerHotKeyScreenMap(Npc& pl);

--- a/game/game/inventory.cpp
+++ b/game/game/inventory.cpp
@@ -946,6 +946,8 @@ Item* Inventory::bestItem(Npc &owner, ItmFlags f) {
       continue;
     if(!i->checkCond(owner))
       continue;
+    if(itData.munition>0 && findByClass(size_t(itData.munition))==nullptr)
+      continue;
 
     if(itData.value>g){
       ret=i.get();

--- a/game/game/inventory.cpp
+++ b/game/game/inventory.cpp
@@ -905,13 +905,9 @@ void Inventory::invalidateCond(Item *&slot, Npc &owner) {
     }
   }
 
-void Inventory::autoEquip(Npc &owner) {
-  sortItems();
-
-  auto a = bestArmour     (owner);
+void Inventory::autoEquipWeapons(Npc &owner) {
   auto m = bestMeleeWeapon(owner);
   auto r = bestRangeWeapon(owner);
-  setSlot(armour,a,owner,false);
   setSlot(melee ,m,owner,false);
   setSlot(range ,r,owner,false);
   }

--- a/game/game/inventory.h
+++ b/game/game/inventory.h
@@ -77,7 +77,7 @@ class Inventory final {
     void   unequip(Item*  cls, Npc &owner);
     void   invalidateCond(Npc &owner);
     bool   isChanged() const { return !sorted; }
-    void   autoEquip(Npc &owner);
+    void   autoEquipWeapons(Npc &owner);
     void   equipArmour         (int32_t cls, Npc &owner);
     void   equipBestArmour     (Npc &owner);
     void   equipBestMeleeWeapon(Npc &owner);

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -474,6 +474,10 @@ bool Npc::resetPositionToTA() {
 
   if(!isDead)
     attachToPoint(at);
+
+  if(g2)
+    owner.script().invokeRefreshAtInsert(*this);
+
   return true;
   }
 

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -168,6 +168,10 @@ Npc::Npc(World &owner, size_t instance, std::string_view waypoint)
 
   owner.script().initializeInstanceNpc(hnpc, instance);
   hnpc->wp       = std::string(waypoint);
+
+  // vanilla forces non-zero damage type
+  if(hnpc->damage_type==0)
+    hnpc->damage_type = 2;
   }
 
 Npc::~Npc(){

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -472,8 +472,11 @@ bool Npc::resetPositionToTA() {
   setDirection(at->dirX,at->dirY,at->dirZ);
   owner.script().fixNpcPosition(*this,0,0);
 
-  if(!isDead)
+  if(!isDead) {
     attachToPoint(at);
+    if(!isMonster())
+      invent.autoEquipWeapons(*this);
+    }
 
   if(g2)
     owner.script().invokeRefreshAtInsert(*this);

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -436,15 +436,12 @@ float Npc::angleDir(float x, float z) {
   }
 
 bool Npc::resetPositionToTA() {
-  const bool g2     = owner.version().game==2;
-  const bool isDead = this->isDead();
+  const bool g2       = owner.version().game==2;
+  const bool isDragon = (g2 && guild()==GIL_DRAGON);
+  const bool isDead   = this->isDead();
 
-  if(isDead && !invent.hasMissionItems()) {
-    const bool isDragon         = (g2 && guild()==GIL_DRAGON);
-    const bool isBackgroundBody = (hnpc->attribute[ATR_HITPOINTSMAX]==1);
-    if(!isBackgroundBody && !isDragon)
-      return false;
-    }
+  if(isDead && !invent.hasMissionItems() && !isDragon)
+    return false;
 
   invent.clearSlot(*this,"",currentInteract!=nullptr);
   if(!isPlayer())


### PR DESCRIPTION
If a npc comes into visibility range:

- Best weapons are automatically equipped. For ranged weapons ammo has to be in inventory. From testing turns out this is checked in `equipBestRangedWeapon`. Bartok can be used as test npc.

- Script function `B_RefreshAtInsert` that restores health is called in G2.

Additionally clean up some leftover of 1hp npc handling and setting the damage type to 2 if its default was 0. Needed for the hero in G1. Tested as behaving the same in G2 for some monsters and humans by setting their damage type to 0 in script.