### PR TITLE
Fix helper npc bugs

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -3226,7 +3226,7 @@ int GameScript::mob_hasitems(std::string_view tag, int item) {
 
 void GameScript::ta_min(std::shared_ptr<zenkit::INpc> npcRef, int start_h, int start_m, int stop_h, int stop_m, int action, std::string_view waypoint) {
   auto npc = findNpc(npcRef);
-  auto at  = world().findPoint(waypoint);
+  auto at  = world().findPoint(waypoint,false);
 
   if(npc!=nullptr)
     npc->addRoutine(gtime(start_h,start_m),gtime(stop_h,stop_m),uint32_t(action),at);

--- a/game/marvin.cpp
+++ b/game/marvin.cpp
@@ -610,7 +610,7 @@ std::string_view Marvin::completeInstanceName(std::string_view inp, bool& fullwo
       }
     if(name.size()>match.size())
       name = name.substr(0,match.size());
-    for(size_t i=0; i<match.size(); ++i) {
+    for(size_t i=0; i<name.size(); ++i) {
       int n = std::tolower(name [i]);
       int m = std::tolower(match[i]);
       if(m!=n) {

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -2973,15 +2973,13 @@ const Npc::Routine& Npc::currentRoutine() const {
   auto time = owner.time();
   time = gtime(int32_t(time.hour()),int32_t(time.minute()));
   for(auto& i:routines) {
-    if(i.point==nullptr)
-      continue;
     if(i.end<i.start && (time<i.end || i.start<=time))
       return i;
     if(i.start<=time && time<i.end)
       return i;
     }
 
-  // take previous routine
+  // take a previous routine if none was found for current time
   const auto     day   = gtime(24,0).toInt();
   const Routine* prevR = nullptr;
   int64_t        delta = std::numeric_limits<int64_t>::max();
@@ -2990,7 +2988,7 @@ const Npc::Routine& Npc::currentRoutine() const {
     int64_t d = time.toInt() - i.end.toInt();
     if(d<0)
       d += day;
-    if(i.point && d<=delta && d>0) {
+    if(d<=delta && d>0) {
       prevR = &i;
       delta = d;
       }


### PR DESCRIPTION
Helper npcs like Characterhelper don't have a valid waypoint but still have their state started in vanilla. This means a check  is not required in `Npc::currentRoutine` as this would only lead to a default routine. State start is needed to have talk perc enabled.

Waypoint for helpers routine is "XXX" which makes them walk to the bandit cave at the beginning of Gothic 2. In vanilla they don't walk at all. Reason is that waypoint search in `GameScript::ta_min` allows an inexact match. Npc's added by insert command get a waypoint/freepoint close to spawn location assigned if there is one. Could still lead to some walking but this is only a small nitpick.

