### PR TITLE
Follow up fix for `TARGET_TYPE`

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1138,6 +1138,13 @@ void GameScript::invokeRefreshAtInsert(Npc& npc) {
   }
 
 CollideMask GameScript::canNpcCollideWithSpell(Npc& npc, Npc* shooter, int32_t spellId) {
+  if(owner.version().game==1) {
+    auto& spl = spellDesc(spellId);
+    if(npc.isTargetableBySpell(TargetType(spl.target_collect_type)))
+      return COLL_DOEVERYTHING; else
+      return COLL_DONOTHING;
+    }
+
   auto fn   = vm.find_symbol_by_name("C_CanNpcCollideWithSpell");
   if(fn==nullptr)
     return COLL_DOEVERYTHING;

--- a/game/world/bullet.cpp
+++ b/game/world/bullet.cpp
@@ -136,11 +136,6 @@ void Bullet::onCollide(zenkit::MaterialGroup matId) {
 void Bullet::onCollide(Npc& npc) {
   if(&npc==origin() || isFinished())
     return;
-  if(isSpell()) {
-    auto& spl = npc.world().script().spellDesc(spellId());
-    if(!npc.isSpellTargetType(TargetType(spl.target_collect_type)))
-      return;
-    }
 
   if(ow!=nullptr) {
     // no damage between ally npc's, only emit pfx effect

--- a/game/world/bullet.cpp
+++ b/game/world/bullet.cpp
@@ -136,6 +136,11 @@ void Bullet::onCollide(zenkit::MaterialGroup matId) {
 void Bullet::onCollide(Npc& npc) {
   if(&npc==origin() || isFinished())
     return;
+  if(isSpell()) {
+    auto& spl = npc.world().script().spellDesc(spellId());
+    if(!npc.isSpellTargetType(TargetType(spl.target_collect_type)))
+      return;
+    }
 
   if(ow!=nullptr) {
     // no damage between ally npc's, only emit pfx effect

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -2815,6 +2815,24 @@ void Npc::runEffect(Effect&& e) {
   visual.startEffect(owner, std::move(e), 0, true);
   }
 
+bool Npc::isSpellTargetType(TargetType t) const {
+  if(bool(t&(TARGET_TYPE_ALL|TARGET_TYPE_NPCS)))
+    return true;
+  Guild gil = Guild(trueGuild());
+  if(bool(t&TARGET_TYPE_HUMANS) && gil<GIL_SEPERATOR_HUM)
+    return true;
+  if(bool(t&TARGET_TYPE_ORCS) && gil>GIL_SEPERATOR_ORC)
+    return true;
+  if(bool(t&TARGET_TYPE_UNDEAD)) {
+    if(gil == GIL_GOBBO_SKELETON || gil == GIL_SUMMONED_GOBBO_SKELETON ||
+      gil == GIL_SKELETON        || gil == GIL_SUMMONED_SKELETON       ||
+      gil == GIL_SKELETON_MAGE   || gil == GIL_SHADOWBEAST_SKELETON    ||
+      gil == GIL_ZOMBIE)
+      return true;
+    }
+  return false;
+  }
+
 void Npc::commitSpell() {
   auto active = invent.getItem(currentSpellCast);
   if(active==nullptr || !active->isSpellOrRune())

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -2815,7 +2815,7 @@ void Npc::runEffect(Effect&& e) {
   visual.startEffect(owner, std::move(e), 0, true);
   }
 
-bool Npc::isSpellTargetType(TargetType t) const {
+bool Npc::isTargetableBySpell(TargetType t) const {
   if(bool(t&(TARGET_TYPE_ALL|TARGET_TYPE_NPCS)))
     return true;
   Guild gil = Guild(trueGuild());

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -398,7 +398,7 @@ class Npc final {
     void      commitSpell();
     void      takeDamage(Npc& other, const Bullet* b);
     void      takeDamage(Npc& other, const Bullet* b, const VisualFx* vfx, int32_t splId);
-    bool      isSpellTargetType(TargetType t) const;
+    bool      isTargetableBySpell(TargetType t) const;
 
     void      emitSoundEffect(std::string_view sound, float range, bool freeSlot);
     void      emitSoundGround(std::string_view sound, float range, bool freeSlot);

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -398,6 +398,7 @@ class Npc final {
     void      commitSpell();
     void      takeDamage(Npc& other, const Bullet* b);
     void      takeDamage(Npc& other, const Bullet* b, const VisualFx* vfx, int32_t splId);
+    bool      isSpellTargetType(TargetType t) const;
 
     void      emitSoundEffect(std::string_view sound, float range, bool freeSlot);
     void      emitSoundGround(std::string_view sound, float range, bool freeSlot);

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -1003,21 +1003,7 @@ template<class T>
 static bool checkTargetType(T&, TargetType) { return true; }
 
 static bool checkTargetType(Npc& n, TargetType t) {
-  if(bool(t&(TARGET_TYPE_ALL|TARGET_TYPE_NPCS)))
-    return true;
-  Guild gil = Guild(n.trueGuild());
-  if(bool(t&TARGET_TYPE_HUMANS) && gil<GIL_SEPERATOR_HUM)
-    return true;
-  if(bool(t&TARGET_TYPE_ORCS) && gil>GIL_SEPERATOR_ORC)
-    return true;
-  if(bool(t&TARGET_TYPE_UNDEAD)) {
-    if(gil == GIL_GOBBO_SKELETON || gil == GIL_SUMMONED_GOBBO_SKELETON ||
-      gil == GIL_SKELETON        || gil == GIL_SUMMONED_SKELETON       ||
-      gil == GIL_SKELETON_MAGE   || gil == GIL_SHADOWBEAST_SKELETON    ||
-      gil == GIL_ZOMBIE)
-      return true;
-    }
-  return false;
+  return n.isSpellTargetType(t);
   }
 
 template<class T>

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -1003,7 +1003,7 @@ template<class T>
 static bool checkTargetType(T&, TargetType) { return true; }
 
 static bool checkTargetType(Npc& n, TargetType t) {
-  return n.isSpellTargetType(t);
+  return n.isTargetableBySpell(t);
   }
 
 template<class T>


### PR DESCRIPTION
https://github.com/Try/OpenGothic/pull/682 allowed focus only if npc guild matches the spell's `TARGET_TYPE`. But that spell could still hit and cause damage. 

Tested both G1&G2. Projectile spells hit only if `TARGET_TYPE` allows for, while spells like firerain ignore type and always hit.

I guess in theory there's same behavior for items and interactives but they can't be damaged anyway so ignore them.