### PR TITLE
Update mover handling

### DIFF
--- a/game/game/serialize.h
+++ b/game/game/serialize.h
@@ -33,7 +33,7 @@ class SaveGameHeader;
 class Serialize {
   public:
     enum Version : uint16_t {
-      Current = 49
+      Current = 50
       };
     Serialize(Tempest::ODevice& fout);
     Serialize(Tempest::IDevice&  fin);

--- a/game/graphics/mesh/animmath.cpp
+++ b/game/graphics/mesh/animmath.cpp
@@ -6,7 +6,7 @@ static float mix(float x,float y,float a){
   return x+(y-x)*a;
   }
 
-static zenkit::Quat slerp(const zenkit::Quat& x, const zenkit::Quat& y, float a) {
+zenkit::Quat slerp(const zenkit::Quat& x, const zenkit::Quat& y, float a) {
   zenkit::Quat z = y;
 
   float cosTheta = x.x*y.x +x.y*y.y + x.z*y.z + x.w*y.w;

--- a/game/graphics/mesh/animmath.h
+++ b/game/graphics/mesh/animmath.h
@@ -6,4 +6,5 @@
 #include <zenkit/ModelAnimation.hh>
 
 zenkit::AnimationSample mix(const zenkit::AnimationSample& x, const zenkit::AnimationSample& y, float a);
+zenkit::Quat            slerp(const zenkit::Quat& x, const zenkit::Quat& y, float a);
 Tempest::Matrix4x4      mkMatrix(const zenkit::AnimationSample& s);

--- a/game/marvin.cpp
+++ b/game/marvin.cpp
@@ -124,8 +124,8 @@ Marvin::Marvin() {
     {"ztimer realtime",            C_TimeRealtime},
     {"ztoggle helpervisuals",      C_Invalid},
     {"ztoggle showzones",          C_Invalid},
-    {"ztrigger %s",                C_Invalid},
-    {"zuntrigger %s",              C_Invalid},
+    {"ztrigger %s",                C_ZTrigger},
+    {"zuntrigger %s",              C_ZUntrigger},
 
     {"cheat full",                 C_CheatFull},
     {"cheat god",                  C_CheatGod},
@@ -401,6 +401,22 @@ bool Marvin::exec(std::string_view v) {
       }
     case C_ToggleDesktop: {
       Gothic::inst().toggleDesktop();
+      return true;
+      }
+    case C_ZTrigger: {
+      World* world = Gothic::inst().world();
+      if(world==nullptr)
+        return false;
+      const TriggerEvent evt(std::string(ret.argv[0]),"",world->tickCount(),TriggerEvent::T_Trigger);
+      world->triggerEvent(evt);
+      return true;
+      }
+    case C_ZUntrigger: {
+      World* world = Gothic::inst().world();
+      if(world==nullptr)
+        return false;
+      const TriggerEvent evt(std::string(ret.argv[0]),"",world->tickCount(),TriggerEvent::T_Untrigger);
+      world->triggerEvent(evt);
       return true;
       }
     case C_Insert: {

--- a/game/marvin.h
+++ b/game/marvin.h
@@ -45,6 +45,9 @@ class Marvin {
       C_ToggleInertia,
       C_ZToggleTimeDemo,
 
+      C_ZTrigger,
+      C_ZUntrigger,
+
       C_AiGoTo,
       C_GoToPos,
       C_GoToVob,

--- a/game/world/triggers/movetrigger.cpp
+++ b/game/world/triggers/movetrigger.cpp
@@ -12,9 +12,13 @@ MoveTrigger::MoveTrigger(Vob* parent, World& world, const zenkit::VMover& mover,
   :AbstractTrigger(parent,world,mover,flags) {
   moverKeyFrames  = mover.keyframes;
   behavior        = mover.behavior;
+  speedType       = mover.speed_mode;
+  lerpType        = mover.lerp_mode;
+  autoRotate      = mover.auto_rotate;
   sfxOpenStart    = mover.sfx_open_start;
-  stayOpenTimeSec = mover.stay_open_time_sec;
+  stayOpenTime    = uint64_t(mover.stay_open_time_sec * 1000.f);
   sfxOpenEnd      = mover.sfx_open_end;
+  sfxCloseStart   = mover.sfx_close_start;
   sfxCloseEnd     = mover.sfx_close_end;
   sfxMoving       = mover.sfx_transitioning;
   visualName      = mover.visual->name;
@@ -59,12 +63,14 @@ MoveTrigger::MoveTrigger(Vob* parent, World& world, const zenkit::VMover& mover,
 
 void MoveTrigger::save(Serialize& fout) const {
   AbstractTrigger::save(fout);
-  fout.write(pos0,uint8_t(state),sAnim,frame);
+  fout.write(pos0,uint8_t(state),frameTime,frame,targetFrame);
   }
 
 void MoveTrigger::load(Serialize& fin) {
   AbstractTrigger::load(fin);
-  fin.read(pos0,reinterpret_cast<uint8_t&>(state),sAnim,frame);
+  fin.read(pos0,reinterpret_cast<uint8_t&>(state),frameTime,frame);
+  if(fin.version()>49)
+    fin.read(targetFrame);
   if(state!=Idle) {
     invalidateView();
     enableTicks();
@@ -111,18 +117,10 @@ void MoveTrigger::setView(MeshObjects::Mesh &&m) {
   view = std::move(m);
   }
 
-void MoveTrigger::emitSound(std::string_view snd,bool freeSlot) {
+void MoveTrigger::emitSound(std::string_view snd,bool freeSlot) const {
   auto p   = position();
   auto sfx = ::Sound(world,::Sound::T_Regular,snd,p,0,freeSlot);
   sfx.play();
-  }
-
-void MoveTrigger::advanceAnim(uint32_t f0, uint32_t f1, float alpha) {
-  alpha    = std::max(0.f,std::min(alpha,1.f));
-  auto fr  = mix(moverKeyFrames[f0],moverKeyFrames[f1],alpha);
-  auto mat = pos0;
-  mat.mul(mkMatrix(fr));
-  setLocalTransform(mat);
   }
 
 void MoveTrigger::invalidateView() {
@@ -142,49 +140,26 @@ void MoveTrigger::moveEvent() {
   }
 
 void MoveTrigger::onTrigger(const TriggerEvent& e) {
-  processTrigger(e,true);
-  }
-
-void MoveTrigger::onUntrigger(const TriggerEvent& e) {
-  if(behavior==zenkit::MoverBehavior::TRIGGER_CONTROL)
-    processTrigger(e,false);
-  }
-
-void MoveTrigger::onGotoMsg(const TriggerEvent& evt) {
-  if(evt.move.key<0 || moverKeyFrames.size()<size_t(evt.move.key))
+  if(moverKeyFrames.size()<2 || keyframes[0].ticks==0)
     return;
-  Log::e("TODO: MoveTrigger::onGotoMsg");
-  }
 
-void MoveTrigger::processTrigger(const TriggerEvent& e, bool onTrigger) {
-  if(moverKeyFrames.size()==0)
-    return;
-  if(state==Loop)
-    return;
-  if(state!=Idle) {
-    // FIXME: can lead to infinite amount of events if multiple movers with same name exist
-    world.triggerEvent(e);
-    return;
-    }
-
-  std::string_view snd = sfxOpenStart;
+  auto prev = state;
   switch(behavior) {
     case zenkit::MoverBehavior::TOGGLE: {
-      if(frame==0) {
-        state = Open;
-        } else {
-        state = Close;
-        }
-      break;
-      }
-    case zenkit::MoverBehavior::TRIGGER_CONTROL: {
-      if(onTrigger)
+      if((frame==0 && state==Idle) || state==Close)
         state = Open; else
         state = Close;
       break;
       }
+    case zenkit::MoverBehavior::TRIGGER_CONTROL: {
+      if(frame==0 && state==Idle)
+        state = Open;
+      break;
+      }
     case zenkit::MoverBehavior::OPEN_TIME: {
-      state = Open;
+      if(state==OpenTimed)
+        frameTime = 0; else
+        state     = Open;
       break;
       }
     case zenkit::MoverBehavior::LOOP: {
@@ -192,127 +167,209 @@ void MoveTrigger::processTrigger(const TriggerEvent& e, bool onTrigger) {
       break;
       }
     case zenkit::MoverBehavior::SINGLE_KEYS: {
-      state = NextKey;
-      break;
-      }
-    }
-
-  sAnim = world.tickCount();
-  enableTicks();
-  // override view
-  invalidateView();
-  emitSound(snd);
-  }
-
-void MoveTrigger::tick(uint64_t /*dt*/) {
-  if(state==Idle || keyframes.size()==0)
-    return;
-
-  uint32_t keySz = uint32_t(moverKeyFrames.size());
-  uint32_t maxFr = uint32_t(moverKeyFrames.size()-1);
-
-  uint64_t maxTicks = 0;
-  for(size_t i=0; ; ++i) {
-    if(i>=keyframes.size())
-      break;
-    if(i+1>=keyframes.size() && state!=Loop && state!=NextKey)
-      break;
-    maxTicks += keyframes[i].ticks;
-    }
-
-  uint64_t dt = world.tickCount()-sAnim, ticks = 0;
-  float    a  = 0;
-  uint32_t f0 = 0, f1 = 0;
-
-  bool finished = false;
-  switch(state) {
-    case Idle:
-      break;
-    case OpenTimed: {
-      if(sAnim+uint64_t(stayOpenTimeSec*1000)<world.tickCount()) {
-        state = Close;
-        sAnim = world.tickCount();
-        }
       return;
       }
-    case Open: {
-      dt = dt<maxTicks ? dt : maxTicks;
-      for(f0=0; f0+1<keyframes.size(); ++f0) {
-        if(dt<keyframes[f0].ticks)
-          break;
-        dt -= keyframes[f0].ticks;
-        }
-      f1       = std::min(f0+1,maxFr);
-      ticks    = keyframes[f0].ticks;
-      a        = ticks>0 ? float(dt)/float(ticks) : 1.f;
-      finished = f0==maxFr;
+    }
+  preProcessTrigger(prev);
+  }
+
+void MoveTrigger::onUntrigger(const TriggerEvent& e) {
+  if(moverKeyFrames.size()<2 || keyframes[0].ticks==0)
+    return;
+  if(behavior!=zenkit::MoverBehavior::TRIGGER_CONTROL)
+    return;
+  if(frame>0 && state==Idle) {
+    state       = Close;
+    targetFrame = 0;
+    preProcessTrigger();
+    }
+  }
+
+void MoveTrigger::onGotoMsg(const TriggerEvent& evt) {
+  if(moverKeyFrames.size()<2 || keyframes[0].ticks==0)
+    return;
+  if(evt.move.key<0 || keyframes.size()<size_t(evt.move.key))
+    return;
+  if(behavior!=zenkit::MoverBehavior::SINGLE_KEYS)
+    return;
+  if(state!=Idle)
+    return;
+  state = SingleKey;
+  switch(evt.move.msg) {
+    case zenkit::MoverMessageType::NEXT:
+      targetFrame = nextFrame(frame);
+      break;
+    case zenkit::MoverMessageType::PREVIOUS:
+      targetFrame = prevFrame(frame);
+      break;
+    case zenkit::MoverMessageType::FIXED_DIRECT:
+    case zenkit::MoverMessageType::FIXED_ORDER:
+      targetFrame = uint32_t(evt.move.key);
       break;
       }
-    case Close: {
-      dt = dt<maxTicks ? maxTicks - dt : 0;
-      for(f0=0; f0+1<keyframes.size(); ++f0) {
-        if(dt<=keyframes[f0].ticks)
-          break;
-        dt -= keyframes[f0].ticks;
-        }
-      f1       = std::min(f0+1,maxFr);
-      ticks    = keyframes[f0].ticks;
-      a        = ticks>0 ? float(dt)/float(ticks) : 1.f;
-      finished = (f0==0 && dt==0);
-      break;
-      }
-    case Loop: {
-      if(maxTicks>0)
-        dt %= maxTicks;
-      for(f0=0; f0+1<keyframes.size(); ++f0) {
-        if(dt<=keyframes[f0].ticks)
-          break;
-        dt -= keyframes[f0].ticks;
-        }
-      f1       = uint32_t(f0+1)%keySz;
-      ticks    = keyframes[f0].ticks;
-      a        = ticks>0 ? float(dt)/float(ticks) : 1.f;
-      break;
-      }
-    case NextKey: {
-      f0       = frame;
-      f1       = uint32_t(f0+1)%uint32_t(moverKeyFrames.size());
-      ticks    = keyframes[f0].ticks;
-      a        = ticks>0 ? float(dt)/float(ticks) : 1.f;
-      a        = std::min(1.f,a);
-      finished = dt>keyframes[f0].ticks;
-      break;
-      }
+    preProcessTrigger();
     }
 
-  advanceAnim(f0,f1,a);
-
-  if(finished) {
-    auto prev = state;
-    state = Idle;
-    frame = f0;
-    invalidateView();
-    disableTicks();
-
-    if(!target.empty()) {
-      TriggerEvent e(target,vobName,TriggerEvent::T_Trigger);
-      world.triggerEvent(e);
+void MoveTrigger::preProcessTrigger(State prev) {
+  if(prev==state || state==Idle)
+    return;
+  if(state==Open) {
+    targetFrame = uint32_t(keyframes.size())-1;
+    emitSound(sfxOpenStart);
+    if(prev==Close) {
+      frameTime = keyframes[frame].ticks - frameTime;
+      frame     = nextFrame(frame);
+      return;
       }
-
-    std::string_view snd = sfxCloseEnd;
-    if(prev==Open)
-      snd = sfxOpenEnd;
-    if(prev==NextKey)
-      snd = "";
-    if(behavior==zenkit::MoverBehavior::OPEN_TIME && prev==Open) {
-      state = OpenTimed;
-      sAnim = world.tickCount();
-      // override view
-      invalidateView();
-      enableTicks();
+    }
+  else if(state==Close) {
+    targetFrame = 0;
+    emitSound(sfxCloseStart);
+    if(prev==Open) {
+      frame     = prevFrame(frame);
+      frameTime = keyframes[frame].ticks - frameTime;
+      return;
       }
-    emitSound(snd);
-    } else {
+    }
+  invalidateView();
+  enableTicks();
+  }
+
+void MoveTrigger::postProcessTrigger() {
+  if(!target.empty()) {
+    TriggerEvent e(target,vobName,TriggerEvent::T_Trigger);
+    world.triggerEvent(e);
+    }
+  if(state==Open)
+    emitSound(sfxOpenEnd);
+  if(state==Close)
+    emitSound(sfxCloseEnd);
+  if(behavior==zenkit::MoverBehavior::OPEN_TIME && state==Open) {
+    state = OpenTimed;
+    return;
+    }
+  state = Idle;
+  invalidateView();
+  disableTicks();
+  }
+
+uint32_t MoveTrigger::nextFrame(uint32_t i) const {
+  uint32_t size = uint32_t(keyframes.size());
+  return (i+1)%size;
+  }
+
+uint32_t MoveTrigger::prevFrame(uint32_t i) const {
+  uint32_t size = uint32_t(keyframes.size());
+  return (i+size-1)%size;
+  }
+
+void MoveTrigger::tick(uint64_t dt) {
+  assert(state!=Idle);
+  frameTime += dt;
+  if(state==OpenTimed) {
+    if(frameTime<=stayOpenTime)
+      return;
+    state       = Close;
+    targetFrame = 0;
+    frameTime  -= stayOpenTime;
+    }
+  advanceAnim();
+  updateFrame();
+  if(frame==targetFrame)
+    postProcessTrigger(); else
     emitSound(sfxMoving);
+  }
+
+void MoveTrigger::updateFrame() {
+  uint32_t f = (state==Close) ? prevFrame(frame) : frame;
+  if(frameTime<keyframes[f].ticks)
+    return;
+  if(state==Close)
+    frame = prevFrame(frame); else
+    frame = nextFrame(frame);
+  frameTime = 0;
+  }
+
+ void MoveTrigger::advanceAnim() {
+  uint32_t f1  = (state==Close) ? prevFrame(frame) : frame;
+  uint32_t f2  = nextFrame(f1);
+  float    a   = calcProgress(f1,f2);
+  auto     m   = calcTransform(f1,f2,a);
+  auto     mat = pos0;
+  mat.mul(m);
+  setLocalTransform(mat);
+  }
+
+float MoveTrigger::calcProgress(uint32_t f1, uint32_t f2) const {
+  float a = float(frameTime)/float(keyframes[f1].ticks);
+  if(state==Close)
+    a = 1 - a;
+  bool start = (f1==0 && state!=Loop);
+  bool end   = (f2==moverKeyFrames.size()-1 && state!=Loop);
+  switch(speedType) {
+    case zenkit::MoverSpeedType::CONSTANT:
+      break;
+    case zenkit::MoverSpeedType::SLOW_START_END:
+    case zenkit::MoverSpeedType::SEGMENT_SLOW_START_END:
+      if((start && end) || speedType==zenkit::MoverSpeedType::SEGMENT_SLOW_START_END)
+        a = (3 - 2*a) * a*a;
+      else if(start)
+        a = (2 - a) * a*a;
+      else if(end)
+        a = ((1 - a)*a + 1)*a;
+      break;
+    case zenkit::MoverSpeedType::SLOW_START:
+    case zenkit::MoverSpeedType::SEGMENT_SLOW_START:
+      if(start || speedType==zenkit::MoverSpeedType::SEGMENT_SLOW_START)
+        a = (2 - a) * a*a;
+      break;
+    case zenkit::MoverSpeedType::SLOW_END:
+    case zenkit::MoverSpeedType::SEGMENT_SLOW_END:
+      if(end || speedType==zenkit::MoverSpeedType::SEGMENT_SLOW_END)
+        a = ((1 - a)*a + 1)*a;
+      break;
     }
+  return std::clamp(a,0.f,1.f);
+  }
+
+Matrix4x4 MoveTrigger::calcTransform(uint32_t f1, uint32_t f2, float a) const {
+  zenkit::AnimationSample fr      = {};
+  Vec3                    forward = {};
+  if(lerpType==zenkit::MoverLerpType::LINEAR) {
+    auto& pos1 = moverKeyFrames[f1].position;
+    auto& pos2 = moverKeyFrames[f2].position;
+    fr      = mix(moverKeyFrames[f1],moverKeyFrames[f2],a);
+    forward = {pos2.x-pos1.x,pos2.y-pos1.y,pos2.z-pos1.z};
+    } else {
+    auto& kF0 = moverKeyFrames[prevFrame(f1)].position;
+    auto& kF1 = moverKeyFrames[f1].position;
+    auto& kF2 = moverKeyFrames[f2].position;
+    auto& kF3 = moverKeyFrames[nextFrame(f2)].position;
+    Vec3  p0  = {kF0.x,kF0.y,kF0.z};
+    Vec3  p1  = {kF1.x,kF1.y,kF1.z};
+    Vec3  p2  = {kF2.x,kF2.y,kF2.z};
+    Vec3  p3  = {kF3.x,kF3.y,kF3.z};
+    Vec3  b1  =  -p0 +   p1 - p2 + p3;
+    Vec3  b2  = 2*p0 - 2*p1 + p2 - p3;
+    Vec3  b3  =  -p0        + p2;
+    Vec3  pos = ((b1*a + b2)*a + b3)*a + p1;
+    forward       = (3*b1*a + 2*b2)*a + b3;
+    fr.position.x = pos.x;
+    fr.position.y = pos.y;
+    fr.position.z = pos.z;
+    fr.rotation   = slerp(moverKeyFrames[f1].rotation,moverKeyFrames[f2].rotation,a);
+    }
+
+  if(!autoRotate)
+    return mkMatrix(fr);
+  Vec3 z  = Vec3::normalize(forward);
+  Vec3 up = std::abs(z.y)<0.999f ? Vec3(0,1,0) : Vec3(1,0,0);
+  Vec3 x  = Vec3::normalize(Vec3::crossProduct(up,z));
+  Vec3 y  = Vec3::crossProduct(z,x);
+  return {
+         x.x, y.x, z.x, fr.position.x,
+         x.y, y.y, z.y, fr.position.y,
+         x.z, y.z, z.z, fr.position.z,
+         0,   0,   0,   1
+         };
   }

--- a/game/world/triggers/movetrigger.h
+++ b/game/world/triggers/movetrigger.h
@@ -20,28 +20,34 @@ class MoveTrigger : public AbstractTrigger {
     void tick(uint64_t dt) override;
 
   private:
-    void  moveEvent() override;
-    void  processTrigger(const TriggerEvent& evt, bool onTrigger);
-
-    void  setView    (MeshObjects::Mesh&& m);
-    void  emitSound  (std::string_view snd, bool freeSlot=true);
-    void  advanceAnim(uint32_t f0, uint32_t f1, float alpha);
-    float scaleRotSpeed (float speed) const;
-
-    void  invalidateView();
-
     enum State : int32_t {
       Idle         = 0,
       Loop         = 1,
       Open         = 2,
       OpenTimed    = 3,
       Close        = 4,
-      NextKey      = 5,
+      SingleKey    = 5,
       };
 
     struct KeyLen {
-      uint64_t ticks    = 0;
+      uint64_t ticks = 0;
       };
+
+    void     moveEvent() override;
+    void     preProcessTrigger(State prev = Idle);
+    void     postProcessTrigger();
+
+    void     setView(MeshObjects::Mesh&& m);
+    void     emitSound(std::string_view snd, bool freeSlot=true) const;
+    void     advanceAnim();
+    float    calcProgress(uint32_t f1, uint32_t f2) const;
+    auto     calcTransform(uint32_t f1, uint32_t f2, float a) const -> Tempest::Matrix4x4;
+    void     updateFrame();
+    uint32_t nextFrame(uint32_t i) const;
+    uint32_t prevFrame(uint32_t i) const;
+    float    scaleRotSpeed(float speed) const;
+
+    void     invalidateView();
 
     Tempest::Matrix4x4                   pos0;
     MeshObjects::Mesh                    view;
@@ -49,14 +55,19 @@ class MoveTrigger : public AbstractTrigger {
     std::vector<KeyLen>                  keyframes;
     std::vector<zenkit::AnimationSample> moverKeyFrames;
     zenkit::MoverBehavior                behavior;
+    zenkit::MoverSpeedType               speedType;
+    zenkit::MoverLerpType                lerpType;
+    bool                                 autoRotate;
     std::string                          sfxOpenStart;
     std::string                          sfxOpenEnd;
+    std::string                          sfxCloseStart;
     std::string                          sfxCloseEnd;
     std::string                          sfxMoving;
     std::string                          visualName;
-    float                                stayOpenTimeSec;
+    uint64_t                             stayOpenTime;
 
-    State                                state     = Idle;
-    uint64_t                             sAnim     = 0;
-    uint32_t                             frame     = 0;
+    State                                state       = Idle;
+    uint64_t                             frameTime   = 0;
+    uint32_t                             frame       = 0;
+    uint32_t                             targetFrame = uint32_t(-1);
   };

--- a/game/world/triggers/movetrigger.h
+++ b/game/world/triggers/movetrigger.h
@@ -20,14 +20,15 @@ class MoveTrigger : public AbstractTrigger {
     void tick(uint64_t dt) override;
 
   private:
-    void moveEvent() override;
-    void processTrigger(const TriggerEvent& evt, bool onTrigger);
+    void  moveEvent() override;
+    void  processTrigger(const TriggerEvent& evt, bool onTrigger);
 
-    void setView     (MeshObjects::Mesh&& m);
-    void emitSound   (std::string_view snd, bool freeSlot=true);
-    void advanceAnim (uint32_t f0, uint32_t f1, float alpha);
+    void  setView    (MeshObjects::Mesh&& m);
+    void  emitSound  (std::string_view snd, bool freeSlot=true);
+    void  advanceAnim(uint32_t f0, uint32_t f1, float alpha);
+    float scaleRotSpeed (float speed) const;
 
-    void invalidateView();
+    void  invalidateView();
 
     enum State : int32_t {
       Idle         = 0,


### PR DESCRIPTION
Main implication for the game experience of this pr are that triggers for non-idle movers are properly handled, fishes move on curves now and speed can be non-constant.

* **Update Speed to tick calculation:**
There are a few movers with extremely slow speed values. For example in Irdorath switch riddle room the gears which are triggered by the two levers have all the same measured movement speed besides speed values given are 0.2,  0.00068 and 0.00028. More values can be found in the commit message.
Speed values for these rotation only movers are taken as rotations per second and scaled if value is irrationally low. First idea was to generally scale low values but that would break harbor boats.

* **Handle repeated trigger events:**
`MoverBehavior::SINGLE_KEYS` and `LOOP` only react to trigger event in idle state. `TOGGLE` and `OPEN_TIME` always react. `TRIGGER_CONTROL` shows confusing behavior while testing where sometimes they behaved like `TOGGLE` type and sometimes wouldn't react at all when sending multiple trigger events. For now treat like `SINGLE_KEY/LOOP`.

* **Support for `MoverMessageType::NEXT:`**
Just makes a mover move to the next keyframe in Open direction. There is only on mover of type `MoverBehavior::SINGLE_KEYS` in both G1/G2 in sleeper temple that requires this functionality. Other types are left out until there's something to test against.

* **Rework mover advance calculation:**
 This allows changing the state e.g. from Open to Close while moving and is necessary for repeated trigger events.

* **Implement some more attributes:**
autoRotate: If true mover "looks" in motion direction. Used exclusively for fish
speedType: defines the global speed behavior. Types are handled like in
CsCamera.
lerpType: defines the curve the mover is following. Type `CURVE`  is
similar to CsCamera Spline. `CURVE` type is only different to `LINEAR` for >3 keyframes which makes this exclusively to fish as well.
sfxCloseStart: Sound to play once mover starts closing.