### PR TITLE
Fix a non-working player check

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1163,7 +1163,7 @@ void GameScript::invokePickLock(Npc& npc, int bSuccess, int bBrokenOpen) {
   }
 
 void GameScript::invokeRefreshAtInsert(Npc& npc) {
-  if(B_RefreshAtInsert==nullptr)
+  if(B_RefreshAtInsert==nullptr || owner.version().game!=2)
     return;
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(B_RefreshAtInsert);

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -156,8 +156,8 @@ struct Npc::TransformBack {
   };
 
 
-Npc::Npc(World &owner, size_t instance, std::string_view waypoint)
-  :owner(owner),mvAlgo(*this) {
+Npc::Npc(World &owner, size_t instance, std::string_view waypoint, ProcessPolicy aiPolicy)
+  :owner(owner),aiPolicy(aiPolicy),mvAlgo(*this) {
   outputPipe          = owner.script().openAiOuput();
 
   hnpc = std::make_shared<zenkit::INpc>();

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -490,9 +490,7 @@ bool Npc::resetPositionToTA() {
     invent.autoEquipWeapons(*this);
     }
 
-  if(g2)
-    owner.script().invokeRefreshAtInsert(*this);
-
+  owner.script().invokeRefreshAtInsert(*this);
   return true;
   }
 

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -74,7 +74,7 @@ class Npc final {
 
     using Anim = AnimationSolver::Anim;
 
-    Npc(World &owner, size_t instance, std::string_view waypoint);
+    Npc(World &owner, size_t instance, std::string_view waypoint, ProcessPolicy aiPolicy = AiNormal);
     Npc(const Npc&)=delete;
     ~Npc();
 

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -130,9 +130,8 @@ void World::createPlayer(std::string_view cls) {
   if(id==size_t(-1))
     return;
   std::string_view waypoint = wmatrix->startPoint().name;
-  auto             npc      = std::make_unique<Npc>(*this,id,waypoint);
+  auto             npc      = std::make_unique<Npc>(*this,id,waypoint,Npc::ProcessPolicy::Player);
   npcPlayer = wobj.insertPlayer(std::move(npc),waypoint);
-  npcPlayer->setProcessPolicy(Npc::ProcessPolicy::Player);
   game.script()->setInstanceNPC("HERO",*npcPlayer);
   }
 

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -130,8 +130,8 @@ void World::createPlayer(std::string_view cls) {
   if(id==size_t(-1))
     return;
   std::string_view waypoint = wmatrix->startPoint().name;
-  auto             npc      = std::make_unique<Npc>(*this,id,waypoint,Npc::ProcessPolicy::Player);
-  npcPlayer = wobj.insertPlayer(std::move(npc),waypoint);
+  auto             npc      = std::make_unique<Npc>(*this, id, waypoint, Npc::ProcessPolicy::Player);
+  npcPlayer = wobj.insertPlayer(std::move(npc), waypoint);
   game.script()->setInstanceNPC("HERO",*npcPlayer);
   }
 

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -322,8 +322,7 @@ Npc* WorldObjects::addNpc(size_t npcInstance, const Vec3& pos) {
   Npc* npc   = new Npc(owner,npcInstance,pstr);
   npc->setPosition  (pos.x,pos.y,pos.z);
   npc->updateTransform();
-  if(owner.version().game==2)
-    owner.script().invokeRefreshAtInsert(*npc);
+  owner.script().invokeRefreshAtInsert(*npc);
 
   npcArr.emplace_back(npc);
   return npc;

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -322,6 +322,8 @@ Npc* WorldObjects::addNpc(size_t npcInstance, const Vec3& pos) {
   Npc* npc   = new Npc(owner,npcInstance,pstr);
   npc->setPosition  (pos.x,pos.y,pos.z);
   npc->updateTransform();
+  if(owner.version().game==2)
+    owner.script().invokeRefreshAtInsert(*npc);
 
   npcArr.emplace_back(npc);
   return npc;


### PR DESCRIPTION
As described in https://github.com/Try/OpenGothic/issues/722 we don't know if `aiPolicy==Player` in npc constructor which means best weapon equip has to be done later.

One of the `addNpc` functions already does this indirectly by calling `restPositionToTA`. The other one is never called for the player so weapon equip can be done here safely as well. This covers the case when marvin insert command is used which was the original motivation to do this in the constructor, see https://github.com/Try/OpenGothic/pull/653#issuecomment-2243476855.

Regarding the mentioned summons, I modified the wolf spell to summon the hero instead. Weapon was equipped while script had only a `createInvItem` line.

Fixes https://github.com/Try/OpenGothic/issues/722