### PR TITLE
Don't consider npc type for attitudes

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1300,8 +1300,6 @@ Attitude GameScript::personAttitude(const Npc &p0, const Npc &p1) const {
   att = npc.attitude();
   if(att!=ATT_NULL)
     return att;
-  if(npc.isFriend())
-    return ATT_FRIENDLY;
   att = guildAttitude(p0,p1);
   return att;
   }
@@ -1310,6 +1308,8 @@ bool GameScript::isFriendlyFire(const Npc& src, const Npc& dst) const {
   static const int AIV_PARTYMEMBER = 15;
   if(src.isPlayer())
     return false;
+  if(src.isFriend())
+    return true;
   if(personAttitude(src, dst)==ATT_FRIENDLY)
     return true;
   if(src.handlePtr()->aivar[AIV_PARTYMEMBER]!=0 && dst.isPlayer())


### PR DESCRIPTION
Special handling for npc type friend in `GameScript::personAttitude`  is preventing a guru from having the default dialog lines. The "don't talk to me" Gurus have this dialog check:
```C++
FUNC INT DIA_BaalTyon_NoTalk_Condition()
{
	if ( Npc_IsInState(self,ZS_TALK) && (BaalTyon_Ansprechbar==FALSE) && (Npc_GetPermAttitude(self,other)!=ATT_FRIENDLY) )
	{
		return 1;
	};
};
```
This is a problem for Baal Tyon who has npc type friend and therefore the attitude check returns false. Other gurus are npc type main and dialogs have no issues.

For testing: `goto vob gur_1210_baaltyon`

In `GameScript::isFriendlyFire` there's the check  `if(personAttitude(src, dst)==ATT_FRIENDLY)`. Don't know if this should check for npc type now instead of attitude considering that like for gururs npc type seems a bit arbitrary.