### PR TITLE
Fix undeclared pthread_setname_np() error

### DIFF
--- a/game/utils/workers.cpp
+++ b/game/utils/workers.cpp
@@ -1,8 +1,3 @@
-// Required by pthread_setname_np()
-#if defined(__GNUC__) && !defined(_GNU_SOURCE)
-#define _GNU_SOURCE
-#endif
-
 #include "workers.h"
 #include "utils/string_frm.h"
 
@@ -15,6 +10,11 @@
 #endif
 
 #if defined(__GNUC__)
+// Required by pthread_setname_np()
+#if !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #include <pthread.h>
 #endif
 

--- a/game/utils/workers.cpp
+++ b/game/utils/workers.cpp
@@ -1,3 +1,8 @@
+// Required by pthread_setname_np()
+#if defined(__GNUC__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+
 #include "workers.h"
 #include "utils/string_frm.h"
 


### PR DESCRIPTION
I tried to compile OpenGothic but it stopped with this error:
```
game/utils/workers.cpp: In static member function ‘static void Workers::setThreadName(const char*)’: 
game/utils/workers.cpp:62:3: error: ‘pthread_setname_np’ was not declared in this scope
   62 |   pthread_setname_np(pthread_self(), threadName);
      |   ^~~~~~~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```
According to:

https://man7.org/linux/man-pages/man3/pthread_setname_np.3.html

the macro `_GNU_SOURCE` is required to be defined for using `pthread_setname_np()`.
Often, this macro is already defined, but in my case it is not, evidently.
So I did this quick patch and I fixed the problem.
It looks like other files include `pthread.h`, so `_GNU_SOURCE` must be declared on top on the file and not where `workers.cpp` includes `pthread.h`.