### PR TITLE
Fix ammo checking for best weapons

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -2195,7 +2195,7 @@ int GameScript::npc_getdisttonpc(std::shared_ptr<zenkit::INpc> aRef, std::shared
 
 bool GameScript::npc_hasequippedarmor(std::shared_ptr<zenkit::INpc> npcRef) {
   auto npc = findNpc(npcRef);
-  return npc!=nullptr && npc->currentArmour()!=nullptr;
+  return npc!=nullptr && npc->currentArmor()!=nullptr;
   }
 
 void GameScript::npc_setperctime(std::shared_ptr<zenkit::INpc> npcRef, float sec) {
@@ -2292,16 +2292,16 @@ std::shared_ptr<zenkit::IItem> GameScript::npc_getequippedmeleeweapon(std::share
 
 std::shared_ptr<zenkit::IItem> GameScript::npc_getequippedrangedweapon(std::shared_ptr<zenkit::INpc> npcRef) {
   auto npc = findNpc(npcRef);
-  if(npc!=nullptr && npc->currentRangeWeapon() != nullptr){
-    return npc->currentRangeWeapon()->handlePtr();
+  if(npc!=nullptr && npc->currentRangedWeapon() != nullptr) {
+    return npc->currentRangedWeapon()->handlePtr();
     }
   return nullptr;
   }
 
 std::shared_ptr<zenkit::IItem> GameScript::npc_getequippedarmor(std::shared_ptr<zenkit::INpc> npcRef) {
   auto npc = findNpc(npcRef);
-  if(npc!=nullptr && npc->currentArmour()!=nullptr){
-    return npc->currentArmour()->handlePtr();
+  if(npc!=nullptr && npc->currentArmor()!=nullptr) {
+    return npc->currentArmor()->handlePtr();
     }
   return nullptr;
   }
@@ -2342,7 +2342,7 @@ bool GameScript::npc_hasequippedweapon(std::shared_ptr<zenkit::INpc> npcRef) {
   auto npc = findNpc(npcRef);
   return (npc!=nullptr &&
      (npc->currentMeleeWeapon()!=nullptr ||
-      npc->currentRangeWeapon()!=nullptr));
+      npc->currentRangedWeapon()!=nullptr));
   }
 
 bool GameScript::npc_hasequippedmeleeweapon(std::shared_ptr<zenkit::INpc> npcRef) {
@@ -2352,7 +2352,7 @@ bool GameScript::npc_hasequippedmeleeweapon(std::shared_ptr<zenkit::INpc> npcRef
 
 bool GameScript::npc_hasequippedrangedweapon(std::shared_ptr<zenkit::INpc> npcRef) {
   auto npc = findNpc(npcRef);
-  return npc!=nullptr && npc->currentRangeWeapon()!=nullptr;
+  return npc!=nullptr && npc->currentRangedWeapon()!=nullptr;
   }
 
 int GameScript::npc_getactivespell(std::shared_ptr<zenkit::INpc> npcRef) {
@@ -3065,7 +3065,7 @@ int GameScript::ai_equipbestmeleeweapon(std::shared_ptr<zenkit::INpc> npcRef) {
 int GameScript::ai_equipbestrangedweapon(std::shared_ptr<zenkit::INpc> npcRef) {
   auto npc = findNpc(npcRef);
   if(npc!=nullptr)
-    npc->aiPush(AiQueue::aiEquipBestRangeWeapon());
+    npc->aiPush(AiQueue::aiEquipBestRangedWeapon());
   return 0;
   }
 
@@ -3104,7 +3104,7 @@ void GameScript::ai_readymeleeweapon(std::shared_ptr<zenkit::INpc> npcRef) {
 void GameScript::ai_readyrangedweapon(std::shared_ptr<zenkit::INpc> npcRef) {
   auto npc = findNpc(npcRef);
   if(npc!=nullptr)
-    npc->aiPush(AiQueue::aiReadyRangeWeapon());
+    npc->aiPush(AiQueue::aiReadyRangedWeapon());
   }
 
 void GameScript::ai_readyspell(std::shared_ptr<zenkit::INpc> npcRef, int spell, int mana) {

--- a/game/game/inventory.cpp
+++ b/game/game/inventory.cpp
@@ -116,7 +116,7 @@ void Inventory::implLoad(Npc* owner, World& world, Serialize &s) {
   s.read(stateSlot.slot);
   stateSlot.item = readPtr(s);
 
-  armour = readPtr(s);
+  armor  = readPtr(s);
   belt   = readPtr(s);
   amulet = readPtr(s);
   ringL  = readPtr(s);
@@ -164,7 +164,7 @@ void Inventory::save(Serialize &fout) const {
   fout.write(ammotSlot.slot,indexOf(ammotSlot.item));
   fout.write(stateSlot.slot,indexOf(stateSlot.item));
 
-  fout.write(indexOf(armour));
+  fout.write(indexOf(armor) );
   fout.write(indexOf(belt)  );
   fout.write(indexOf(amulet));
   fout.write(indexOf(ringL) );
@@ -350,8 +350,8 @@ bool Inventory::unequip(size_t cls, Npc &owner) {
   }
 
 void Inventory::unequip(Item *it, Npc &owner) {
-  if(armour==it) {
-    setSlot(armour,nullptr,owner,false);
+  if(armor==it) {
+    setSlot(armor,nullptr,owner,false);
     return;
     }
   if(belt==it) {
@@ -414,7 +414,7 @@ bool Inventory::setSlot(Item *&slot, Item* next, Npc& owner, bool force) {
     auto  mainFlag = ItmFlags(itData.main_flag);
     auto  flag     = ItmFlags(itData.flags);
 
-    applyArmour(*slot,owner,-1);
+    applyArmor(*slot,owner,-1);
     if(slot->isEquipped())
       slot->setAsEquipped(false);
     if(&slot==active)
@@ -425,13 +425,13 @@ bool Inventory::setSlot(Item *&slot, Item* next, Npc& owner, bool force) {
       owner.setShield(MeshObjects::Mesh());
       }
     else if(mainFlag & ITM_CAT_ARMOR){
-      owner.updateArmour();
+      owner.updateArmor();
       }
     else if(mainFlag & ITM_CAT_NF){
       owner.setSword(MeshObjects::Mesh());
       }
     else if(mainFlag & ITM_CAT_FF){
-      owner.setRangeWeapon(MeshObjects::Mesh());
+      owner.setRangedWeapon(MeshObjects::Mesh());
       }
     vm.invokeItem(&owner,uint32_t(itData.on_unequip));
     }
@@ -443,9 +443,9 @@ bool Inventory::setSlot(Item *&slot, Item* next, Npc& owner, bool force) {
   slot=next;
   slot->setAsEquipped(true);
   slot->setSlot(slotId(slot));
-  applyArmour(*slot,owner,1);
+  applyArmor(*slot,owner,1);
 
-  updateArmourView(owner);
+  updateArmorView (owner);
   updateSwordView (owner);
   updateBowView   (owner);
   updateShieldView(owner);
@@ -460,7 +460,7 @@ bool Inventory::setSlot(Item *&slot, Item* next, Npc& owner, bool force) {
 void Inventory::updateView(Npc& owner) {
   auto& world = owner.world();
 
-  updateArmourView(owner);
+  updateArmorView (owner);
   updateSwordView (owner);
   updateBowView   (owner);
   updateShieldView(owner);
@@ -480,14 +480,14 @@ void Inventory::updateView(Npc& owner) {
     }
   }
 
-void Inventory::updateArmourView(Npc& owner) {
-  if(armour==nullptr)
+void Inventory::updateArmorView(Npc& owner) {
+  if(armor==nullptr)
     return;
 
-  auto& itData = armour->handle();
+  auto& itData = armor->handle();
   auto  flag   = ItmFlags(itData.main_flag);
   if(flag & ITM_CAT_ARMOR)
-    owner.updateArmour();
+    owner.updateArmor();
   }
 
 void Inventory::updateSwordView(Npc &owner) {
@@ -502,14 +502,14 @@ void Inventory::updateSwordView(Npc &owner) {
 
 void Inventory::updateBowView(Npc &owner) {
   if(range==nullptr) {
-    owner.setRangeWeapon(MeshObjects::Mesh());
+    owner.setRangedWeapon(MeshObjects::Mesh());
     return;
     }
 
   auto flag = range->mainFlag();
   if(flag & ITM_CAT_FF){
     auto  vbody  = owner.world().addView(range->handle());
-    owner.setRangeWeapon(std::move(vbody));
+    owner.setRangedWeapon(std::move(vbody));
     }
   }
 
@@ -544,8 +544,8 @@ void Inventory::equipBestMeleeWeapon(Npc &owner) {
     setSlot(melee,a,owner,false);
   }
 
-void Inventory::equipBestRangeWeapon(Npc &owner) {
-  auto a = bestRangeWeapon(owner);
+void Inventory::equipBestRangedWeapon(Npc &owner) {
+  auto a = bestRangedWeapon(owner);
   if(a!=nullptr)
     setSlot(range,a,owner,false);
   }
@@ -555,8 +555,8 @@ void Inventory::unequipWeapons(GameScript &, Npc &owner) {
   setSlot(range,nullptr,owner,false);
   }
 
-void Inventory::unequipArmour(GameScript &, Npc &owner) {
-  setSlot(armour,nullptr,owner,false);
+void Inventory::unequipArmor(GameScript &, Npc &owner) {
+  setSlot(armor,nullptr,owner,false);
   }
 
 void Inventory::clear(GameScript&, Npc&, bool includeMissionItm) {
@@ -802,7 +802,7 @@ bool Inventory::equipNumSlot(Item *next, uint8_t slotHint, Npc &owner, bool forc
   return false;
   }
 
-void Inventory::applyArmour(Item &it, Npc &owner, int32_t sgn) {
+void Inventory::applyArmor(Item &it, Npc &owner, int32_t sgn) {
   for(size_t i=0;i<PROT_MAX;++i){
     auto v = owner.protection(Protection(i));
     owner.changeProtection(Protection(i),v+it.handle().protection[i]*sgn);
@@ -836,7 +836,7 @@ bool Inventory::use(size_t cls, Npc &owner, uint8_t slotHint, bool force) {
     }
 
   if(mainflag & ITM_CAT_ARMOR)
-    return setSlot(armour,it,owner,force);
+    return setSlot(armor,it,owner,force);
 
   if(flag & ITM_BELT)
     return setSlot(belt,it,owner,force);
@@ -889,7 +889,7 @@ bool Inventory::equip(size_t cls, Npc &owner, bool force) {
 void Inventory::invalidateCond(Npc &owner) {
   if(!owner.isPlayer())
     return; // gothic doesn't care
-  invalidateCond(armour,owner);
+  invalidateCond(armor,owner);
   invalidateCond(belt  ,owner);
   invalidateCond(amulet,owner);
   invalidateCond(ringL ,owner);
@@ -911,10 +911,10 @@ void Inventory::autoEquipWeapons(Npc &owner) {
   if(owner.isMonster())
     return;
   equipBestMeleeWeapon(owner);
-  equipBestRangeWeapon(owner);
+  equipBestRangedWeapon(owner);
   }
 
-void Inventory::equipArmour(int32_t cls, Npc &owner) {
+void Inventory::equipArmor(int32_t cls, Npc &owner) {
   if(cls<=0)
     return;
   auto it = findByClass(size_t(cls));
@@ -926,10 +926,10 @@ void Inventory::equipArmour(int32_t cls, Npc &owner) {
     }
   }
 
-void Inventory::equipBestArmour(Npc &owner) {
-  auto a = bestArmour(owner);
+void Inventory::equipBestArmor(Npc &owner) {
+  auto a = bestArmor(owner);
   if(a!=nullptr)
-    setSlot(armour,a,owner,false);
+    setSlot(armor,a,owner,false);
   }
 
 Item *Inventory::findByClass(size_t cls) {
@@ -980,7 +980,7 @@ Item* Inventory::bestItem(Npc &owner, ItmFlags f) {
   return ret;
   }
 
-Item *Inventory::bestArmour(Npc &owner) {
+Item *Inventory::bestArmor(Npc &owner) {
   return bestItem(owner,ITM_CAT_ARMOR);
   }
 
@@ -988,7 +988,7 @@ Item *Inventory::bestMeleeWeapon(Npc &owner) {
   return bestItem(owner,ITM_CAT_NF);
   }
 
-Item *Inventory::bestRangeWeapon(Npc &owner) {
+Item *Inventory::bestRangedWeapon(Npc &owner) {
   return bestItem(owner,ITM_CAT_FF);
   }
 

--- a/game/game/inventory.cpp
+++ b/game/game/inventory.cpp
@@ -540,12 +540,14 @@ void Inventory::updateRuneView(Npc &owner) {
 
 void Inventory::equipBestMeleeWeapon(Npc &owner) {
   auto a = bestMeleeWeapon(owner);
-  setSlot(melee,a,owner,false);
+  if(a!=nullptr)
+    setSlot(melee,a,owner,false);
   }
 
 void Inventory::equipBestRangeWeapon(Npc &owner) {
   auto a = bestRangeWeapon(owner);
-  setSlot(range,a,owner,false);
+  if(a!=nullptr)
+    setSlot(range,a,owner,false);
   }
 
 void Inventory::unequipWeapons(GameScript &, Npc &owner) {
@@ -908,10 +910,8 @@ void Inventory::invalidateCond(Item *&slot, Npc &owner) {
 void Inventory::autoEquipWeapons(Npc &owner) {
   if(owner.isMonster())
     return;
-  auto m = bestMeleeWeapon(owner);
-  auto r = bestRangeWeapon(owner);
-  setSlot(melee ,m,owner,false);
-  setSlot(range ,r,owner,false);
+  equipBestMeleeWeapon(owner);
+  equipBestRangeWeapon(owner);
   }
 
 void Inventory::equipArmour(int32_t cls, Npc &owner) {
@@ -928,7 +928,8 @@ void Inventory::equipArmour(int32_t cls, Npc &owner) {
 
 void Inventory::equipBestArmour(Npc &owner) {
   auto a = bestArmour(owner);
-  setSlot(armour,a,owner,false);
+  if(a!=nullptr)
+    setSlot(armour,a,owner,false);
   }
 
 Item *Inventory::findByClass(size_t cls) {
@@ -967,9 +968,8 @@ Item* Inventory::bestItem(Npc &owner, ItmFlags f) {
       continue;
     if(!i->checkCond(owner))
       continue;
-    // NOTE: not checking itData.munition, as it breaks Cavalorn in G2
-    // if(itData.munition>0 && findByClass(size_t(itData.munition))==nullptr)
-    //   continue;
+    if(itData.munition>0 && findByClass(size_t(itData.munition))==nullptr)
+      continue;
 
     if(std::make_tuple(itData.damage_total, itData.value)>std::make_tuple(damage, value)){
       ret    = i.get();

--- a/game/game/inventory.h
+++ b/game/game/inventory.h
@@ -78,19 +78,19 @@ class Inventory final {
     void   invalidateCond(Npc &owner);
     bool   isChanged() const { return !sorted; }
     void   autoEquipWeapons(Npc &owner);
-    void   equipArmour         (int32_t cls, Npc &owner);
-    void   equipBestArmour     (Npc &owner);
+    void   equipArmor          (int32_t cls, Npc &owner);
+    void   equipBestArmor      (Npc &owner);
     void   equipBestMeleeWeapon(Npc &owner);
-    void   equipBestRangeWeapon(Npc &owner);
+    void   equipBestRangedWeapon(Npc &owner);
     void   unequipWeapons(GameScript &vm, Npc &owner);
-    void   unequipArmour(GameScript &vm, Npc &owner);
+    void   unequipArmor(GameScript &vm, Npc &owner);
     void   clear(GameScript &vm, Npc &owner, bool includeMissionItm = false);
     void   clear(GameScript &vm, Interactive &owner, bool includeMissionItm = false);
     bool   hasSpell(int32_t spl) const;
     bool   hasMissionItems() const;
     bool   hasRangedWeaponWithAmmo() const;
 
-    void   updateArmourView(Npc& owner);
+    void   updateArmorView (Npc& owner);
     void   updateSwordView (Npc& owner);
     void   updateBowView   (Npc& owner);
     void   updateShieldView(Npc& owner);
@@ -103,9 +103,9 @@ class Inventory final {
     void   switchActiveWeapon(Npc &owner, uint8_t slot);
     void   switchActiveSpell (int32_t spell, Npc &owner);
 
-    Item*  currentArmour()         { return armour;     }
+    Item*  currentArmor()          { return armor;      }
     Item*  currentMeleeWeapon()    { return melee;      }
-    Item*  currentRangeWeapon()    { return range;      }
+    Item*  currentRangedWeapon()   { return range;      }
     Item*  currentSpell(uint8_t s) { return numslot[s]; }
     const Item*  currentSpell(uint8_t s) const { return numslot[s]; }
     Item*  findByFlags(ItmFlags f, uint32_t num) const;
@@ -133,16 +133,16 @@ class Inventory final {
 
     bool   setSlot     (Item*& slot, Item *next, Npc &owner, bool force);
     bool   equipNumSlot(Item *next, uint8_t slotHint, Npc &owner, bool force);
-    void   applyArmour (Item& it, Npc &owner, int32_t sgn);
+    void   applyArmor  (Item& it, Npc &owner, int32_t sgn);
 
     Item*  findByClass(size_t cls);
     void   delItem    (Item* it, size_t count, Npc& owner);
     void   invalidateCond(Item*& slot,  Npc &owner);
 
     Item*  bestItem       (Npc &owner, ItmFlags f);
-    Item*  bestArmour     (Npc &owner);
+    Item*  bestArmor      (Npc &owner);
     Item*  bestMeleeWeapon(Npc &owner);
-    Item*  bestRangeWeapon(Npc &owner);
+    Item*  bestRangedWeapon(Npc &owner);
 
     void   applyWeaponStats(Npc &owner, const Item& weap, int sgn);
 
@@ -157,7 +157,7 @@ class Inventory final {
     uint32_t                           indexOf(const Item* it) const;
     Item*                              readPtr(Serialize& fin);
 
-    Item*                              armour     = nullptr;
+    Item*                              armor      = nullptr;
     Item*                              belt       = nullptr;
     Item*                              amulet     = nullptr;
     Item*                              ringL      = nullptr;

--- a/game/game/inventory.h
+++ b/game/game/inventory.h
@@ -78,9 +78,9 @@ class Inventory final {
     void   invalidateCond(Npc &owner);
     bool   isChanged() const { return !sorted; }
     void   autoEquipWeapons(Npc &owner);
-    void   equipArmor          (int32_t cls, Npc &owner);
-    void   equipBestArmor      (Npc &owner);
-    void   equipBestMeleeWeapon(Npc &owner);
+    void   equipArmor           (int32_t cls, Npc &owner);
+    void   equipBestArmor       (Npc &owner);
+    void   equipBestMeleeWeapon (Npc &owner);
     void   equipBestRangedWeapon(Npc &owner);
     void   unequipWeapons(GameScript &vm, Npc &owner);
     void   unequipArmor(GameScript &vm, Npc &owner);

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -76,7 +76,7 @@ void PlayerControl::onKeyPressed(KeyCodec::Action a, Tempest::KeyEvent::KeyType 
       else {
         if(wctrlLast>=WeaponAction::Weapon3 && pl->inventory().currentSpell(static_cast<uint8_t>(wctrlLast-3))==nullptr)
           wctrlLast=WeaponAction::WeaponBow;  //Spell no longer available -> fallback to Bow.
-        if(wctrlLast==WeaponAction::WeaponBow && pl->currentRangeWeapon()==nullptr)
+        if(wctrlLast==WeaponAction::WeaponBow && pl->currentRangedWeapon()==nullptr)
           wctrlLast=WeaponAction::WeaponMele; //Bow no longer available -> fallback to Mele.
         wctrl[wctrlLast] = true;
         }
@@ -631,7 +631,7 @@ void PlayerControl::implMove(uint64_t dt) {
       return;
       }
     if(wctrl[WeaponBow]) {
-      if(pl.currentRangeWeapon()!=nullptr){
+      if(pl.currentRangedWeapon()!=nullptr) {
         wctrl[WeaponBow] = !pl.drawWeaponBow();
         wctrlLast        = WeaponBow;
         } else {

--- a/game/graphics/mdlvisual.cpp
+++ b/game/graphics/mdlvisual.cpp
@@ -112,11 +112,11 @@ void MdlVisual::setBody(Npc& npc, MeshObjects::Mesh&& a, const int32_t version) 
   setObjMatrix(pos);
   }
 
-void MdlVisual::setArmour(Npc& npc, MeshObjects::Mesh&& armour) {
+void MdlVisual::setArmor(Npc& npc, MeshObjects::Mesh&& armor) {
   // NOTE: Giant_Bug have no version tag in attachments;
   // Light dragon hunter armour has broken attachment with no tags
   // Big dragon hunter armour has many atachments with version tags
-  implSetBody(&npc,npc.world(),std::move(armour),-1);
+  implSetBody(&npc,npc.world(),std::move(armor),-1);
   setObjMatrix(pos);
   }
 
@@ -165,7 +165,7 @@ void MdlVisual::setSword(MeshObjects::Mesh &&s) {
   bind(sword,std::move(s),"ZS_RIGHTHAND");
   }
 
-void MdlVisual::setRangeWeapon(MeshObjects::Mesh &&b) {
+void MdlVisual::setRangedWeapon(MeshObjects::Mesh &&b) {
   bind(bow,std::move(b),"ZS_BOW");
   }
 
@@ -286,7 +286,7 @@ void MdlVisual::dropWeapon(Npc& npc) {
   Item* itm = nullptr;
   if(fgtMode==WeaponState::W1H || fgtMode==WeaponState::W2H)
     itm = npc.currentMeleeWeapon(); else
-    itm = npc.currentRangeWeapon();
+    itm = npc.currentRangedWeapon();
 
   if(itm==nullptr)
     return;

--- a/game/graphics/mdlvisual.h
+++ b/game/graphics/mdlvisual.h
@@ -45,10 +45,10 @@ class MdlVisual final {
     void                           delOverlay(const Skeleton*  sk);
     void                           clearOverlays();
 
-    void                           setArmour     (Npc& npc, MeshObjects::Mesh&& armour);
+    void                           setArmor      (Npc& npc, MeshObjects::Mesh&& armor);
     void                           setBody       (Npc& npc, MeshObjects::Mesh&& body, const int32_t version);
     void                           setSword      (MeshObjects::Mesh&& sword);
-    void                           setRangeWeapon(MeshObjects::Mesh&& bow);
+    void                           setRangedWeapon(MeshObjects::Mesh&& bow);
     void                           setShield     (MeshObjects::Mesh&& shield);
     void                           setAmmoItem   (MeshObjects::Mesh&& ammo, std::string_view bone);
     void                           setSlotItem   (MeshObjects::Mesh&& itm,  std::string_view bone);

--- a/game/world/aiqueue.cpp
+++ b/game/world/aiqueue.cpp
@@ -204,7 +204,7 @@ AiQueue::AiAction AiQueue::aiEquipBestMeleeWeapon() {
   return a;
   }
 
-AiQueue::AiAction AiQueue::aiEquipBestRangeWeapon() {
+AiQueue::AiAction AiQueue::aiEquipBestRangedWeapon() {
   AiAction a;
   a.act = AI_EquipRange;
   return a;
@@ -252,7 +252,7 @@ AiQueue::AiAction AiQueue::aiReadyMeleeWeapon() {
   return a;
   }
 
-AiQueue::AiAction AiQueue::aiReadyRangeWeapon() {
+AiQueue::AiAction AiQueue::aiReadyRangedWeapon() {
   AiAction a;
   a.act = AI_DrawWeaponRange;
   return a;

--- a/game/world/aiqueue.h
+++ b/game/world/aiqueue.h
@@ -61,14 +61,14 @@ class AiQueue {
     static AiAction aiEquipArmor(int32_t id);
     static AiAction aiEquipBestArmor();
     static AiAction aiEquipBestMeleeWeapon();
-    static AiAction aiEquipBestRangeWeapon();
+    static AiAction aiEquipBestRangedWeapon();
     static AiAction aiUseMob(std::string_view name,int st);
     static AiAction aiUseItem(int32_t id);
     static AiAction aiUseItemToState(int32_t id, int32_t state);
     static AiAction aiTeleport(const WayPoint& to);
     static AiAction aiDrawWeapon();
     static AiAction aiReadyMeleeWeapon();
-    static AiAction aiReadyRangeWeapon();
+    static AiAction aiReadyRangedWeapon();
     static AiAction aiReadySpell(int32_t spell, int32_t mana);
     static AiAction aiAttack();
     static AiAction aiFlee();

--- a/game/world/objects/item.cpp
+++ b/game/world/objects/item.cpp
@@ -250,7 +250,7 @@ bool Item::isRing() const {
   return flg & ITM_RING;
   }
 
-bool Item::isArmour() const {
+bool Item::isArmor() const {
   auto flg = ItmFlags(mainFlag());
   return flg & ITM_CAT_ARMOR;
   }

--- a/game/world/objects/item.h
+++ b/game/world/objects/item.h
@@ -60,7 +60,7 @@ class Item : public Vob {
     bool                is2H() const;
     bool                isCrossbow() const;
     bool                isRing() const;
-    bool                isArmour() const;
+    bool                isArmor() const;
     bool                isSpellShoot() const;
     bool                isSpellOrRune() const;
     bool                isSpell() const;

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -836,13 +836,13 @@ void Npc::setVisualBody(int32_t headTexNr, int32_t teethTexNr, int32_t bodyTexNr
   auto  vhead = head.empty() ? MeshObjects::Mesh() : owner.addView(FileExt::addExt(head,".MMB"),vHead,vTeeth,bdColor);
   auto  vbody = body.empty() ? MeshObjects::Mesh() : owner.addView(FileExt::addExt(body,".ASC"),vColor,0,bdColor);
   visual.setVisualBody(*this,std::move(vhead),std::move(vbody),bdColor);
-  updateArmour();
+  updateArmor();
 
   durtyTranform|=TR_Pos; // update obj matrix
   }
 
-void Npc::updateArmour() {
-  auto  ar = invent.currentArmour();
+void Npc::updateArmor() {
+  auto  ar = invent.currentArmor();
   auto& w  = owner;
 
   if(ar==nullptr) {
@@ -854,7 +854,7 @@ void Npc::updateArmour() {
     if(flag & ITM_CAT_ARMOR){
       auto& asc   = itData.visual_change;
       auto  vbody = asc.empty() ? MeshObjects::Mesh() : w.addView(asc,vColor,0,bdColor);
-      visual.setArmour(*this,std::move(vbody));
+      visual.setArmor(*this,std::move(vbody));
       }
     }
   }
@@ -864,8 +864,8 @@ void Npc::setSword(MeshObjects::Mesh&& s) {
   updateWeaponSkeleton();
   }
 
-void Npc::setRangeWeapon(MeshObjects::Mesh&& b) {
-  visual.setRangeWeapon(std::move(b));
+void Npc::setRangedWeapon(MeshObjects::Mesh&& b) {
+  visual.setRangedWeapon(std::move(b));
   updateWeaponSkeleton();
   }
 
@@ -897,7 +897,7 @@ void Npc::clearSlotItem(std::string_view slot) {
   }
 
 void Npc::updateWeaponSkeleton() {
-  visual.updateWeaponSkeleton(invent.currentMeleeWeapon(),invent.currentRangeWeapon());
+  visual.updateWeaponSkeleton(invent.currentMeleeWeapon(),invent.currentRangedWeapon());
   }
 
 void Npc::setPhysic(DynamicWorld::NpcItem &&item) {
@@ -2377,16 +2377,16 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
       break;
       }
     case AI_EquipArmor:
-      invent.equipArmour(act.i0,*this);
+      invent.equipArmor(act.i0,*this);
       break;
     case AI_EquipBestArmor:
-      invent.equipBestArmour(*this);
+      invent.equipBestArmor(*this);
       break;
     case AI_EquipMelee:
       invent.equipBestMeleeWeapon(*this);
       break;
     case AI_EquipRange:
-      invent.equipBestRangeWeapon(*this);
+      invent.equipBestRangedWeapon(*this);
       break;
     case AI_UseMob: {
       if(act.i0<0) {
@@ -2518,7 +2518,7 @@ void Npc::nextAiAction(AiQueue& queue, uint64_t dt) {
       invent.unequipWeapons(owner.script(),*this);
       break;
     case AI_UnEquipArmor:
-      invent.unequipArmour(owner.script(),*this);
+      invent.unequipArmor(owner.script(),*this);
       break;
     case AI_Output:
     case AI_OutputSvm:
@@ -3229,16 +3229,16 @@ void Npc::clearInventory() {
   invent.clear(owner.script(),*this);
   }
 
-Item *Npc::currentArmour() {
-  return invent.currentArmour();
+Item *Npc::currentArmor() {
+  return invent.currentArmor();
   }
 
 Item *Npc::currentMeleeWeapon() {
   return invent.currentMeleeWeapon();
   }
 
-Item *Npc::currentRangeWeapon() {
-  return invent.currentRangeWeapon();
+Item *Npc::currentRangedWeapon() {
+  return invent.currentRangedWeapon();
   }
 
 Vec3 Npc::mapWeaponBone() const {
@@ -3436,7 +3436,7 @@ bool Npc::drawWeaponBow() {
   if(!canSwitchWeapon())
     return false;
   auto weaponSt=weaponState();
-  if(weaponSt==WeaponState::Bow || weaponSt==WeaponState::CBow || invent.currentRangeWeapon()==nullptr)
+  if(weaponSt==WeaponState::Bow || weaponSt==WeaponState::CBow || invent.currentRangedWeapon()==nullptr)
     return true;
   if(weaponSt!=WeaponState::NoWeapon) {
     closeWeapon(false);
@@ -3446,7 +3446,7 @@ bool Npc::drawWeaponBow() {
   if(!setInteraction(nullptr,true))
     return false;
 
-  auto& weapon = *invent.currentRangeWeapon();
+  auto& weapon = *invent.currentRangedWeapon();
   auto  st     = weapon.isCrossbow() ? WeaponState::CBow : WeaponState::Bow;
   if(!visual.startAnim(*this,st))
     return false;
@@ -3796,7 +3796,7 @@ bool Npc::shootBow(Interactive* focOverride) {
   b.setOrigin(this);
   b.setDamage(DamageCalculator::rangeDamageValue(*this));
 
-  auto rgn = currentRangeWeapon();
+  auto rgn = currentRangedWeapon();
   if(Gothic::inst().version().game==1) {
     b.setHitChance(float(hnpc->attribute[ATR_DEXTERITY])/100.f);
     if(rgn!=nullptr && rgn->isCrossbow())

--- a/game/world/objects/npc.h
+++ b/game/world/objects/npc.h
@@ -151,9 +151,9 @@ class Npc final {
     void       setVisualBody (int32_t headTexNr, int32_t teethTexNr,
                               int32_t bodyVer, int32_t bodyColor,
                               std::string_view body, std::string_view head);
-    void       updateArmour  ();
+    void       updateArmor   ();
     void       setSword      (MeshObjects::Mesh&& sword);
-    void       setRangeWeapon(MeshObjects::Mesh&& bow);
+    void       setRangedWeapon(MeshObjects::Mesh&& bow);
     void       setShield     (MeshObjects::Mesh&& shield);
     void       setMagicWeapon(Effect&& spell);
     void       setSlotItem   (MeshObjects::Mesh&& itm, std::string_view slot);
@@ -348,9 +348,9 @@ class Npc final {
     void      buyItem    (size_t id, Npc& from,          size_t count=1);
     void      dropItem   (size_t id,                     size_t count=1);
     void      clearInventory();
-    Item*     currentArmour();
+    Item*     currentArmor();
     Item*     currentMeleeWeapon();
-    Item*     currentRangeWeapon();
+    Item*     currentRangedWeapon();
     auto      mapWeaponBone() const -> Tempest::Vec3;
     auto      mapHeadBone() const -> Tempest::Vec3;
     auto      mapBone(std::string_view bone) const -> Tempest::Vec3;

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -723,7 +723,7 @@ Sound World::addWeaponHitEffect(Npc& src, const Bullet* srcArrow, Npc& reciver) 
   pos.translate((p0+p1)*0.5f);
 
   const char* armor = "FL";
-  if(auto a = reciver.currentArmour()) {
+  if(auto a = reciver.currentArmor()) {
     auto m = ItemMaterial(a->handle().material);
     // NOTE: in vanilla only those sfx are defined for armor
     if(m==ItemMaterial::MAT_METAL || m==ItemMaterial::MAT_WOOD)


### PR DESCRIPTION
Ranged weapon auto equip would accidentally unequip current equipped weapon if no best weapon could be found. 

In Cavalorn case this is because script function `EquipItem` doesn't check ammo availability but the `AI_BestWeapon` functions do. So the weapon is first equipped and later unequipped because no best weapon could be found. 

The fix is to just do nothing in this case. For consistency this has been added for armor and melee weapons too but should never be triggered.  I added a second commit to bring variable/function naming in line with script functions.

