### PR TITLE
Fix some Gothic 1 magic bugs

### DIFF
--- a/game/graphics/effect.cpp
+++ b/game/graphics/effect.cpp
@@ -306,6 +306,9 @@ void Effect::onCollide(World& world, const VisualFx* root, const Vec3& pos, Npc*
   if(npc!=nullptr)
     vfx = root->emFXCollDyn;
 
+   // Gothic 1 uses emFXCollDyn->sendAssessMagic as check for PERC_ASSESSMAGIC
+   // Gothic 2 instead introduced new vfx emFXCollDynPerc specific for this purpose
+  bool g2 = world.version().game==2;
   if(vfx!=nullptr) {
     Effect eff(*vfx,world,pos,SpellFxKey::Collide);
     eff.setSpellId(splId,world);
@@ -314,7 +317,7 @@ void Effect::onCollide(World& world, const VisualFx* root, const Vec3& pos, Npc*
 
     if(npc!=nullptr) {
       npc ->runEffect(std::move(eff));
-      if(vfx->sendAssessMagic) {
+      if(!g2 && vfx->sendAssessMagic) {
         auto oth = other==nullptr ? npc : other;
         npc->perceptionProcess(*oth,npc,0,PERC_ASSESSMAGIC);
         }
@@ -323,7 +326,7 @@ void Effect::onCollide(World& world, const VisualFx* root, const Vec3& pos, Npc*
       }
     }
 
-  if(npc!=nullptr && root->emFXCollDynPerc!=nullptr) {
+  if(g2 && npc!=nullptr && root->emFXCollDynPerc!=nullptr) {
     const VisualFx* vfx = root->emFXCollDynPerc;
     Effect eff(*vfx,world,pos,SpellFxKey::Collide);
     eff.setActive(true);

--- a/game/graphics/effect.cpp
+++ b/game/graphics/effect.cpp
@@ -312,9 +312,15 @@ void Effect::onCollide(World& world, const VisualFx* root, const Vec3& pos, Npc*
     eff.setOrigin(other);
     eff.setActive(true);
 
-    if(npc!=nullptr)
-      npc ->runEffect(std::move(eff)); else
+    if(npc!=nullptr) {
+      npc ->runEffect(std::move(eff));
+      if(vfx->sendAssessMagic) {
+        auto oth = other==nullptr ? npc : other;
+        npc->perceptionProcess(*oth,npc,0,PERC_ASSESSMAGIC);
+        }
+      } else {
       world.runEffect(std::move(eff));
+      }
     }
 
   if(npc!=nullptr && root->emFXCollDynPerc!=nullptr) {

--- a/game/world/objects/item.cpp
+++ b/game/world/objects/item.cpp
@@ -210,8 +210,9 @@ bool Item::isSpellShoot() const {
   // Only hardcode Stormfist for now since other spells work with the heuristic based on target_collect_algo
   if(!isSpellOrRune())
     return false;
-  bool g1 = world.version().game==1;
-  if(g1 && spellId()==47)
+  bool          g1            = world.version().game==1;
+  const int32_t SPL_STORMFIST = 47;
+  if(g1 && spellId()==SPL_STORMFIST)
     return true;
   auto& spl = world.script().spellDesc(spellId());
   return spl.target_collect_algo!=TargetCollect::TARGET_COLLECT_NONE &&

--- a/game/world/objects/item.cpp
+++ b/game/world/objects/item.cpp
@@ -4,6 +4,7 @@
 
 #include "game/serialize.h"
 #include "game/gamescript.h"
+#include "utils/versioninfo.h"
 #include "world/objects/npc.h"
 #include "world/world.h"
 #include "utils/fileext.h"
@@ -204,12 +205,19 @@ bool Item::isMulti() const {
   }
 
 bool Item::isSpellShoot() const {
+  // Whether a spell is a projectile is hardcoded in vanilla, see
+  // https://forum.worldofplayers.de/forum/threads/1460092-Stuck-in-a-charge-spell/page2?p=24786462&viewfull=1#post24786462
+  // Only hardcode Stormfist for now since other spells work with the heuristic based on target_collect_algo
   if(!isSpellOrRune())
     return false;
+  bool g1 = world.version().game==1;
+  if(g1 && spellId()==47)
+    return true;
   auto& spl = world.script().spellDesc(spellId());
   return spl.target_collect_algo!=TargetCollect::TARGET_COLLECT_NONE &&
          spl.target_collect_algo!=TargetCollect::TARGET_COLLECT_CASTER &&
-         spl.target_collect_algo!=TargetCollect::TARGET_COLLECT_FOCUS;
+         spl.target_collect_algo!=TargetCollect::TARGET_COLLECT_FOCUS &&
+         spl.target_collect_algo!=TargetCollect::TARGET_COLLECT_ALL_FALLBACK_NONE;
   }
 
 bool Item::isSpellOrRune() const {

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -184,7 +184,7 @@ class World final {
     void                 invalidateVobIndex();
 
   private:
-    const zenkit::IFocus& searchPolicy(const Npc& pl, TargetCollect& coll, WorldObjects::SearchFlg& opt) const;
+    const zenkit::IFocus& searchPolicy(const Npc& pl, TargetCollect& collAlgo, TargetType& collType, WorldObjects::SearchFlg& opt) const;
     std::string                           wname;
     GameSession&                          game;
 

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -972,16 +972,16 @@ void WorldObjects::setMobState(std::string_view scheme, int32_t st) {
   }
 
 template<class T>
-T& deref(std::unique_ptr<T>& x){ return *x; }
+static T& deref(std::unique_ptr<T>& x){ return *x; }
 
 template<class T>
-T& deref(T* x){ return *x; }
+static T& deref(T* x){ return *x; }
 
 template<class T>
-T& deref(T& x){ return x; }
+static T& deref(T& x){ return x; }
 
 template<class T>
-bool checkFlag(T&,WorldObjects::SearchFlg){ return true; }
+static bool checkFlag(T&,WorldObjects::SearchFlg){ return true; }
 
 static bool checkFlag(Npc& n,WorldObjects::SearchFlg f){
   if(n.handle().no_focus)
@@ -1000,7 +1000,7 @@ static bool checkFlag(Interactive& i,WorldObjects::SearchFlg f){
   }
 
 template<class T>
-bool checkTargetType(T&, TargetType) { return true; }
+static bool checkTargetType(T&, TargetType) { return true; }
 
 static bool checkTargetType(Npc& n, TargetType t) {
   if(bool(t&(TARGET_TYPE_ALL|TARGET_TYPE_NPCS)))
@@ -1021,7 +1021,7 @@ static bool checkTargetType(Npc& n, TargetType t) {
   }
 
 template<class T>
-bool canSee(const Npc&,const T&){ return true; }
+static bool canSee(const Npc&,const T&){ return true; }
 
 static bool canSee(const Npc& pl, const Npc& n){
   return pl.canSeeNpc(n,true);

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -1005,7 +1005,7 @@ bool checkTargetType(T&, TargetType) { return true; }
 static bool checkTargetType(Npc& n, TargetType t) {
   if(bool(t&(TARGET_TYPE_ALL|TARGET_TYPE_NPCS)))
     return true;
-  int32_t gil = n.trueGuild();
+  Guild gil = Guild(n.trueGuild());
   if(bool(t&TARGET_TYPE_HUMANS) && gil<GIL_SEPERATOR_HUM)
     return true;
   if(bool(t&TARGET_TYPE_ORCS) && gil>GIL_SEPERATOR_ORC)

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -39,11 +39,12 @@ class WorldObjects final {
 
     struct SearchOpt final {
       SearchOpt()=default;
-      SearchOpt(float rangeMin, float rangeMax, float azi, TargetCollect collectAlgo=TARGET_COLLECT_CASTER, SearchFlg flags=NoFlg);
+      SearchOpt(float rangeMin, float rangeMax, float azi, TargetCollect collectAlgo=TARGET_COLLECT_CASTER, TargetType collectType=TARGET_TYPE_ALL, SearchFlg flags=NoFlg);
       float         rangeMin    = 0;
       float         rangeMax    = 0;
       float         azi         = 0;
       TargetCollect collectAlgo = TARGET_COLLECT_CASTER;
+      TargetType    collectType = TARGET_TYPE_ALL;
       SearchFlg     flags       = NoFlg;
       };
 


### PR DESCRIPTION
This PR fixes issues 1. and 2. from https://github.com/Try/OpenGothic/issues/661 and  18.1 and 18.2 from G1 bug [discussion](https://github.com/Try/OpenGothic/discussions/622).

(1) Broken firerain effect is fixed by adding it's `Target_collect_algo` attribute to `Item::isSpellShoot`. I proposed this change some time ago but withdrew because it would break Stormfist. Found out now that projectile property is hardcoded ([source](https://forum.worldofplayers.de/forum/threads/1460092-Stuck-in-a-charge-spell/page2?p=24786462&viewfull=1#post24786462)) and used that for Stormfist.

(2) Added a missing perc trigger on collision to make icewave freezing work.

(18.1/2.) Spell targets can be restricted based on attribute `Target_collect_type`, meaning orc priest just cannot be targeted. For `TARGET_TYPE_UNDEAD`  I took `C_NpcIsUndead` script function from G2 as reference since it doesn't exist in G1. 
Target type is not always correctly set in vanilla. For example icewave can target items.

While at it also limited focus search for interactives in combat to only bow and crossbow as magic can't target those.



