### PR TITLE
Implement opening the map via hotkey in Gothic 1

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1169,10 +1169,28 @@ CollideMask GameScript::canNpcCollideWithSpell(Npc& npc, Npc* shooter, int32_t s
   return CollideMask(vm.call_function<int>(fn, spellId));
   }
 
+// Gothic 1 only differentiates between the two worldmap types with and
+// without the orc addition and does this inside the code, not the script
+int GameScript::playerHotKeyScreenMap_G1(Npc& pl) {
+  size_t map = findSymbolIndex("itwrworldmap_orc");
+  if(map==size_t(-1) || pl.itemCount(uint32_t(map))<1)
+    map = findSymbolIndex("itwrworldmap");
+
+  if(map==size_t(-1) || pl.itemCount(uint32_t(map))<1)
+    return -1;
+
+  pl.useItem(size_t(map));
+
+  return int(map);
+  }
+
 int GameScript::playerHotKeyScreenMap(Npc& pl) {
   auto fn   = vm.find_symbol_by_name("player_hotkey_screen_map");
-  if(fn==nullptr)
-    return -1;
+  if(fn==nullptr) {
+    if(owner.version().game==1)
+      return playerHotKeyScreenMap_G1(pl); else
+      return -1;
+    }
 
   ScopeVar self(*vm.global_self(), pl.handlePtr());
   int map = vm.call_function<int>(fn);

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1173,13 +1173,13 @@ CollideMask GameScript::canNpcCollideWithSpell(Npc& npc, Npc* shooter, int32_t s
 // without the orc addition and does this inside the code, not the script
 int GameScript::playerHotKeyScreenMap_G1(Npc& pl) {
   size_t map = findSymbolIndex("itwrworldmap_orc");
-  if(map==size_t(-1) || pl.itemCount(uint32_t(map))<1)
+  if(map==size_t(-1) || pl.itemCount(map)<1)
     map = findSymbolIndex("itwrworldmap");
 
-  if(map==size_t(-1) || pl.itemCount(uint32_t(map))<1)
+  if(map==size_t(-1) || pl.itemCount(map)<1)
     return -1;
 
-  pl.useItem(size_t(map));
+  pl.useItem(map);
 
   return int(map);
   }
@@ -1188,8 +1188,8 @@ int GameScript::playerHotKeyScreenMap(Npc& pl) {
   auto fn   = vm.find_symbol_by_name("player_hotkey_screen_map");
   if(fn==nullptr) {
     if(owner.version().game==1)
-      return playerHotKeyScreenMap_G1(pl); else
-      return -1;
+      return playerHotKeyScreenMap_G1(pl);
+    return -1;
     }
 
   ScopeVar self(*vm.global_self(), pl.handlePtr());

--- a/game/game/gamescript.h
+++ b/game/game/gamescript.h
@@ -140,6 +140,7 @@ class GameScript final {
     void invokeRefreshAtInsert(Npc& npc);
     auto canNpcCollideWithSpell(Npc& npc, Npc* shooter, int32_t spellId) -> CollideMask;
 
+    int  playerHotKeyScreenMap_G1(Npc& pl);
     int  playerHotKeyScreenMap(Npc& pl);
     void playerHotLamePotion(Npc& pl);
     void playerHotLameHeal(Npc& pl);


### PR DESCRIPTION
Where Gothic 2 has a script function player_hotkey_screen_map() that gets called on the map-hotkey and is expected to provide the map to use, Gothic 1 is doing this in-engine.

In Gothic 1 this was of course easy, as there was only one world and experimenting with Vanilla Gothic 1 showed that the hotkey function seems ignores all maps except ITWRWORLDMAP and ITWRWORLDMAP_ORC - world maps with and without the orc-territory addition. The map with the orc-addition takes precedence over the regular map.

Also these two items are the only ITWR* items contained in the actual original Gothic.exe.

So implement a G1 specific script function that gets called when the player_hotkey_screen_map() cannot be found and we're on in Gothic 1.