### PR TITLE
Fix spell charging animation

### DIFF
--- a/game/graphics/mesh/animationsolver.cpp
+++ b/game/graphics/mesh/animationsolver.cpp
@@ -393,7 +393,7 @@ const Animation::Sequence* AnimationSolver::solveAnim(std::string_view scheme, b
     name = string_frm("T_MAGMOVE_2_",scheme,"CAST");
   else if(run)
     name = string_frm("T_MAGMOVE_2_",scheme,"SHOOT");
-  else if(run)
+  else if(invest)
     name = string_frm("T_MAGRUN_2_",scheme,"CAST");
   else
     name = string_frm("T_MAGRUN_2_",scheme,"SHOOT");


### PR DESCRIPTION
Fixes a c&p leftover where parameter `run` was checked twice in `AnimationSolver::solveAnim`. Introduced here https://github.com/Try/OpenGothic/commit/825bf12b32e000c28dca4585d9b545b57ea19a96.