### PR TITLE
Fixing some mover bugs

### DIFF
--- a/game/world/triggers/movetrigger.cpp
+++ b/game/world/triggers/movetrigger.cpp
@@ -133,7 +133,10 @@ void MoveTrigger::onGotoMsg(const TriggerEvent& evt) {
 void MoveTrigger::processTrigger(const TriggerEvent& e, bool onTrigger) {
   if(moverKeyFrames.size()==0)
     return;
+  if(state==Loop)
+    return;
   if(state!=Idle) {
+    // FIXME: can lead to infinite amount of events if multiple movers with same name exist
     world.triggerEvent(e);
     return;
     }

--- a/game/world/triggers/movetrigger.cpp
+++ b/game/world/triggers/movetrigger.cpp
@@ -142,16 +142,16 @@ void MoveTrigger::processTrigger(const TriggerEvent& e, bool onTrigger) {
   switch(behavior) {
     case zenkit::MoverBehavior::TOGGLE: {
       if(frame==0) {
-        state = Close;
-        } else {
         state = Open;
+        } else {
+        state = Close;
         }
       break;
       }
     case zenkit::MoverBehavior::TRIGGER_CONTROL: {
       if(onTrigger)
-        state = Close; else
-        state = Open;
+        state = Open; else
+        state = Close;
       break;
       }
     case zenkit::MoverBehavior::OPEN_TIME: {
@@ -206,7 +206,7 @@ void MoveTrigger::tick(uint64_t /*dt*/) {
         }
       return;
       }
-    case Close:{
+    case Open: {
       dt = dt<maxTicks ? dt : maxTicks;
       for(f0=0; f0+1<keyframes.size(); ++f0) {
         if(dt<keyframes[f0].ticks)
@@ -219,7 +219,7 @@ void MoveTrigger::tick(uint64_t /*dt*/) {
       finished = f0==maxFr;
       break;
       }
-    case Open: {
+    case Close: {
       dt = dt<maxTicks ? maxTicks - dt : 0;
       for(f0=0; f0+1<keyframes.size(); ++f0) {
         if(dt<=keyframes[f0].ticks)
@@ -270,9 +270,9 @@ void MoveTrigger::tick(uint64_t /*dt*/) {
       world.triggerEvent(e);
       }
 
-    std::string_view snd = sfxOpenEnd;
-    if(prev==Close)
-      snd = sfxCloseEnd;
+    std::string_view snd = sfxCloseEnd;
+    if(prev==Open)
+      snd = sfxOpenEnd;
     if(prev==NextKey)
       snd = "";
     if(behavior==zenkit::MoverBehavior::OPEN_TIME && prev==Open) {


### PR DESCRIPTION
Swapping `Close` with `Open` fixed  issues:

- **13.2** Death trap with roof coming down `goto waypoint TPL_044`
- **13.4** Uriziel room entry trap  `goto waypoint TPL_191`
- **13.5** Sleeper Temple Arrow Target Puzzle `goto waypoint TPL_085`

in sleeper temple from  https://github.com/Try/OpenGothic/issues/637.

Same issue has been fixed before for `TRIGGER_CONTROL` type movers in https://github.com/Try/OpenGothic/commit/2194ac2d935d0e1ff23ce4250db94a32df6add13

---

If there are multiple movers with same name an infinite retrigger loop could arise on a second  trigger.  Preliminary solution is to never retrigger if mover is in-non idle state. Problematic location: `goto waypoint TPL_062.`

Testing suggests that events are executed immediately and never retriggered e.g if a pillar moves up and the down switch is triggered the movement direction would change instantly. Couldn't come up with something working in general so far, I leave that for a follow-up PR.
