### PR TITLE
macOS/Metal: gate VSM 3D storage texture allocation to fix Metal validation crash

### DIFF
--- a/game/graphics/renderer.cpp
+++ b/game/graphics/renderer.cpp
@@ -172,7 +172,8 @@ void Renderer::resetSwapchain() {
     vsm.pageListTmp = StorageBuffer();
 
     //FIXME: used internally by DrawCommands
-    vsm.pageTbl  = device.image3d(TextureFormat::R32U, 32, 32, 16);
+    if(settings.vsmEnabled && Shaders::isVsmSupported())
+      vsm.pageTbl  = device.image3d(TextureFormat::R32U, 32, 32, 16);
   }
 
   // rtsm


### PR DESCRIPTION
### Summary
- **Fix**: Avoid early creation of Virtual Shadow Maps (VSM) 3D storage textures on macOS/Metal unless VSM is enabled and supported.
- **Why**: Prevents startup crash due to Metal rejecting linear 3D textures.

### Error
```text
_mtlValidateStrideTextureParameters:1824: failed assertion `Texture Descriptor Validation
Linear texture: must have depth == 1, depth (16) disallowed
Linear texture: must be of type MTLTextureType2D or linear MTLTextureType2DArray, textureType (MTLTextureType3D) disallowed
```

### Root cause
- On Metal where native image atomics aren’t available (MSL < 3.1), storage images fall back to buffer‑backed “linear” textures.
- Metal allows linear 2D/2D array only; a linear 3D texture (for VSM page table) triggers validation and aborts.

### Impact
- **macOS (VSM off by default)**: No performance/visual change; startup crash resolved.
- **Supported platforms with VSM on**: Unchanged; VSM resources still allocate on demand.
- **Unsupported macOS configs**: Keep VSM off (or run with `-vsm 0`).

### How to test
1. Build on macOS and run: `./Gothic2Notr.sh -g "<path-to-Gothic2>"`.
2. Expect normal startup (no Metal validation assert).
3. Optionally test with `-vsm 0` to force-disable VSM.