### PR TITLE
Implement npc_sendsingleperc

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -197,6 +197,7 @@ void GameScript::initCommon() {
   bindExternal("npc_gettarget",                  &GameScript::npc_gettarget);
   bindExternal("npc_getnexttarget",              &GameScript::npc_getnexttarget);
   bindExternal("npc_sendpassiveperc",            &GameScript::npc_sendpassiveperc);
+  bindExternal("npc_sendsingleperc",             &GameScript::npc_sendsingleperc);
   bindExternal("npc_checkinfo",                  &GameScript::npc_checkinfo);
   bindExternal("npc_getportalguild",             &GameScript::npc_getportalguild);
   bindExternal("npc_isinplayersroom",            &GameScript::npc_isinplayersroom);
@@ -2470,6 +2471,14 @@ void GameScript::npc_sendpassiveperc(std::shared_ptr<zenkit::INpc> npcRef, int i
 
   if(npc && other && victum)
     world().sendPassivePerc(*npc,*other,*victum,id);
+  }
+
+void GameScript::npc_sendsingleperc(std::shared_ptr<zenkit::INpc> npcRef, std::shared_ptr<zenkit::INpc> otherRef, int id) {
+  auto other  = findNpc(otherRef);
+  auto npc    = findNpc(npcRef);
+
+  if(npc && other)
+    other->perceptionProcess(*npc,nullptr,0,PercType(id));
   }
 
 bool GameScript::npc_checkinfo(std::shared_ptr<zenkit::INpc> npcRef, int imp) {

--- a/game/game/gamescript.h
+++ b/game/game/gamescript.h
@@ -329,6 +329,7 @@ class GameScript final {
     bool npc_gettarget       (std::shared_ptr<zenkit::INpc> npcRef);
     bool npc_getnexttarget   (std::shared_ptr<zenkit::INpc> npcRef);
     void npc_sendpassiveperc (std::shared_ptr<zenkit::INpc> npcRef, int id, std::shared_ptr<zenkit::INpc> victimRef, std::shared_ptr<zenkit::INpc> otherRef);
+    void npc_sendsingleperc  (std::shared_ptr<zenkit::INpc> npcRef, std::shared_ptr<zenkit::INpc> otherRef, int id);
     bool npc_checkinfo       (std::shared_ptr<zenkit::INpc> npcRef, int imp);
     int  npc_getportalguild  (std::shared_ptr<zenkit::INpc> npcRef);
     bool npc_isinplayersroom (std::shared_ptr<zenkit::INpc> npcRef);


### PR DESCRIPTION
The worldofgothic function list describes the function [0] as "send perception to a single Npc" and in another forum post [1] the function also is described as "make target react to * from caster"

So it seems correct to directly start the perception process of the target npc for the percid.

This function is for example used in Gothic 1 when the a monster should react to the shrinking spell.

This function does not seem to be used in Gothic 2.

[0] https://www.worldofgothic.de/modifikation/article_371_2.htm#231
[1] https://forum.worldofplayers.de/forum/threads/1544378-How-to-create-VFX-with-separated-origin-and-instigator?p=26210828&viewfull=1#post26210828