### PR TITLE
Prevent deadlocking the perceptionProcess when perceptiontime is not set

### DIFF
--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -3837,6 +3837,12 @@ bool Npc::perceptionProcess(Npc &pl) {
   if(isPlayer())
     return true;
 
+  // Prevent deadlocking the perception handling
+  if(perceptionTime == 0) {
+    Log::e("Fixing 0 perception time of Npc ",displayName());
+    setPerceptionTime(1000);
+    }
+
   bool ret=false;
   if(processPolicy()!=Npc::AiNormal) {
     perceptionNextTime = owner.tickCount()+perceptionTime;


### PR DESCRIPTION
It seems some Npc do not get a perception-time set, which lets it stay at 0. If the perceptionProcess runs with that value, it will immediately rerun itself again, potentially leading to a deadlock.

The Npc where this happens in practice is the Firedemon in Xardas' tower in Gothic 1. When the player reaches it, all Npc (and player) motion will stop and with enabled logging, everthing will be flooded with messages about the Firedemon perception process - rerunning the AssessPlayer routine over and over.