### PR TITLE
Fix Character Rotation When Stationary & Improve Dialogue Skipping Sync

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1908,7 +1908,7 @@ void GameScript::mdl_setmodelscale(std::shared_ptr<zenkit::INpc> npcRef, float x
 
 void GameScript::mdl_startfaceani(std::shared_ptr<zenkit::INpc> npcRef, std::string_view ani, float intensity, float time) {
   if(npcRef!=nullptr)
-	findNpc(npcRef.get())->startFaceAnim(ani, intensity, uint64_t(time * 1000.f));
+    findNpc(npcRef.get())->startFaceAnim(ani,intensity,uint64_t(time*1000.f));
   }
 
 void GameScript::mdl_applyrandomani(std::shared_ptr<zenkit::INpc> npcRef, std::string_view s1, std::string_view s0) {

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1908,7 +1908,7 @@ void GameScript::mdl_setmodelscale(std::shared_ptr<zenkit::INpc> npcRef, float x
 
 void GameScript::mdl_startfaceani(std::shared_ptr<zenkit::INpc> npcRef, std::string_view ani, float intensity, float time) {
   if(npcRef!=nullptr)
-    findNpc(npcRef.get())->startFaceAnim(ani, intensity, uint64_t(time * 36.9f)); //1000.f to 333.f (for better lip sync)
+    findNpc(npcRef.get())->startFaceAnim(ani, intensity, uint64_t(time * 333.f)); //1000.f to 333.f (for better lip sync)
   }
 
 void GameScript::mdl_applyrandomani(std::shared_ptr<zenkit::INpc> npcRef, std::string_view s1, std::string_view s0) {

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1908,7 +1908,7 @@ void GameScript::mdl_setmodelscale(std::shared_ptr<zenkit::INpc> npcRef, float x
 
 void GameScript::mdl_startfaceani(std::shared_ptr<zenkit::INpc> npcRef, std::string_view ani, float intensity, float time) {
   if(npcRef!=nullptr)
-	  findNpc(npcRef.get())->startFaceAnim(ani, intensity, uint64_t(time * 1000.f));
+	findNpc(npcRef.get())->startFaceAnim(ani, intensity, uint64_t(time * 1000.f));
   }
 
 void GameScript::mdl_applyrandomani(std::shared_ptr<zenkit::INpc> npcRef, std::string_view s1, std::string_view s0) {

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1908,7 +1908,7 @@ void GameScript::mdl_setmodelscale(std::shared_ptr<zenkit::INpc> npcRef, float x
 
 void GameScript::mdl_startfaceani(std::shared_ptr<zenkit::INpc> npcRef, std::string_view ani, float intensity, float time) {
   if(npcRef!=nullptr)
-    findNpc(npcRef.get())->startFaceAnim(ani, intensity, uint64_t(time * 333.f)); //1000.f to 333.f (for better lip sync)
+	  findNpc(npcRef.get())->startFaceAnim(ani, intensity, uint64_t(time * 1000.f));
   }
 
 void GameScript::mdl_applyrandomani(std::shared_ptr<zenkit::INpc> npcRef, std::string_view s1, std::string_view s0) {

--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -1908,7 +1908,7 @@ void GameScript::mdl_setmodelscale(std::shared_ptr<zenkit::INpc> npcRef, float x
 
 void GameScript::mdl_startfaceani(std::shared_ptr<zenkit::INpc> npcRef, std::string_view ani, float intensity, float time) {
   if(npcRef!=nullptr)
-    findNpc(npcRef.get())->startFaceAnim(ani,intensity,uint64_t(time*1000.f));
+    findNpc(npcRef.get())->startFaceAnim(ani, intensity, uint64_t(time * 36.9f)); //1000.f to 333.f (for better lip sync)
   }
 
 void GameScript::mdl_applyrandomani(std::shared_ptr<zenkit::INpc> npcRef, std::string_view s1, std::string_view s0) {

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -1031,7 +1031,7 @@ void PlayerControl::quitPicklock(Npc& pl) {
   }
 
 void PlayerControl::assignRunAngle(Npc& pl, float rotation, uint64_t dt) {
-  //Only assign run angle if player is running (to prevent weird angles when stationary)
+  //Only assign run angle if player is running. (to prevent weird angles when stationary)
   if(pl.isInState(ScriptFn()) && pl.isAttackAnim() && !pl.isFinishingMove()) {
     runAngleDest = 0;
     return;

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -1031,7 +1031,7 @@ void PlayerControl::quitPicklock(Npc& pl) {
   }
 
 void PlayerControl::assignRunAngle(Npc& pl, float rotation, uint64_t dt) {
-  //Only assign run angle if player is running. (to prevent weird angles when stationary)
+  //Only assign run angle if player is running (to prevent weird angles when stationary)
   if(pl.isInState(ScriptFn()) && pl.isAttackAnim() && !pl.isFinishingMove()) {
     runAngleDest = 0;
     return;

--- a/game/game/playercontrol.cpp
+++ b/game/game/playercontrol.cpp
@@ -1031,6 +1031,16 @@ void PlayerControl::quitPicklock(Npc& pl) {
   }
 
 void PlayerControl::assignRunAngle(Npc& pl, float rotation, uint64_t dt) {
+  //Only assign run angle if player is running (to prevent weird angles when stationary)
+  if(pl.isInState(ScriptFn()) && pl.isAttackAnim() && !pl.isFinishingMove()) {
+    runAngleDest = 0;
+    return;
+  }
+  if (pl.animMoveSpeed(0).x < 0 || pl.animMoveSpeed(0).z < 0) {
+    runAngleDest = 0;
+    return;
+  }
+
   float dtF    = (float(dt)/1000.f);
   float angle  = pl.rotation();
   float dangle = (rotation-angle)/dtF;

--- a/game/ui/dialogmenu.cpp
+++ b/game/ui/dialogmenu.cpp
@@ -379,12 +379,14 @@ void DialogMenu::startTrade() {
 
 void DialogMenu::skipPhrase() {
   if(current.time>0) {
-    if(pl!=nullptr)
-      pl->setAiOutputBarrier(0,false);
+    if (pl != nullptr) {
+      pl->setAiOutputBarrier(0, false);
       pl->stopDlgAnim(); //skip pl-dialog phrase
-    if(other!=nullptr)
-      other->setAiOutputBarrier(0,false);
-      other->stopDlgAnim(); //skip npc-dialog phrase
+    }
+    if (other != nullptr) {
+      other->setAiOutputBarrier(0, false);
+      other->stopDlgAnim(); //skip other-dialog phrase
+    }
     currentSnd   = SoundEffect();
     current.time = 1;
     }

--- a/game/ui/dialogmenu.cpp
+++ b/game/ui/dialogmenu.cpp
@@ -381,8 +381,10 @@ void DialogMenu::skipPhrase() {
   if(current.time>0) {
     if(pl!=nullptr)
       pl->setAiOutputBarrier(0,false);
+	  pl->stopDlgAnim(); //skip pl-dialog phrase
     if(other!=nullptr)
       other->setAiOutputBarrier(0,false);
+      other->stopDlgAnim(); //skip npc-dialog phrase
     currentSnd   = SoundEffect();
     current.time = 1;
     }

--- a/game/ui/dialogmenu.cpp
+++ b/game/ui/dialogmenu.cpp
@@ -381,7 +381,7 @@ void DialogMenu::skipPhrase() {
   if(current.time>0) {
     if(pl!=nullptr)
       pl->setAiOutputBarrier(0,false);
-	  pl->stopDlgAnim(); //skip pl-dialog phrase
+      pl->stopDlgAnim(); //skip pl-dialog phrase
     if(other!=nullptr)
       other->setAiOutputBarrier(0,false);
       other->stopDlgAnim(); //skip npc-dialog phrase


### PR DESCRIPTION
## Summary

Fixes two small but impactful issues related to player control and dialogue system:

### 1. Prevent Character Rotation When Stationary
- Updated `PlayerControl::assignRunAngle` to check for zero or negative movement on the X/Z axes.
- Prevents rotation updates when the player is idle but in attack or finishing animation states.
- This avoids unwanted snapping/clipping while stationary.

### 2. Improve Dialogue Skip Sync
- In `DialogMenu::skipPhrase`, added calls to `stopDlgAnim()` for both player and NPC.
- Ensures animations are stopped when skipping dialogue, keeping lip-sync and timing consistent.

## Files Modified
- `game/game/playercontrol.cpp`
- `game/ui/dialogmenu.cpp`

Let me know if anything needs adjustment!