### PR TITLE
Handle Gothic 1 guilds

### DIFF
--- a/game/game/constants.h
+++ b/game/game/constants.h
@@ -73,7 +73,53 @@ enum Guild: uint32_t {
   GIL_EMPTY_X                 = 63,
   GIL_EMPTY_Y                 = 64,
   GIL_EMPTY_Z                 = 65,
-  GIL_MAX                     = 66
+  GIL_MAX                     = 66,
+
+  // Gothic 1 guilds
+  GIL_G1_NONE                 = GIL_NONE,
+  GIL_G1_HUMAN                = GIL_HUMAN,
+  GIL_G1_EBR                  = 1,  // Erzbaron
+  GIL_G1_GRD                  = 2,  // Gardist
+  GIL_G1_STT                  = 3,  // Schatten
+  GIL_G1_KDF                  = GIL_KDF,
+  GIL_G1_VLK                  = 5,  // Buddler
+  GIL_G1_KDW                  = 6,  // Wassermagier
+  GIL_G1_SLD                  = GIL_SLD,
+  GIL_G1_ORG                  = 8,  // Bandit
+  GIL_G1_BAU                  = 9,  // Bauer
+  GIL_G1_SFB                  = 10, // Schuerfer
+  GIL_G1_GUR                  = 11, // Guru
+  GIL_G1_NOV                  = 12, // Novize
+  GIL_G1_TPL                  = 13, // Templer
+  GIL_G1_DMB                  = 14, // Darkmagic Xardas
+  GIL_G1_BAB                  = 15, // Female
+  GIL_G1_SEPERATOR_HUM        = GIL_SEPERATOR_HUM,
+  GIL_G1_WARAN                = 17,
+  GIL_G1_SLF                  = 18, // Sleeper
+  GIL_G1_GOBBO                = GIL_GOBBO,
+  GIL_G1_TROLL                = 20,
+  GIL_G1_SNAPPER              = 21,
+  GIL_G1_MINECRAWLER          = 22,
+  GIL_G1_MEATBUG              = 23,
+  GIL_G1_SCAVENGER            = 24,
+  GIL_G1_DEMON                = 25,
+  GIL_G1_WOLF                 = 26,
+  GIL_G1_SHADOWBEAST          = 27,
+  GIL_G1_BLOODFLY             = 28,
+  GIL_G1_SWAMPSHARK           = 29,
+  GIL_G1_ZOMBIE               = 30,
+  GIL_G1_UNDEADORC            = 31,
+  GIL_G1_SKELETON             = 32,
+  GIL_G1_ORCDOG               = 33,
+  GIL_G1_MOLERAT              = 34,
+  GIL_G1_GOLEM                = 35,
+  GIL_G1_LURKER               = 36,
+  GIL_G1_SEPERATOR_ORC        = 37,
+  GIL_G1_ORCSHAMAN            = 38,
+  GIL_G1_ORCWARROIR           = 39,
+  GIL_G1_ORCSCOUT             = 40,
+  GIL_G1_ORCSLAVE             = 41,
+  GIL_G1_MAX                  = 42,
   };
 
 enum {

--- a/game/game/constants.h
+++ b/game/game/constants.h
@@ -72,7 +72,7 @@ enum Guild: uint32_t {
   GIL_DRACONIAN               = 62,
   GIL_EMPTY_X                 = 63,
   GIL_EMPTY_Y                 = 64,
-  GIL_EMPTY_Z	                = 65,
+  GIL_EMPTY_Z                 = 65,
   GIL_MAX                     = 66
   };
 
@@ -286,7 +286,7 @@ enum ItmFlags : uint32_t {
   ITM_MULTI      = 1 << 21,
   ITM_AMULET     = 1 << 22,
   ITM_BELT       = 1 << 24,
-  ITM_TORCH	     = 1 << 28
+  ITM_TORCH      = 1 << 28
   };
 
 enum Action:uint32_t {
@@ -426,7 +426,7 @@ enum SpellCode : int32_t {
   SPL_SENDSTOP                    = 3,
   SPL_NEXTLEVEL                   = 4,
   SPL_STATUS_CANINVEST_NO_MANADEC = 8,
-  SPL_FORCEINVEST		              = 1 << 16
+  SPL_FORCEINVEST                 = 1 << 16
   };
 
 enum Protection : uint8_t {

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1209,7 +1209,9 @@ uint32_t Npc::guild() const {
   }
 
 bool Npc::isMonster() const {
-  return Guild::GIL_SEPERATOR_HUM<guild() && guild()<Guild::GIL_SEPERATOR_ORC;
+  const bool g2 = owner.version().game==2;
+  const auto SEPERATOR_ORC = g2 ? GIL_SEPERATOR_ORC : GIL_G1_SEPERATOR_ORC;
+  return GIL_SEPERATOR_HUM<guild() && guild()<SEPERATOR_ORC;
   }
 
 void Npc::setTrueGuild(int32_t g) {
@@ -2818,18 +2820,27 @@ void Npc::runEffect(Effect&& e) {
 bool Npc::isTargetableBySpell(TargetType t) const {
   if(bool(t&(TARGET_TYPE_ALL|TARGET_TYPE_NPCS)))
     return true;
+
   Guild gil = Guild(trueGuild());
+
+  const bool g2 = owner.version().game==2;
+  const auto SEPERATOR_ORC = g2 ? GIL_SEPERATOR_ORC : GIL_G1_SEPERATOR_ORC;
+  const auto G1_UNDEAD = (gil == GIL_G1_ZOMBIE ||
+    gil == GIL_G1_UNDEADORC || gil == GIL_G1_SKELETON);
+  const auto G2_UNDEAD = (gil == GIL_GOBBO_SKELETON ||
+    gil == GIL_SUMMONED_GOBBO_SKELETON || gil == GIL_SKELETON      ||
+    gil == GIL_SUMMONED_SKELETON       || gil == GIL_SKELETON_MAGE ||
+    gil == GIL_SHADOWBEAST_SKELETON    || gil == GIL_ZOMBIE);
+
   if(bool(t&TARGET_TYPE_HUMANS) && gil<GIL_SEPERATOR_HUM)
     return true;
-  if(bool(t&TARGET_TYPE_ORCS) && gil>GIL_SEPERATOR_ORC)
+  if(bool(t&TARGET_TYPE_ORCS) && gil>SEPERATOR_ORC)
     return true;
-  if(bool(t&TARGET_TYPE_UNDEAD)) {
-    if(gil == GIL_GOBBO_SKELETON || gil == GIL_SUMMONED_GOBBO_SKELETON ||
-      gil == GIL_SKELETON        || gil == GIL_SUMMONED_SKELETON       ||
-      gil == GIL_SKELETON_MAGE   || gil == GIL_SHADOWBEAST_SKELETON    ||
-      gil == GIL_ZOMBIE)
-      return true;
-    }
+  if(bool(t&TARGET_TYPE_UNDEAD) && g2 && G2_UNDEAD)
+    return true;
+  if(bool(t&TARGET_TYPE_UNDEAD) && !g2 && G1_UNDEAD)
+    return true;
+
   return false;
   }
 


### PR DESCRIPTION
I was wondering why I couldn't cast the "kill undead" spell on the Zombie-Keeper in the Stone-Circle when retrieving the magical focus.

Tracked it down to the Zombie-Keeper being of guild "Lurker" ;-) .

I've added the G1 guilds to the enum and added the version check to the Npc::isTargetableBySpell().
This seems to be the only location right now that needs to look at the guild in detail.