### PR TITLE
do not crash on wrong texture format

### DIFF
--- a/game/resources.cpp
+++ b/game/resources.cpp
@@ -349,9 +349,9 @@ Tempest::Texture2d* Resources::implLoadTexture(TextureCache& cache, std::string_
         if(t!=nullptr)
           return t;
         } else {
-        auto rgba = tex.as_rgba8(0);
 
         try {
+          auto rgba = tex.as_rgba8(0);
           Tempest::Pixmap    pm(tex.width(), tex.height(), TextureFormat::RGBA8);
           std::memcpy(pm.data(), rgba.data(), rgba.size());
 
@@ -360,7 +360,11 @@ Tempest::Texture2d* Resources::implLoadTexture(TextureCache& cache, std::string_
           cache[std::move(name)] = std::move(t);
           return ret;
           }
+        catch (std::exception& e) {
+              Log::e("unable to convert texture: \"", std::string(cname), "\", reason: ", e.what());
+          }
         catch (...) {
+              Log::e("unable to convert texture: \"", std::string(cname), "\", unknown error");
           }
         }
       }


### PR DESCRIPTION
Got crash when loading [unofficial](https://github.com/dosinabox/g2nr_unofficial_update_eng) [scriptpatch29](https://worldofplayers.ru/threads/36817/) on `zenkit::Texture::as_rgba8`
Added some logging instead:
`unable to convert texture: "PROGRESS_BAR.TGA", reason: failed parsing resource of type texture [context: cannot convert format to rgba: 6]`

full crashlog:
`#1:  - /usr/lib64/libstdc++.so.6(+0xcfbd3) [0x7f03106cfbd3]
#2:  - /usr/lib64/libstdc++.so.6(+0xcfe64) [0x7f03106cfe64]
#3:  - /home/***/github/OpenGothic/build/opengothic/Gothic2Notr(+0x152bc7) [0x558d240e8bc7]
#4: zenkit::Texture::as_rgba8(unsigned int) const - /home/***/github/OpenGothic/build/opengothic/Gothic2Notr(_ZNK6zenkit7Texture8as_rgba8Ej+0xb0) [0x558d2433a4d0]
#5: Resources::implLoadTexture(std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unique_ptr<Tempest::Texture2d, std::default_delete<Tempest::Texture2d> >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::unique_ptr<Tempest::Texture2d, std::default_delete<Tempest::Texture2d> > > > >&, std::basic_string_view<char, std::char_traits<char> >) - /home/***/github/OpenGothic/build/opengothic/Gothic2Notr(_ZN9Resources15implLoadTextureERSt13unordered_mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt10unique_ptrIN7Tempest9Texture2dESt14default_deleteIS9_EESt4hashIS6_ESt8equal_toIS6_ESaISt4pairIKS6_SC_EEESt17basic_string_viewIcS4_E+0x5f1) [0x558d2425c031]
#6: Resources::loadTexture(std::basic_string_view<char, std::char_traits<char> >) - /home/***/github/OpenGothic/build/opengothic/Gothic2Notr(_ZN9Resources11loadTextureESt17basic_string_viewIcSt11char_traitsIcEE+0x4c) [0x558d2425c1ac]
#7: MainWindow::MainWindow(Tempest::Device&) - /home/***/github/OpenGothic/build/opengothic/Gothic2Notr(_ZN10MainWindowC1ERN7Tempest6DeviceE+0x771) [0x558d24243a41]
#8: main - /home/***/github/OpenGothic/build/opengothic/Gothic2Notr(main+0x201) [0x558d240eda81]`