### PR TITLE
Implement ai_quicklook

### DIFF
--- a/game/game/constants.h
+++ b/game/game/constants.h
@@ -386,6 +386,7 @@ enum Action:uint32_t {
   AI_LookAt,
   AI_WhirlToNpc,
   AI_TurnAway,
+  AI_QuickLook,
   };
 
 

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -238,6 +238,7 @@ void GameScript::initCommon() {
   bindExternal("ai_standupquick",                &GameScript::ai_standupquick);
   bindExternal("ai_continueroutine",             &GameScript::ai_continueroutine);
   bindExternal("ai_stoplookat",                  &GameScript::ai_stoplookat);
+  bindExternal("ai_quicklook",                   &GameScript::ai_quicklook);
   bindExternal("ai_lookat",                      &GameScript::ai_lookat);
   bindExternal("ai_lookatnpc",                   &GameScript::ai_lookatnpc);
   bindExternal("ai_removeweapon",                &GameScript::ai_removeweapon);
@@ -2894,6 +2895,13 @@ void GameScript::ai_stoplookat(std::shared_ptr<zenkit::INpc> selfRef) {
   auto self = findNpc(selfRef);
   if(self!=nullptr)
     self->aiPush(AiQueue::aiStopLookAt());
+  }
+
+void GameScript::ai_quicklook(std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef) {
+  auto npc  = findNpc(npcRef);
+  auto self = findNpc(selfRef);
+  if(self!=nullptr)
+    self->aiPush(AiQueue::aiQuickLook(npc));
   }
 
 void GameScript::ai_lookat(std::shared_ptr<zenkit::INpc> selfRef, std::string_view waypoint) {

--- a/game/game/gamescript.h
+++ b/game/game/gamescript.h
@@ -370,6 +370,7 @@ class GameScript final {
     void ai_standupquick     (std::shared_ptr<zenkit::INpc> selfRef);
     void ai_continueroutine  (std::shared_ptr<zenkit::INpc> selfRef);
     void ai_stoplookat       (std::shared_ptr<zenkit::INpc> selfRef);
+    void ai_quicklook        (std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef);
     void ai_lookat           (std::shared_ptr<zenkit::INpc> selfRef, std::string_view waypoint);
     void ai_lookatnpc        (std::shared_ptr<zenkit::INpc> selfRef, std::shared_ptr<zenkit::INpc> npcRef);
     void ai_removeweapon     (std::shared_ptr<zenkit::INpc> npcRef);

--- a/game/world/aiqueue.cpp
+++ b/game/world/aiqueue.cpp
@@ -79,6 +79,13 @@ AiQueue::AiAction AiQueue::aiLookAt(const WayPoint* to) {
   return a;
   }
 
+AiQueue::AiAction AiQueue::aiQuickLook(Npc* other) {
+  AiAction a;
+  a.act    = AI_QuickLook;
+  a.target = other;
+  return a;
+  }
+
 AiQueue::AiAction AiQueue::aiLookAtNpc(Npc* other) {
   AiAction a;
   a.act    = AI_LookAtNpc;

--- a/game/world/aiqueue.h
+++ b/game/world/aiqueue.h
@@ -43,6 +43,7 @@ class AiQueue {
     void     onWldItemRemoved(const Item& itm);
 
     static AiAction aiLookAt(const WayPoint* to);
+    static AiAction aiQuickLook(Npc* other);
     static AiAction aiLookAtNpc(Npc* other);
     static AiAction aiStopLookAt();
     static AiAction aiRemoveWeapon();

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -596,6 +596,9 @@ class Npc final {
     Npc*                           currentOther   =nullptr;
     Npc*                           currentVictim  =nullptr;
 
+    Npc*                           quickLookNpc=nullptr;
+    uint64_t                       quickLookEnd=0;
+
     const WayPoint*                currentLookAt=nullptr;
     Npc*                           currentLookAtNpc=nullptr;
     Npc*                           currentTarget  =nullptr;


### PR DESCRIPTION
The quicklook function is meant to have the Npc just move its head to the player for two seconds.

Testcase in vanilla Gothic 1 was at the exchange place, while Diego walks back to the old camp. Stand next to where he is walking and pick up one of the berries, arrows, etc. Diego will continue walking but turn his head over for those 2 seconds.

So the implementation does the same, not changing the currentLookAtNpc but storing the temporary one in a separate variable for the duration of the action. That way this cinematic should not influence any other parts or save/load mechanisms.