### PR TITLE
fix. lockpicking reaction.

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -3188,7 +3188,6 @@ void GameScript::snd_play3d(std::shared_ptr<zenkit::INpc> npcRef, std::string_vi
     c = char(std::toupper(c));
   auto sfx = ::Sound(*owner.world(),::Sound::T_3D,file,npc->position(),0.f,false);
   sfx.play();
-  owner.world()->sendImmediatePerc(*npc,*npc,*npc,PERC_ASSESSQUIETSOUND);
   }
 
 void GameScript::exitsession() {


### PR DESCRIPTION
Hi!
[Npcs wake up if player is picking a lock in sneak mode](https://github.com/Try/OpenGothic/issues/639) because every lock-picking action calls `snd_play3d` which unconditionally sends `PERC_ASSESSQUIETSOUND`. 

In G2NotR scripts `snd_play3d` function is used only for lock-picking status sounds. And script sends `PERC_ASSESSQUIETSOUND` only when lock-pick was broken:

```
func void G_PickLock(var int bSuccess,var int bBrokenOpen)
{
	var int rnd;
	if(bSuccess)
	{
		if(bBrokenOpen)
		{
			Snd_Play3d(self,"PICKLOCK_UNLOCK");
			Print(PRINT_PICKLOCK_UNLOCK);
		}
		else
		{
			Snd_Play3d(self,"PICKLOCK_SUCCESS");
			Print(PRINT_PICKLOCK_SUCCESS);
		};
	}
	else if(bBrokenOpen)
	{
		Snd_Play3d(self,"PICKLOCK_BROKEN");
		Print(PRINT_PICKLOCK_BROKEN);
		rnd = Hlp_Random(100);
		if(rnd <= 25)
		{
			Npc_SendPassivePerc(hero,PERC_ASSESSQUIETSOUND,hero,hero);
		};
	}
	else
	{
		Snd_Play3d(self,"PICKLOCK_FAILURE");
		Print(PRINT_PICKLOCK_FAILURE);
	};
};
```

