### PR TITLE
fix ini parsing: handle multiple values in the one line

### DIFF
--- a/game/utils/inifile.cpp
+++ b/game/utils/inifile.cpp
@@ -149,7 +149,7 @@ void IniFile::implLine(std::istream &s) {
     s.get(ch);
     while(ch!='=' && ch!='\n' && ch!='\r' && ch!='\0' && !s.eof())
       s.get(ch);
-    std::string value = implName(s);
+    std::string value = implValue(s);
     addValue(std::move(name),std::move(value));
     }
 
@@ -177,6 +177,31 @@ std::string IniFile::implName(std::istream &s) {
     name.push_back(ch);
     s.get(ch);
     ch=char(s.peek());
+    }
+  return name;
+  }
+
+std::string IniFile::implValue(std::istream &s) {
+  std::string name;
+  char ch=char(s.peek());
+  while((ch==' ' || ch=='\t') && !s.eof()) {
+    s.get(ch);
+    ch=char(s.peek());
+    }
+  while(ch!='\n' && ch!='\r' && ch!=';' && !s.eof()){
+    name.push_back(ch);
+    s.get(ch);
+    ch=char(s.peek());
+    if(ch==' ' || ch=='\t') {
+      name.push_back(' ');
+      do {
+        s.get(ch);
+        ch=char(s.peek());
+        } while((ch==' ' || ch=='\t') && !s.eof());
+      }
+    }
+  if(!name.empty() && name.back()==' ') {
+    name.pop_back();
     }
   return name;
   }

--- a/game/utils/inifile.h
+++ b/game/utils/inifile.h
@@ -36,6 +36,7 @@ class IniFile final {
     void  implLine(std::istream &fin);
     char  implSpace(std::istream &fin);
     auto  implName (std::istream &fin) -> std::string;
+    auto  implValue (std::istream &fin) -> std::string;
 
     void  addSection(std::string&& name);
     void  addValue  (std::string&& name, std::string&& val);


### PR DESCRIPTION
Multi-files mods were not handled properly. In example below only `scriptpatch_v29.mod` was parsed.
Now ini-parser will not skip single space/tab symbols in values.

Example (G2a_NR_ScriptPatch_v29.ini):
```
[FILES]
VDF=scriptpatch_v29.mod scriptpatch_v29_ru.mod scriptpatch_v29_speech_add_ru.mod scriptpatch_v29_speech_fix_ru.mod scriptpatch_v29_widescreen.mod

```

This code in `gothic.cpp` allow multiple vdfs

```
std::u16string vdf = TextCodec::toUtf16(std::string(modFile->getS("FILES","VDF")));
modFilter = modFile->has("FILES","VDF");
for(size_t start = 0, split = 0; split != std::string::npos; start = split+1) {
  split = vdf.find(' ', start);
  std::u16string mod = vdf.substr(start, split-start);
  if(!mod.empty())
    modvdfs.emplace_back(std::move(mod));
  }
}
Resources::loadVdfs(modvdfs, modFilter);
```

