### PR TITLE
Implement Gothic1 behaviour for missing items

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -973,48 +973,60 @@ void GameScript::printCannotBuyError(Npc &npc) {
 
 void GameScript::printMobMissingItem(Npc &npc) {
   auto id = vm.find_symbol_by_name("player_mob_missing_item");
-  if(id==nullptr)
+  if(id==nullptr) {
+    npc_playani(npc.handlePtr(), "T_DONTKNOW");
     return;
+  }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
 
 void GameScript::printMobMissingKey(Npc& npc) {
   auto id = vm.find_symbol_by_name("player_mob_missing_key");
-  if(id==nullptr)
+  if(id==nullptr) {
+    npc_playani(npc.handlePtr(), "T_DONTKNOW");
     return;
+  }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
 
 void GameScript::printMobAnotherIsUsing(Npc &npc) {
   auto id = vm.find_symbol_by_name("player_mob_another_is_using");
-  if(id==nullptr)
+  if(id==nullptr) {
+    npc_playani(npc.handlePtr(), "T_DONTKNOW");
     return;
+  }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
 
 void GameScript::printMobMissingKeyOrLockpick(Npc& npc) {
   auto id = vm.find_symbol_by_name("player_mob_missing_key_or_lockpick");
-  if(id==nullptr)
+  if(id==nullptr) {
+    npc_playani(npc.handlePtr(), "T_DONTKNOW");
     return;
+  }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
 
 void GameScript::printMobMissingLockpick(Npc& npc) {
   auto id = vm.find_symbol_by_name("player_mob_missing_lockpick");
-  if(id==nullptr)
+  if(id==nullptr) {
+    npc_playani(npc.handlePtr(), "T_DONTKNOW");
     return;
+  }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
 
 void GameScript::printMobTooFar(Npc& npc) {
   auto id = vm.find_symbol_by_name("player_mob_too_far_away");
-  if(id==nullptr)
+  if(id==nullptr) {
+    npc_playani(npc.handlePtr(), "T_DONTKNOW");
     return;
+  }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
@@ -1287,8 +1299,10 @@ uint32_t GameScript::messageTime(std::string_view id) const {
 
 void GameScript::printNothingToGet() {
   auto id = vm.find_symbol_by_name("player_plunder_is_empty");
-  if(id==nullptr)
+  if(id==nullptr) {
+    npc_playani(owner.player()->handlePtr(), "T_DONTKNOW");
     return;
+  }
   ScopeVar self(*vm.global_self(), owner.player()->handlePtr());
   vm.call_function<void>(id);
   }

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -974,9 +974,10 @@ void GameScript::printCannotBuyError(Npc &npc) {
 void GameScript::printMobMissingItem(Npc &npc) {
   auto id = vm.find_symbol_by_name("player_mob_missing_item");
   if(id==nullptr) {
-    npc_playani(npc.handlePtr(), "T_DONTKNOW");
+    if(owner.version().game==1)
+      owner.player()->playAnimByName("T_DONTKNOW", BS_NONE);
     return;
-  }
+    }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
@@ -984,9 +985,10 @@ void GameScript::printMobMissingItem(Npc &npc) {
 void GameScript::printMobMissingKey(Npc& npc) {
   auto id = vm.find_symbol_by_name("player_mob_missing_key");
   if(id==nullptr) {
-    npc_playani(npc.handlePtr(), "T_DONTKNOW");
+    if(owner.version().game==1)
+      owner.player()->playAnimByName("T_DONTKNOW", BS_NONE);
     return;
-  }
+    }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
@@ -994,9 +996,10 @@ void GameScript::printMobMissingKey(Npc& npc) {
 void GameScript::printMobAnotherIsUsing(Npc &npc) {
   auto id = vm.find_symbol_by_name("player_mob_another_is_using");
   if(id==nullptr) {
-    npc_playani(npc.handlePtr(), "T_DONTKNOW");
+    if(owner.version().game==1)
+      owner.player()->playAnimByName("T_DONTKNOW", BS_NONE);
     return;
-  }
+    }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
@@ -1004,9 +1007,10 @@ void GameScript::printMobAnotherIsUsing(Npc &npc) {
 void GameScript::printMobMissingKeyOrLockpick(Npc& npc) {
   auto id = vm.find_symbol_by_name("player_mob_missing_key_or_lockpick");
   if(id==nullptr) {
-    npc_playani(npc.handlePtr(), "T_DONTKNOW");
+    if(owner.version().game==1)
+      owner.player()->playAnimByName("T_DONTKNOW", BS_NONE);
     return;
-  }
+    }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
@@ -1014,9 +1018,10 @@ void GameScript::printMobMissingKeyOrLockpick(Npc& npc) {
 void GameScript::printMobMissingLockpick(Npc& npc) {
   auto id = vm.find_symbol_by_name("player_mob_missing_lockpick");
   if(id==nullptr) {
-    npc_playani(npc.handlePtr(), "T_DONTKNOW");
+    if(owner.version().game==1)
+      owner.player()->playAnimByName("T_DONTKNOW", BS_NONE);
     return;
-  }
+    }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
@@ -1024,9 +1029,9 @@ void GameScript::printMobMissingLockpick(Npc& npc) {
 void GameScript::printMobTooFar(Npc& npc) {
   auto id = vm.find_symbol_by_name("player_mob_too_far_away");
   if(id==nullptr) {
-    npc_playani(npc.handlePtr(), "T_DONTKNOW");
+    owner.player()->playAnimByName("T_DONTKNOW", BS_NONE);
     return;
-  }
+    }
   ScopeVar self(*vm.global_self(), npc.handlePtr());
   vm.call_function<void>(id);
   }
@@ -1300,9 +1305,10 @@ uint32_t GameScript::messageTime(std::string_view id) const {
 void GameScript::printNothingToGet() {
   auto id = vm.find_symbol_by_name("player_plunder_is_empty");
   if(id==nullptr) {
-    npc_playani(owner.player()->handlePtr(), "T_DONTKNOW");
+    if(owner.version().game==1)
+      owner.player()->playAnimByName("T_DONTKNOW", BS_NONE);
     return;
-  }
+    }
   ScopeVar self(*vm.global_self(), owner.player()->handlePtr());
   vm.call_function<void>(id);
   }


### PR DESCRIPTION
The Gothic 2 script provides callback functions when the inventory of a npc is empty or too far away, the player is missing a key for a chest or another npc is using an object.

Vanilla Gothic 1 is less sophisticated and will just play the shoulder shrug animation (T_DONTKNOW). There is no textual output displayed in vanilla g1 for any of the mentioned cases, although the script seems to contain at least an unused text definition _STR_MESSAGE_INTERACT_NO_KEY for the chest-without-key/-lockpick case.

Implement this behaviour as a fallback when the engine can't find the symbol in the script, as right now the player character just does nothing.

The T_DONTKNOW animation is also the animation played in Gothic 2 from inside the callback functions.