### PR TITLE
Added wld_removenpc call

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -103,6 +103,7 @@ void GameScript::initCommon() {
   bindExternal("hlp_getinstanceid",              &GameScript::hlp_getinstanceid);
 
   bindExternal("wld_insertnpc",                  &GameScript::wld_insertnpc);
+  bindExternal("wld_removenpc",                  &GameScript::wld_removenpc);
   bindExternal("wld_insertitem",                 &GameScript::wld_insertitem);
   bindExternal("wld_settime",                    &GameScript::wld_settime);
   bindExternal("wld_getday",                     &GameScript::wld_getday);
@@ -1893,6 +1894,13 @@ void GameScript::wld_insertnpc(int npcInstance, std::string_view spawnpoint) {
   auto npc = world().addNpc(size_t(npcInstance),spawnpoint);
   if(npc!=nullptr)
     fixNpcPosition(*npc,0,0);
+  }
+
+void GameScript::wld_removenpc(int npcInstance) {
+  if(npcInstance<=0)
+    return;
+
+  world().removeNpc(size_t(npcInstance));
   }
 
 void GameScript::wld_insertitem(int itemInstance, std::string_view spawnpoint) {

--- a/game/game/gamescript.h
+++ b/game/game/gamescript.h
@@ -235,6 +235,7 @@ class GameScript final {
 
     void wld_insertitem      (int itemInstance, std::string_view spawnpoint);
     void wld_insertnpc       (int npcInstance, std::string_view spawnpoint);
+    void wld_removenpc       (int npcInstance);
     void wld_settime         (int hour, int minute);
     int  wld_getday          ();
     void wld_playeffect      (std::string_view visual, std::shared_ptr<zenkit::DaedalusInstance> sourceId, std::shared_ptr<zenkit::DaedalusInstance> targetId, int effectLevel, int damage, int damageType, int isProjectile);

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -592,8 +592,13 @@ Npc *World::addNpc(size_t npcInstance, std::string_view at) {
   return wobj.addNpc(npcInstance,at);
   }
 
+
 Npc* World::addNpc(size_t itemInstance, const Tempest::Vec3& at) {
   return wobj.addNpc(itemInstance,at);
+  }
+
+void World::removeNpc(size_t npcInstance) {
+  wobj.removeNpcByInstance(npcInstance);
   }
 
 Item *World::addItem(size_t itemInstance, std::string_view at) {

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -149,6 +149,8 @@ class World final {
     Npc*                 addNpc     (std::string_view name, std::string_view     at);
     Npc*                 addNpc     (size_t itemInstance,   std::string_view     at);
     Npc*                 addNpc     (size_t itemInstance,   const Tempest::Vec3& at);
+    void                 removeNpc  (size_t npcInstance);
+
     Item*                addItem    (size_t itemInstance,   std::string_view     at);
     Item*                addItem    (const zenkit::VItem& vob);
     Item*                addItem    (size_t itemInstance, const Tempest::Vec3&      pos);

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -460,6 +460,17 @@ Npc *WorldObjects::findNpcByInstance(size_t instance, size_t n) {
   return nullptr;
   }
 
+void WorldObjects::removeNpcByInstance(size_t instance) {
+  for(size_t i=0; i<npcArr.size(); ++i){
+    auto& npc=*npcArr[i];
+    if(npc.handle().symbol_index()==instance){
+      npcArr[i] = std::move(npcArr.back());
+      npcArr.pop_back();
+      return;
+      }
+    }
+  }
+
 Item* WorldObjects::findItemByInstance(size_t instance, size_t n) {
   for(auto& i:itemArr) {
     if(i->handle().symbol_index()==instance) {

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -61,6 +61,8 @@ class WorldObjects final {
     bool           isTargeted(Npc& npc);
     Npc*           findHero();
     Npc*           findNpcByInstance(size_t instance, size_t n = 0);
+    void           removeNpcByInstance(size_t instance);
+
     Item*          findItemByInstance(size_t instance, size_t n = 0);
     void           detectNpcNear(const std::function<void(Npc&)>& f);
     void           detectNpc (const float x, const float y, const float z, const float r, const std::function<void(Npc&)>&  f);


### PR DESCRIPTION
Wld_RemoveNpc(instance) removes NPC from the world. This function is used by [Gothic2 Notr unofficial patch](https://github.com/dosinabox/g2nr_unofficial_update/blob/20e506c5ed07a2b915e96f93661d39466afe568b/PrjGOTHIC/Story/Events/B_GolemChest.d#L10).

Also Wld_RemoveNpc is present in some scripting tutorials and in Gothic.DAT file for Gothic1 1.08, Gothic2 Notr.