### PR TITLE
2 additional AI turn actions

### DIFF
--- a/game/game/constants.h
+++ b/game/game/constants.h
@@ -385,6 +385,7 @@ enum Action:uint32_t {
   AI_PrintScreen,
   AI_LookAt,
   AI_WhirlToNpc,
+  AI_TurnAway,
   };
 
 

--- a/game/game/constants.h
+++ b/game/game/constants.h
@@ -383,7 +383,8 @@ enum Action:uint32_t {
   AI_PointAt,
   AI_StopPointAt,
   AI_PrintScreen,
-  AI_LookAt
+  AI_LookAt,
+  AI_WhirlToNpc,
   };
 
 

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -242,6 +242,7 @@ void GameScript::initCommon() {
   bindExternal("ai_lookatnpc",                   &GameScript::ai_lookatnpc);
   bindExternal("ai_removeweapon",                &GameScript::ai_removeweapon);
   bindExternal("ai_unreadyspell",                &GameScript::ai_unreadyspell);
+  bindExternal("ai_turnaway",                    &GameScript::ai_turnaway);
   bindExternal("ai_turntonpc",                   &GameScript::ai_turntonpc);
   bindExternal("ai_whirlaround",                 &GameScript::ai_whirlaround);
   bindExternal("ai_outputsvm",                   &GameScript::ai_outputsvm);
@@ -2919,6 +2920,13 @@ void GameScript::ai_unreadyspell(std::shared_ptr<zenkit::INpc> npcRef) {
   auto npc = findNpc(npcRef);
   if(npc!=nullptr)
     npc->aiPush(AiQueue::aiRemoveWeapon());
+  }
+
+void GameScript::ai_turnaway(std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef) {
+  auto npc  = findNpc(npcRef);
+  auto self = findNpc(selfRef);
+  if(self!=nullptr)
+    self->aiPush(AiQueue::aiTurnAway(npc));
   }
 
 void GameScript::ai_turntonpc(std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef) {

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -243,6 +243,7 @@ void GameScript::initCommon() {
   bindExternal("ai_removeweapon",                &GameScript::ai_removeweapon);
   bindExternal("ai_unreadyspell",                &GameScript::ai_unreadyspell);
   bindExternal("ai_turntonpc",                   &GameScript::ai_turntonpc);
+  bindExternal("ai_whirlaround",                 &GameScript::ai_whirlaround);
   bindExternal("ai_outputsvm",                   &GameScript::ai_outputsvm);
   bindExternal("ai_outputsvm_overlay",           &GameScript::ai_outputsvm_overlay);
   bindExternal("ai_startstate",                  &GameScript::ai_startstate);
@@ -2925,6 +2926,13 @@ void GameScript::ai_turntonpc(std::shared_ptr<zenkit::INpc> selfRef, std::shared
   auto self = findNpc(selfRef);
   if(self!=nullptr)
     self->aiPush(AiQueue::aiTurnToNpc(npc));
+  }
+
+void GameScript::ai_whirlaround(std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef) {
+  auto npc  = findNpc(npcRef);
+  auto self = findNpc(selfRef);
+  if(self!=nullptr)
+    self->aiPush(AiQueue::aiWhirlToNpc(npc));
   }
 
 void GameScript::ai_outputsvm(std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> targetRef, std::string_view name) {

--- a/game/game/gamescript.h
+++ b/game/game/gamescript.h
@@ -374,6 +374,7 @@ class GameScript final {
     void ai_lookatnpc        (std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef);
     void ai_removeweapon     (std::shared_ptr<zenkit::INpc> npcRef);
     void ai_unreadyspell     (std::shared_ptr<zenkit::INpc> npcRef);
+    void ai_turnaway         (std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef);
     void ai_turntonpc        (std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef);
     void ai_whirlaround      (std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef);
     void ai_outputsvm        (std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> targetRef, std::string_view name);

--- a/game/game/gamescript.h
+++ b/game/game/gamescript.h
@@ -375,6 +375,7 @@ class GameScript final {
     void ai_removeweapon     (std::shared_ptr<zenkit::INpc> npcRef);
     void ai_unreadyspell     (std::shared_ptr<zenkit::INpc> npcRef);
     void ai_turntonpc        (std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef);
+    void ai_whirlaround      (std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef);
     void ai_outputsvm        (std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> targetRef, std::string_view name);
     void ai_outputsvm_overlay(std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> targetRef, std::string_view name);
     void ai_startstate       (std::shared_ptr<zenkit::INpc> selfRef, int func, int state, std::string_view wp);

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -1087,7 +1087,7 @@ void PlayerControl::processAutoRotate(Npc& pl, float& rot, uint64_t dt) {
       float step = float(pl.world().script().guildVal().turn_speed[gl]);
       if(actrl[ActGeneric])
         step*=2.f;
-      pl.rotateTo(dp.x,dp.z,step,false,dt);
+      pl.rotateTo(dp.x,dp.z,step,AnimationSolver::TurnType::Std,dt);
       rot = pl.rotation();
       }
     }

--- a/game/graphics/mdlvisual.cpp
+++ b/game/graphics/mdlvisual.cpp
@@ -588,7 +588,8 @@ const Animation::Sequence* MdlVisual::startAnimAndGet(Npc& npc, AnimationSolver:
                                                       uint8_t comb,
                                                       WeaponState st, WalkBit wlk) {
   // for those use MdlVisual::setRotation
-  assert(a!=AnimationSolver::Anim::RotL && a!=AnimationSolver::Anim::RotR);
+  assert(a!=AnimationSolver::Anim::RotL && a!=AnimationSolver::Anim::RotR &&
+         a!=AnimationSolver::Anim::WhirlL && a!=AnimationSolver::Anim::WhirlR);
 
   if(a==AnimationSolver::InteractIn ||
      a==AnimationSolver::InteractOut ||
@@ -651,6 +652,8 @@ const Animation::Sequence* MdlVisual::startAnimAndGet(Npc& npc, AnimationSolver:
         bs = BS_RUN;
     case AnimationSolver::Anim::RotL:
     case AnimationSolver::Anim::RotR:
+    case AnimationSolver::Anim::WhirlL:
+    case AnimationSolver::Anim::WhirlR:
       break;
     case AnimationSolver::Anim::Fall:
     case AnimationSolver::Anim::FallDeep:

--- a/game/graphics/mdlvisual.cpp
+++ b/game/graphics/mdlvisual.cpp
@@ -743,7 +743,11 @@ bool MdlVisual::startAnim(Npc &npc, WeaponState st) {
   }
 
 void MdlVisual::setAnimRotate(Npc &npc, int dir) {
-  skInst->setAnimRotate(solver,npc,fgtMode,dir);
+  skInst->setAnimRotate(solver,npc,fgtMode,AnimationSolver::TurnType::Std,dir);
+  }
+
+void MdlVisual::setAnimWhirl(Npc &npc, int dir) {
+  skInst->setAnimRotate(solver,npc,fgtMode,AnimationSolver::TurnType::Whirl,dir);
   }
 
 void MdlVisual::interrupt() {

--- a/game/graphics/mdlvisual.h
+++ b/game/graphics/mdlvisual.h
@@ -100,6 +100,7 @@ class MdlVisual final {
     bool                           hasAnim        (std::string_view scheme) const;
     void                           stopWalkAnim   (Npc &npc);
     void                           setAnimRotate  (Npc &npc, int dir);
+    void                           setAnimWhirl   (Npc &npc, int dir);
 
     void                           interrupt();
     WeaponState                    fightMode() const { return fgtMode; }

--- a/game/graphics/mesh/animationsolver.cpp
+++ b/game/graphics/mesh/animationsolver.cpp
@@ -277,6 +277,34 @@ const Animation::Sequence* AnimationSolver::implSolveAnim(AnimationSolver::Anim 
       return solveFrm("T_%sWALKWTURNR",st);
     return solveFrm("T_%sRUNTURNR",st);
     }
+  // Whirl around
+  if(a==WhirlL) {
+    // Whirling in water should not happen, but just to make sure
+    if(bool(wlkMode & WalkBit::WM_Dive))
+      return solveFrm("T_DIVETURNL");
+    if(bool(wlkMode & WalkBit::WM_Swim))
+      return solveFrm("T_SWIMTURNL");
+
+    // whirling is only used in G1, but the script function is present
+    // in all games. In G2 all models except the human also have the
+    // needed animation.
+    const Animation::Sequence* s = solveFrm("T_SURPRISE_CCW");
+    if(s==nullptr)
+      s = solveFrm("T_%sRUNTURNL",st);
+    return s;
+    }
+  if(a==WhirlR) {
+    // Whirling in water should not happen, but just to make sure
+    if(bool(wlkMode & WalkBit::WM_Dive))
+      return solveFrm("T_DIVETURNR");
+    if(bool(wlkMode & WalkBit::WM_Swim))
+      return solveFrm("T_SWIMTURNR");
+
+    const Animation::Sequence* s = solveFrm("T_SURPRISE_CW");
+    if(s==nullptr)
+      s = solveFrm("T_%sRUNTURNR",st);
+    return s;
+    }
   // Jump regular
   if(a==Jump)
     return solveFrm("S_JUMP");

--- a/game/graphics/mesh/animationsolver.h
+++ b/game/graphics/mesh/animationsolver.h
@@ -28,6 +28,8 @@ class AnimationSolver final {
       MoveR,
       RotL,
       RotR,
+      WhirlL,
+      WhirlR,
       Fall,
       FallDeep,
       FallDeepA,

--- a/game/graphics/mesh/animationsolver.h
+++ b/game/graphics/mesh/animationsolver.h
@@ -72,6 +72,12 @@ class AnimationSolver final {
       MagNoMana
       };
 
+    enum TurnType : uint8_t {
+      Std = 0,
+      None,
+      Whirl,
+      };
+
     struct Overlay final {
       const Skeleton* skeleton=nullptr;
       uint64_t        time    =0;

--- a/game/graphics/mesh/pose.cpp
+++ b/game/graphics/mesh/pose.cpp
@@ -812,7 +812,7 @@ Vec2 Pose::headRotation() const {
   return Vec2(headRotX,headRotY);
   }
 
-void Pose::setAnimRotate(const AnimationSolver &solver, Npc &npc, WeaponState fightMode, int dir) {
+void Pose::setAnimRotate(const AnimationSolver &solver, Npc &npc, WeaponState fightMode, AnimationSolver::TurnType turn, int dir) {
   const Animation::Sequence *sq = nullptr;
   if(dir==0) {
     if(rotation!=nullptr) {
@@ -823,11 +823,15 @@ void Pose::setAnimRotate(const AnimationSolver &solver, Npc &npc, WeaponState fi
     }
   if(bodyState()!=BS_STAND)
     return;
-  if(dir<0) {
-    sq = solver.solveAnim(AnimationSolver::Anim::RotL,fightMode,npc.walkMode(),*this);
+
+  enum AnimationSolver::Anim ani;
+  if(turn==AnimationSolver::TurnType::Whirl) {
+    ani = (dir<0)?AnimationSolver::Anim::WhirlL:AnimationSolver::Anim::WhirlR;
     } else {
-    sq = solver.solveAnim(AnimationSolver::Anim::RotR,fightMode,npc.walkMode(),*this);
+    ani = (dir<0)?AnimationSolver::Anim::RotL:AnimationSolver::Anim::RotR;
     }
+
+  sq = solver.solveAnim(ani,fightMode,npc.walkMode(),*this);
   if(rotation!=nullptr) {
     if(sq!=nullptr && rotation->name==sq->name)
       return;

--- a/game/graphics/mesh/pose.h
+++ b/game/graphics/mesh/pose.h
@@ -7,6 +7,7 @@
 
 #include "game/constants.h"
 #include "animation.h"
+#include "animationsolver.h"
 #include "resources.h"
 
 class Skeleton;
@@ -84,7 +85,7 @@ class Pose final {
 
     void               setHeadRotation(float dx, float dz);
     Tempest::Vec2      headRotation() const;
-    void               setAnimRotate(const AnimationSolver &solver, Npc &npc, WeaponState fightMode, int dir);
+    void               setAnimRotate(const AnimationSolver &solver, Npc &npc, WeaponState fightMode, AnimationSolver::TurnType turn, int dir);
     auto               setAnimItem(const AnimationSolver &solver, Npc &npc, std::string_view scheme, int state) -> const Animation::Sequence*;
     bool               stopItemStateAnim(const AnimationSolver &solver, uint64_t tickCount);
 

--- a/game/world/aiqueue.cpp
+++ b/game/world/aiqueue.cpp
@@ -98,6 +98,13 @@ AiQueue::AiAction AiQueue::aiRemoveWeapon() {
   return a;
   }
 
+AiQueue::AiAction AiQueue::aiTurnAway(Npc *other) {
+  AiAction a;
+  a.act    = AI_TurnAway;
+  a.target = other;
+  return a;
+  }
+
 AiQueue::AiAction AiQueue::aiTurnToNpc(Npc *other) {
   AiAction a;
   a.act    = AI_TurnToNpc;

--- a/game/world/aiqueue.cpp
+++ b/game/world/aiqueue.cpp
@@ -105,6 +105,13 @@ AiQueue::AiAction AiQueue::aiTurnToNpc(Npc *other) {
   return a;
   }
 
+AiQueue::AiAction AiQueue::aiWhirlToNpc(Npc *other) {
+  AiAction a;
+  a.act    = AI_WhirlToNpc;
+  a.target = other;
+  return a;
+  }
+
 AiQueue::AiAction AiQueue::aiGoToNpc(Npc *other) {
   AiAction a;
   a.act    = AI_GoToNpc;

--- a/game/world/aiqueue.h
+++ b/game/world/aiqueue.h
@@ -46,6 +46,7 @@ class AiQueue {
     static AiAction aiLookAtNpc(Npc* other);
     static AiAction aiStopLookAt();
     static AiAction aiRemoveWeapon();
+    static AiAction aiTurnAway (Npc *other);
     static AiAction aiTurnToNpc(Npc *other);
     static AiAction aiWhirlToNpc(Npc *other);
     static AiAction aiGoToNpc  (Npc *other);

--- a/game/world/aiqueue.h
+++ b/game/world/aiqueue.h
@@ -47,6 +47,7 @@ class AiQueue {
     static AiAction aiStopLookAt();
     static AiAction aiRemoveWeapon();
     static AiAction aiTurnToNpc(Npc *other);
+    static AiAction aiWhirlToNpc(Npc *other);
     static AiAction aiGoToNpc  (Npc *other);
     static AiAction aiGoToNextFp(std::string_view fp);
     static AiAction aiStartState(ScriptFn stateFn, int behavior, Npc *other, Npc* victim, std::string_view wp);

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -2172,6 +2172,20 @@ void Npc::tick(uint64_t dt) {
   implAiTick(dt);
   }
 
+bool Npc::prepareTurn() {
+  const auto st = bodyStateMasked();
+  if(interactive()==nullptr && (st==BS_WALK || st==BS_SNEAK)) {
+    visual.stopWalkAnim(*this);
+    setAnimRotate(0);
+    return false;
+    }
+  if(interactive()==nullptr) {
+    visual.stopWalkAnim(*this);
+    visual.stopDlgAnim(*this);
+    }
+  return true;
+}
+
 void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
   if(isInAir())
     return;
@@ -2191,16 +2205,9 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
       break;
       }
     case AI_TurnToNpc: {
-      const auto st = bodyStateMasked();
-      if(interactive()==nullptr && (st==BS_WALK || st==BS_SNEAK)) {
-        visual.stopWalkAnim(*this);
-        setAnimRotate(0);
+      if(!prepareTurn()) {
         queue.pushFront(std::move(act));
         break;
-        }
-      if(interactive()==nullptr) {
-        visual.stopWalkAnim(*this);
-        visual.stopDlgAnim(*this);
         }
       if(act.target!=nullptr && implTurnTo(*act.target,dt)) {
         queue.pushFront(std::move(act));

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1329,6 +1329,18 @@ bool Npc::implLookAt(float dx, float dy, float dz, uint64_t dt) {
   return false;
   }
 
+bool Npc::implTurnAway(const Npc &oth, uint64_t dt) {
+  if(&oth==this)
+    return true;
+
+  // turn npc's back to oth, so calculate direction from oth to npc
+  auto dx = x-oth.x;
+  auto dz = z-oth.z;
+  auto  gl   = guild();
+  float step = float(owner.script().guildVal().turn_speed[gl]);
+  return rotateTo(dx,dz,step,AnimationSolver::TurnType::Std,dt);
+  }
+
 bool Npc::implTurnTo(const Npc &oth, uint64_t dt) {
   if(&oth==this)
     return true;
@@ -2207,6 +2219,17 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
     case AI_LookAt:{
       currentLookAtNpc=nullptr;
       currentLookAt=act.point;
+      break;
+      }
+    case AI_TurnAway: {
+      if(!prepareTurn()) {
+        queue.pushFront(std::move(act));
+        break;
+        }
+      if(act.target!=nullptr && implTurnAway(*act.target,dt)) {
+        queue.pushFront(std::move(act));
+        break;
+        }
       break;
       }
     case AI_TurnToNpc: {

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1334,21 +1334,25 @@ bool Npc::implTurnTo(const Npc &oth, uint64_t dt) {
     return true;
   auto dx = oth.x-x;
   auto dz = oth.z-z;
-  return implTurnTo(dx,dz,false,dt);
+  return implTurnTo(dx,dz,AnimationSolver::TurnType::Std,dt);
   }
 
-bool Npc::implTurnTo(const Npc& oth, bool noAnim, uint64_t dt) {
+bool Npc::implTurnTo(const Npc& oth, AnimationSolver::TurnType anim, uint64_t dt) {
   if(&oth==this)
     return true;
   auto dx = oth.x-x;
   auto dz = oth.z-z;
-  return implTurnTo(dx,dz,noAnim,dt);
+  return implTurnTo(dx,dz,anim,dt);
   }
 
-bool Npc::implTurnTo(float dx, float dz, bool noAnim, uint64_t dt) {
+bool Npc::implTurnTo(float dx, float dz, AnimationSolver::TurnType anim, uint64_t dt) {
   auto  gl   = guild();
   float step = float(owner.script().guildVal().turn_speed[gl]);
-  return rotateTo(dx,dz,step,noAnim,dt);
+  return rotateTo(dx,dz,step,anim,dt);
+  }
+
+bool Npc::implWhirlTo(const Npc &oth, uint64_t dt) {
+  return implTurnTo(oth,AnimationSolver::TurnType::Whirl,dt);
   }
 
 bool Npc::implGoTo(uint64_t dt) {
@@ -1396,7 +1400,7 @@ bool Npc::implGoTo(uint64_t dt, float destDist) {
         }
       }
     if(finished) {
-      if(go2.flag==Npc::GT_NextFp && implTurnTo(go2.wp->dirX,go2.wp->dirZ,false,dt))
+      if(go2.flag==Npc::GT_NextFp && implTurnTo(go2.wp->dirX,go2.wp->dirZ,AnimationSolver::TurnType::Std,dt))
         return true;
       clearGoTo();
       }
@@ -1405,7 +1409,7 @@ bool Npc::implGoTo(uint64_t dt, float destDist) {
       mvAlgo.tick(dt);
       return true;
       }
-    if(mvAlgo.checkLastBounce() && implTurnTo(dpos.x,dpos.z,false,dt)) {
+    if(mvAlgo.checkLastBounce() && implTurnTo(dpos.x,dpos.z,AnimationSolver::TurnType::Std,dt)) {
       mvAlgo.tick(dt);
       return true;
       }
@@ -1537,7 +1541,7 @@ bool Npc::implAttack(uint64_t dt) {
       if(shootBow()) {
         fghAlgo.consumeAction();
         } else {
-        if(!implTurnTo(*currentTarget,true,dt)) {
+        if(!implTurnTo(*currentTarget,AnimationSolver::TurnType::None,dt)) {
           if(!aimBow())
             setAnim(Anim::Idle);
           }
@@ -1656,10 +1660,10 @@ void Npc::adjustAttackRotation(uint64_t dt) {
   if(currentTarget!=nullptr && !currentTarget->isDown()) {
     auto ws = weaponState();
     if(ws!=WeaponState::NoWeapon) {
-      bool noAnim = !hasAutoroll();
+      enum AnimationSolver::TurnType anim = !hasAutoroll() ? AnimationSolver::TurnType::None : AnimationSolver::TurnType::Std;
       if(ws==WeaponState::Bow || ws==WeaponState::CBow || ws==WeaponState::Mage)
-         noAnim = true;
-      implTurnTo(*currentTarget,noAnim,dt);
+         anim = AnimationSolver::TurnType::None;
+      implTurnTo(*currentTarget,anim,dt);
       }
     }
   }
@@ -1752,15 +1756,16 @@ bool Npc::implAiFlee(uint64_t dt) {
     setAnim(Anim::Idle);
     }
 
+  auto anim = (go2.flag!=GT_No)?AnimationSolver::TurnType::None:AnimationSolver::TurnType::Std;
   if(wp==nullptr || oth.qDistTo(wp)<oth.qDistTo(*this)) {
     auto  dx  = oth.x-x;
     auto  dz  = oth.z-z;
-    if(implTurnTo(-dx,-dz,(go2.flag!=GT_No),dt))
+    if(implTurnTo(-dx,-dz,anim,dt))
       return (go2.flag==GT_Flee);
     } else {
     auto  dx  = wp->x-x;
     auto  dz  = wp->z-z;
-    if(implTurnTo(dx,dz,(go2.flag!=GT_No),dt))
+    if(implTurnTo(dx,dz,anim,dt))
       return (go2.flag==GT_Flee);
     }
 
@@ -2219,6 +2224,17 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
       // currentLookAtNpc = nullptr;
       break;
       }
+    case AI_WhirlToNpc: {
+      if(!prepareTurn()) {
+        queue.pushFront(std::move(act));
+        break;
+        }
+      if(act.target!=nullptr && implWhirlTo(*act.target,dt)) {
+        queue.pushFront(std::move(act));
+        break;
+        }
+      break;
+      }
     case AI_GoToNpc:
       if(!setInteraction(nullptr)) {
         queue.pushFront(std::move(act));
@@ -2555,7 +2571,7 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
     case AI_AlignToFp:{
       if(auto fp = currentFp){
         if(fp->dirX!=0.f || fp->dirZ!=0.f){
-          if(implTurnTo(fp->dirX,fp->dirZ,false,dt))
+          if(implTurnTo(fp->dirX,fp->dirZ,AnimationSolver::TurnType::Std,dt))
             queue.pushFront(std::move(act));
           }
         }
@@ -3223,10 +3239,10 @@ Vec3 Npc::mapBone(std::string_view bone) const {
   }
 
 bool Npc::turnTo(float dx, float dz, bool noAnim, uint64_t dt) {
-  return implTurnTo(dx,dz,noAnim,dt);
+  return implTurnTo(dx,dz,noAnim?AnimationSolver::TurnType::None:AnimationSolver::TurnType::Std,dt);
   }
 
-bool Npc::rotateTo(float dx, float dz, float step, bool noAnim, uint64_t dt) {
+bool Npc::rotateTo(float dx, float dz, float step, AnimationSolver::TurnType anim, uint64_t dt) {
   //step *= (float(dt)/1000.f)*60.f/100.f;
   step *= (float(dt)/1000.f);
 
@@ -3241,26 +3257,32 @@ bool Npc::rotateTo(float dx, float dz, float step, bool noAnim, uint64_t dt) {
   float a  = angleDir(dx,dz);
   float da = a-angle;
 
-  if(noAnim || std::cos(double(da)*M_PI/180.0)>0) {
+  if(anim == AnimationSolver::TurnType::None || std::cos(double(da)*M_PI/180.0)>0) {
     if(float(std::abs(int(da)%180))<=(step*2.f)) {
       setAnimRotate(0);
       setDirection(a);
       return false;
       }
     } else {
-    stopWalkAnimation();
+    visual.stopWalkAnim(*this);
     }
 
   const auto sgn = std::sin(double(da)*M_PI/180.0);
-  if(sgn<0) {
-    setAnimRotate(noAnim ? 0 : +1);
-    setDirection(angle-step);
-    } else
-  if(sgn>0) {
-    setAnimRotate(noAnim ? 0 : -1);
-    setDirection(angle+step);
-    } else {
+  if(sgn==0) {
     setAnimRotate(0);
+    } else {
+      switch(anim) {
+        case AnimationSolver::TurnType::Std:
+          setAnimRotate((sgn<0)?+1:-1);
+          break;
+        case AnimationSolver::TurnType::None:
+          setAnimRotate(0);
+          break;
+        case AnimationSolver::TurnType::Whirl:
+          visual.setAnimWhirl(*this,(sgn<0)?+1:-1);
+          break;
+      }
+      setDirection((sgn<0)?angle-step:angle+step);
     }
   return true;
   }
@@ -3603,7 +3625,7 @@ bool Npc::tickCast(uint64_t dt) {
       }
 
     if(!isPlayer() && currentTarget!=nullptr) {
-      implTurnTo(*currentTarget,true,dt);
+      implTurnTo(*currentTarget,AnimationSolver::TurnType::None,dt);
       }
     }
 

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -495,6 +495,7 @@ class Npc final {
     bool      checkHealth(bool onChange, bool forceKill);
     void      onNoHealth(bool death, HitSound sndMask);
     bool      hasAutoroll() const;
+    bool      prepareTurn();
     void      stopWalkAnimation();
     void      takeDamage(Npc& other, const Bullet* b, const CollideMask bMask, int32_t splId, bool isSpell);
     void      takeFallDamage(const Tempest::Vec3& fallSpeed);

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -356,7 +356,8 @@ class Npc final {
     auto      mapBone(std::string_view bone) const -> Tempest::Vec3;
 
     bool      turnTo  (float dx, float dz, bool noAnim, uint64_t dt);
-    bool      rotateTo(float dx, float dz, float speed, bool anim, uint64_t dt);
+    bool      rotateTo(float dx, float dz, float speed, AnimationSolver::TurnType anim, uint64_t dt);
+    bool      whirlTo(float dx, float dz, float step, uint64_t dt);
     bool      isRotationAllowed() const;
     auto      playAnimByName(std::string_view name, BodyState bs) -> const Animation::Sequence*;
 
@@ -472,8 +473,9 @@ class Npc final {
     bool      implLookAtNpc(uint64_t dt);
     bool      implLookAt (float dx, float dy, float dz, uint64_t dt);
     bool      implTurnTo (const Npc& oth, uint64_t dt);
-    bool      implTurnTo (const Npc& oth, bool noAnim, uint64_t dt);
-    bool      implTurnTo (float dx, float dz, bool noAnim, uint64_t dt);
+    bool      implTurnTo (const Npc& oth, AnimationSolver::TurnType anim, uint64_t dt);
+    bool      implTurnTo (float dx, float dz, AnimationSolver::TurnType anim, uint64_t dt);
+    bool      implWhirlTo(const Npc& oth, uint64_t dt);
     bool      implGoTo   (uint64_t dt);
     bool      implGoTo   (uint64_t dt, float destDist);
     bool      implAttack  (uint64_t dt);

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -472,6 +472,7 @@ class Npc final {
     bool      implLookAtWp(uint64_t dt);
     bool      implLookAtNpc(uint64_t dt);
     bool      implLookAt (float dx, float dy, float dz, uint64_t dt);
+    bool      implTurnAway(const Npc& oth, uint64_t dt);
     bool      implTurnTo (const Npc& oth, uint64_t dt);
     bool      implTurnTo (const Npc& oth, AnimationSolver::TurnType anim, uint64_t dt);
     bool      implTurnTo (float dx, float dz, AnimationSolver::TurnType anim, uint64_t dt);


### PR DESCRIPTION
AI_WhirlAround is doing the same as ai_turntonpc, just faster.
The script does not contain specific values for whirl-speed, so just use
double of the NPc's turn-speed.

AI_turnaway does what the name implies and turns the back to the npc.
There might be a nicer way to calculate that angle than in my code.