### PR TITLE
Don't set victim when picking up an item from the floor

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1053,8 +1053,9 @@ int GameScript::invokeState(Npc* npc, Npc* oth, Npc* vic, ScriptFn fn) {
   if(oth==nullptr){
     // oth=npc; //FIXME: PC_Levelinspektor?
     }
-  if(vic==nullptr)
-    vic=owner.player();
+  if(vic==nullptr){
+    // vic=owner.player();
+    }
 
   if(fn==ZS_Talk){
     if(oth==nullptr || !oth->isPlayer()) {
@@ -2469,8 +2470,8 @@ void GameScript::npc_sendpassiveperc(std::shared_ptr<zenkit::INpc> npcRef, int i
   auto victim = findNpc(victimRef);
   auto npc    = findNpc(npcRef);
 
-  if(npc && other && victim)
-    world().sendPassivePerc(*npc,*other,*victim,id);
+  if(npc && other)
+    world().sendPassivePerc(*npc,*other,victim,id);
   }
 
 void GameScript::npc_sendsingleperc(std::shared_ptr<zenkit::INpc> npcRef, std::shared_ptr<zenkit::INpc> otherRef, int id) {

--- a/game/world/objects/interactive.cpp
+++ b/game/world/objects/interactive.cpp
@@ -337,7 +337,7 @@ void Interactive::implTick(Pos& p) {
 
   if(needToLockpick(npc)) {
     if(p.attachMode) {
-      npc.world().sendPassivePerc(npc,npc,npc,PERC_ASSESSUSEMOB);
+      npc.world().sendPassivePerc(npc,npc,PERC_ASSESSUSEMOB);
       return; // chest is locked - need to crack lock first
       }
     }
@@ -352,12 +352,12 @@ void Interactive::implTick(Pos& p) {
     }
 
   if(state==0 && p.attachMode) {
-    npc.world().sendPassivePerc(npc,npc,npc,PERC_ASSESSUSEMOB);
+    npc.world().sendPassivePerc(npc,npc,PERC_ASSESSUSEMOB);
     emitTriggerEvent(TriggerEvent::T_Trigger);
     }
 
   if(state==stateNum && p.attachMode && reverseState) {
-    npc.world().sendPassivePerc(npc,npc,npc,PERC_ASSESSUSEMOB);
+    npc.world().sendPassivePerc(npc,npc,PERC_ASSESSUSEMOB);
     emitTriggerEvent(TriggerEvent::T_Untrigger);
     }
 

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1807,7 +1807,7 @@ void Npc::takeDamage(Npc &other, const Bullet* b) {
   lastHit = &other;
   if(!isPlayer())
     setOther(&other);
-  owner.sendPassivePerc(*this,other,*this,PERC_ASSESSFIGHTSOUND);
+  owner.sendPassivePerc(*this,other,this,PERC_ASSESSFIGHTSOUND);
 
   if(!(isBlock || isJumpb) || b!=nullptr) {
     takeDamage(other,b,COLL_DOEVERYTHING,0,false);
@@ -1889,12 +1889,12 @@ void Npc::takeDamage(Npc& other, const Bullet* b, const CollideMask bMask, int32
     changeAttribute(ATR_HITPOINTS,-hitResult.value,dontKill);
 
     if(bMask&(COLL_APPLYVICTIMSTATE|COLL_DOEVERYTHING)) {
-      owner.sendPassivePerc(*this,other,*this,PERC_ASSESSOTHERSDAMAGE);
+      owner.sendPassivePerc(*this,other,this,PERC_ASSESSOTHERSDAMAGE);
       if(isUnconscious()){
-        owner.sendPassivePerc(*this,other,*this,PERC_ASSESSDEFEAT);
+        owner.sendPassivePerc(*this,other,this,PERC_ASSESSDEFEAT);
         }
       else if(isDead()) {
-        owner.sendPassivePerc(*this,other,*this,PERC_ASSESSMURDER);
+        owner.sendPassivePerc(*this,other,this,PERC_ASSESSMURDER);
         }
       else {
         if(owner.script().rand(2)==0) {
@@ -3100,7 +3100,7 @@ Item* Npc::takeItem(Item& item) {
 
   it = addItem(std::move(ptr));
   if(isPlayer() && it!=nullptr)
-    owner.sendPassivePerc(*this,*this,*this,*it,PERC_ASSESSTHEFT);
+    owner.sendPassivePerc(*this,*this,*it,PERC_ASSESSTHEFT);
 
   implAniWait(uint64_t(sq->totalTime()));
   return it;
@@ -3325,7 +3325,7 @@ bool Npc::closeWeapon(bool noAnim) {
   currentSpellCast = size_t(-1);
   castNextTime     = 0;
   if(isPlayer())
-    owner.sendPassivePerc(*this,*this,*this,PERC_ASSESSREMOVEWEAPON);
+    owner.sendPassivePerc(*this,*this,PERC_ASSESSREMOVEWEAPON);
   return true;
   }
 
@@ -3491,7 +3491,7 @@ bool Npc::finishingMove() {
   if(doAttack(Anim::AttackFinish,BS_HIT)) {
     currentTarget->hnpc->attribute[ATR_HITPOINTS] = 0;
     currentTarget->checkHealth(true,false);
-    owner.sendPassivePerc(*this,*this,*currentTarget,PERC_ASSESSMURDER);
+    owner.sendPassivePerc(*this,*this,currentTarget,PERC_ASSESSMURDER);
     return true;
     }
   return false;

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -690,12 +690,20 @@ Bullet& World::shootBullet(const Item &itm, const Npc &npc, const Npc *target, c
   return b;
   }
 
-void World::sendPassivePerc(Npc &self, Npc &other, Npc &victim, int32_t perc) {
+void World::sendPassivePerc(Npc &self, Npc &other, int32_t perc) {
+  wobj.sendPassivePerc(self,other,nullptr,nullptr,perc);
+  }
+
+void World::sendPassivePerc(Npc &self, Npc &other, Npc* victim, int32_t perc) {
   wobj.sendPassivePerc(self,other,victim,nullptr,perc);
   }
 
-void World::sendPassivePerc(Npc &self, Npc &other, Npc &victim, Item& item, int32_t perc) {
+void World::sendPassivePerc(Npc &self, Npc &other, Npc* victim, Item& item, int32_t perc) {
   wobj.sendPassivePerc(self,other,victim,&item,perc);
+  }
+
+void World::sendPassivePerc(Npc &self, Npc &other, Item& item, int32_t perc) {
+  wobj.sendPassivePerc(self,other,nullptr,&item,perc);
   }
 
 void World::sendImmediatePerc(Npc& self, Npc& other, Npc& victim, int32_t perc) {

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -163,8 +163,10 @@ class World final {
     Bullet&              shootBullet(const Item &itmId, const Npc& npc, const Npc* target, const Interactive* inter);
     Bullet&              shootSpell(const Item &itm, const Npc &npc, const Npc *target);
 
-    void                 sendPassivePerc  (Npc& self, Npc& other, Npc& victim, int32_t perc);
-    void                 sendPassivePerc  (Npc& self, Npc& other, Npc& victim, Item& item, int32_t perc);
+    void                 sendPassivePerc  (Npc& self, Npc& other, int32_t perc);
+    void                 sendPassivePerc  (Npc& self, Npc& other, Npc* victim, int32_t perc);
+    void                 sendPassivePerc  (Npc& self, Npc& other, Item& item, int32_t perc);
+    void                 sendPassivePerc  (Npc& self, Npc& other, Npc* victim, Item& item, int32_t perc);
 
     void                 sendImmediatePerc(Npc& self, Npc& other, Npc& victim, int32_t perc);
     void                 sendImmediatePerc(Npc& self, Npc& other, Npc& victim, Item& item, int32_t perc);

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -869,13 +869,13 @@ void WorldObjects::setMobRoutine(gtime time, std::string_view scheme, int32_t st
   routines.emplace_back(std::move(st));
   }
 
-void WorldObjects::sendPassivePerc(Npc &self, Npc &other, Npc &victim, Item* itm, int32_t perc) {
+void WorldObjects::sendPassivePerc(Npc &self, Npc &other, Npc* victim, Item* itm, int32_t perc) {
   PerceptionMsg m;
   m.what   = perc;
   m.pos    = self.position();
   m.self   = &self;
   m.other  = &other;
-  m.victim = &victim;
+  m.victim = victim;
   if(itm!=nullptr)
     m.item   = itm->handle().symbol_index();
   sndPerc.push_back(m);

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -130,7 +130,7 @@ class WorldObjects final {
     Interactive*   availableMob(const Npc& pl, std::string_view name);
     void           setMobRoutine(gtime time, std::string_view scheme, int32_t state);
 
-    void           sendPassivePerc  (Npc& self, Npc& other, Npc& victim, Item* itm, int32_t perc);
+    void           sendPassivePerc  (Npc& self, Npc& other, Npc* victim, Item* itm, int32_t perc);
     void           sendImmediatePerc(Npc& self, Npc& other, Npc& victim, Item* itm, int32_t perc);
 
     void           resetPositionToTA();


### PR DESCRIPTION
At least the Gothic 1 script assesses theft differently depending on whether a victim is set or not.

```
if (npc_canseenpc(self, other)) {
        printdebugnpc(pd_zs_check, "...NSC kann den Dieb sehen!");
        if (hlp_isvaliditem(item) && (!hlp_isvalidnpc(victim))) {
            printdebugnpc(pd_zs_check, "...Item wurde aufgehoben!"); // Item picked up
            ...
        }
        else {
            printdebugnpc(pd_zs_check, "...Taschendiebstahl!"); //pickpocket
            ...
        }
```
This causes NPC around an item to tell the player that something is getting stolen right now and also indicates that victim is not always set in the perception process.

So adapt the sent passivePerc accordingly to not transmit the player as victim when picking up items.

GameScript::invokeState() already removed the default setting of other=npc for the !other case in commit 3fc5c39e2095 ("damage from faling") as part of the fix for #18, so do the same for the current default victim setting.

This fixes #717.