### PR TITLE
Protect the renderer against not finding any valid shadow or zbuffer formats

### DIFF
--- a/game/graphics/renderer.cpp
+++ b/game/graphics/renderer.cpp
@@ -46,6 +46,7 @@ Renderer::Renderer(Tempest::Swapchain& swapchain)
     TextureFormat::Depth16,
     TextureFormat::Depth24x8,
     TextureFormat::Depth32F,
+    TextureFormat::Last,
     };
 
   for(auto& i:sfrm) {
@@ -53,18 +54,23 @@ Renderer::Renderer(Tempest::Swapchain& swapchain)
       shadowFormat = i;
       break;
       }
+    if(i==TextureFormat::Last)
+      throw std::runtime_error("no valid shadow format - broken graphics driver?");
     }
 
   static const TextureFormat zfrm[] = {
     TextureFormat::Depth32F,
     TextureFormat::Depth24x8,
     TextureFormat::Depth16,
+    TextureFormat::Last,
     };
   for(auto& i:zfrm) {
     if(device.properties().hasDepthFormat(i) && device.properties().hasSamplerFormat(i)){
       zBufferFormat = i;
       break;
       }
+    if(i==TextureFormat::Last)
+      throw std::runtime_error("no valid zBuffer format - broken graphics driver?");
     }
 
   // crappy rasbery-pi like hardware


### PR DESCRIPTION
While unlikely, there may be cases with broken or not yet feature-complete graphics drivers, where the renderer might not find valid formats for shadows or zbuffers.

When that happens the default values will stay in place and the game will fail later with very obscure exceptions.

The TextureFormat enum in Tempest already has a "Last" element, so use that as a sentinel to catch the no-valid-format case.

As there is no way to recover from this and it shouldn't happen in the first place, throw an exception.