### PR TITLE
CsCamera refactor and smooth phasing

### DIFF
--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -254,6 +254,7 @@ void MainWindow::paintEvent(PaintEvent& event) {
       world->marchPoints(dbg);
       world->marchInteractives(dbg);
       world->view()->dbgLights(dbg);
+      world->marchCsCameras(dbg);
       }
     }
 

--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -1164,6 +1164,8 @@ void Npc::changeAttribute(Attribute a, int32_t val, bool allowUnconscious) {
   if(val<0 && a==ATR_HITPOINTS) {
     if(isPlayer() && Gothic::inst().isGodMode())
       return;
+    if(isPlayer() && owner.currentCs()!=nullptr)
+      return;
     if(isImmortal())
       return;
     }

--- a/game/world/triggers/abstracttrigger.cpp
+++ b/game/world/triggers/abstracttrigger.cpp
@@ -140,6 +140,10 @@ void AbstractTrigger::moveEvent() {
   boxNpc.setPosition(position()+bboxOrigin);
   }
 
+bool AbstractTrigger::hasTicksEnabled() const {
+  return ticksEnabled;
+  }
+
 void AbstractTrigger::onIntersect(Npc& n) {
   if(vobType==zenkit::VirtualObjectType::zCMover || vobType==zenkit::VirtualObjectType::zCCSCamera)
     return;

--- a/game/world/triggers/abstracttrigger.h
+++ b/game/world/triggers/abstracttrigger.h
@@ -72,6 +72,7 @@ class AbstractTrigger : public Vob {
     virtual void                 onGotoMsg(const TriggerEvent& evt);
     void                         moveEvent() override;
 
+    bool                         hasTicksEnabled() const;
     void                         enableTicks();
     void                         disableTicks();
     const std::vector<Npc*>&     intersections() const;

--- a/game/world/triggers/cscamera.cpp
+++ b/game/world/triggers/cscamera.cpp
@@ -35,13 +35,21 @@ CsCamera::KbSpline::KbSpline(const std::vector<std::shared_ptr<zenkit::VCameraTr
 
   const size_t size = keyframe.size();
   for(size_t i=0; i+1<size; ++i) {
+    auto& kF0 = i==0 ? keyframe[i+0] : keyframe[i-1];
+    auto& kF1 = keyframe[i+0];
+    auto& kF2 = keyframe[i+1];
+    auto& kF3 = i+2==size ? kF2 : keyframe[i+2];
+
+    auto& p0  = kF0.c[3];
+    auto& p1  = kF1.c[3];
+    auto& p2  = kF2.c[3];
+    auto& p3  = kF3.c[3];
+
+    float dt  = kF2.time-kF1.time;
+    Vec3  dd  = (p2-p0) * dt/(kF2.time-kF0.time);
+    Vec3  sd  = (p3-p1) * dt/(kF3.time-kF1.time);
+
     auto& kF  = keyframe[i];
-    Vec3  p0  = i==0 ? kF.c[3] : keyframe[i-1].c[3];
-    Vec3  p1  = kF.c[3];
-    Vec3  p2  = keyframe[i+1].c[3];
-    Vec3  p3  = i+2==size ? kF.c[3] : keyframe[i+2].c[3];
-    Vec3  dd  = (p2-p0)*0.5f;
-    Vec3  sd  = (p3-p1)*0.5f;
     kF.c[0] =  2 * p1 - 2*p2 +   dd + sd;
     kF.c[1] = -3 * p1 + 3*p2 - 2*dd - sd;
     kF.c[2] = std::move(dd);

--- a/game/world/triggers/cscamera.cpp
+++ b/game/world/triggers/cscamera.cpp
@@ -7,9 +7,110 @@
 
 using namespace Tempest;
 
+Vec3 CsCamera::KeyFrame::position(float u) const {
+  return ((c[0]*u + c[1])*u + c[2])*u + c[3];
+  }
+
+float CsCamera::KeyFrame::arcLength() const {
+  float len  = 0;
+  Vec3  prev = c[3];
+  for(int i=1; i<=100; ++i) {
+    Vec3 at = position(float(i)/100.f);
+    len += (at-prev).length();
+    prev = at;
+    }
+  return len;
+  }
+
+CsCamera::KbSpline::KbSpline(const std::vector<std::shared_ptr<zenkit::VCameraTrajectoryFrame> >& frames, const float duration, std::string_view vobName) {
+  keyframe.reserve(frames.size());
+  for(auto& f : frames) {
+    KeyFrame kF;
+    kF.c[3]  = Vec3(f->original_pose[3][0],f->original_pose[3][1],f->original_pose[3][2]);
+    kF.time  = f->time;
+    keyframe.push_back(kF);
+    }
+
+  const size_t size = keyframe.size();
+  float pathLength = 0;
+  for(size_t i=0; i+1<size; ++i) {
+    auto& kF  = keyframe[i];
+    Vec3  p0  = i==0 ? kF.c[3] : keyframe[i-1].c[3];
+    Vec3  p1  = kF.c[3];
+    Vec3  p2  = keyframe[i+1].c[3];
+    Vec3  p3  = i+2==size ? kF.c[3] : keyframe[i+2].c[3];
+    Vec3  dd  = (p2-p0)*0.5f;
+    Vec3  sd  = (p3-p1)*0.5f;
+    kF.c[0] =  2 * p1 - 2*p2 +   dd + sd;
+    kF.c[1] = -3 * p1 + 3*p2 - 2*dd - sd;
+    kF.c[2] = std::move(dd);
+
+    pathLength += kF.arcLength();
+    }
+
+  if(size<2)
+    return;
+
+  if(keyframe.front().time!=0) {
+    Log::e("CsCamera: \"", vobName, "\" - invalid first frame");
+    }
+  if(keyframe.back().time!=duration) {
+    Log::e("CsCamera: \"", vobName, "\" - invalid sequence duration");
+    }
+
+  const float ref    = 1.f/std::max(pathLength, 0.0001f);
+  const float slow   = 0;
+  const float linear = duration * ref;
+  const float fast   = 2 * duration * ref;
+
+  const zenkit::CameraMotion mType0 = frames.front()->motion_type;
+  const zenkit::CameraMotion mType1 = frames.back() ->motion_type;
+
+  float d0 = slow;
+  float d1 = slow;
+  if(mType0!=zenkit::CameraMotion::SLOW && mType1!=zenkit::CameraMotion::SLOW) {
+    d0 = linear;
+    d1 = linear;
+    }
+  else if(mType0==zenkit::CameraMotion::SLOW && mType1!=zenkit::CameraMotion::SLOW) {
+    d0 = slow;
+    d1 = fast;
+    }
+  else if(mType0!=zenkit::CameraMotion::SLOW && mType1==zenkit::CameraMotion::SLOW) {
+    d0 = fast;
+    d1 = slow;
+    }
+
+  this->c[0] = -2*duration +   d0 + d1;
+  this->c[1] =  3*duration - 2*d0 - d1;
+  this->c[2] = d0;
+  }
+
+float CsCamera::KbSpline::applyMotionScaling(float t) const {
+  return std::min(((c[0]*t + c[1])*t + c[2])*t, keyframe.back().time);
+  }
+
+Vec3 CsCamera::KbSpline::position(float time) const {
+  const float t = applyMotionScaling(time);
+
+  //TODO: lower bound
+  uint32_t n = 0;
+  while(n+1<keyframe.size() && t>=keyframe[n+1].time) {
+    ++n;
+    }
+
+  auto& kF0 = keyframe[n];
+  auto& kF1 = keyframe[n+1];
+  float u   = (t - kF0.time) / (kF1.time - kF0.time);
+  assert(0<=u && u<=1);
+
+  return keyframe[n].position(u);
+  }
+
+
 CsCamera::CsCamera(Vob* parent, World& world, const zenkit::VCutsceneCamera& cam, Flags flags)
   :AbstractTrigger(parent,world,cam,flags) {
-  if(cam.position_count<1 || cam.total_duration<0)
+  if(cam.position_count<1 || cam.total_duration<=0)
     return;
 
   if(cam.trajectory_for==zenkit::CameraCoordinateReference::OBJECT || cam.target_trajectory_for==zenkit::CameraCoordinateReference::OBJECT) {
@@ -17,83 +118,13 @@ CsCamera::CsCamera(Vob* parent, World& world, const zenkit::VCutsceneCamera& cam
     return;
     }
 
-  durationF     = cam.total_duration;
   duration      = uint64_t(cam.total_duration * 1000.f);
   delay         = uint64_t(cam.auto_untrigger_last_delay * 1000.f);
   autoUntrigger = cam.auto_untrigger_last;
   playerMovable = cam.auto_player_movable;
 
-  for(auto& f : cam.trajectory_frames) {
-    KeyFrame kF;
-    kF.c[3]  = Vec3(f->original_pose[3][0],f->original_pose[3][1],f->original_pose[3][2]);
-    kF.time  = f->time;
-    posSpline.keyframe.push_back(kF);
-    }
-
-  for(auto& f : cam.target_frames) {
-    KeyFrame kF;
-    kF.c[3]  = Vec3(f->original_pose[3][0],f->original_pose[3][1],f->original_pose[3][2]);
-    kF.time  = f->time;
-    targetSpline.keyframe.push_back(kF);
-    }
-
-  for(auto spl : {&posSpline,&targetSpline}) {
-    uint32_t size = uint32_t(spl->size());
-    for(uint32_t i=0;i+1<size;++i) {
-      auto& kF  = spl->keyframe[i];
-      Vec3  p0  = i==0 ? kF.c[3] : spl->keyframe[i-1].c[3];
-      Vec3  p1  = kF.c[3];
-      Vec3  p2  = spl->keyframe[i+1].c[3];
-      Vec3  p3  = i+2==size ? kF.c[3] : spl->keyframe[i+2].c[3];
-      Vec3  dd  = (p2-p0)*0.5f;
-      Vec3  sd  = (p3-p1)*0.5f;
-      kF.c[0] =  2 * p1 - 2*p2 +   dd + sd;
-      kF.c[1] = -3 * p1 + 3*p2 - 2*dd - sd;
-      kF.c[2] = std::move(dd);
-      }
-
-    if(size<2)
-      continue;
-
-    if(spl->keyframe.front().time!=0) {
-      Log::e("CsCamera: \"",cam.vob_name,"\" - invalid first frame");
-      }
-    if(spl->keyframe.back().time!=durationF) {
-      Log::e("CsCamera: \"",cam.vob_name,"\" - invalid sequence duration");
-      }
-
-    const float slow   = 0;
-    const float linear = durationF;
-    const float fast   = 2 * durationF;
-
-    zenkit::CameraMotion mType0, mType1;
-    if(spl == &posSpline) {
-      mType0 = cam.trajectory_frames[0]->motion_type;
-      mType1 = cam.trajectory_frames.back()->motion_type;
-      } else {
-      mType0 = cam.target_frames[0]->motion_type;
-      mType1 = cam.target_frames.back()->motion_type;
-      }
-
-    float d0 = slow;
-    float d1 = slow;
-    if(mType0!=zenkit::CameraMotion::SLOW && mType1!=zenkit::CameraMotion::SLOW) {
-      d0 = linear;
-      d1 = linear;
-      }
-    else if(mType0==zenkit::CameraMotion::SLOW && mType1!=zenkit::CameraMotion::SLOW) {
-      d0 = slow;
-      d1 = fast;
-      }
-    else if(mType0!=zenkit::CameraMotion::SLOW && mType1==zenkit::CameraMotion::SLOW) {
-      d0 = fast;
-      d1 = slow;
-      }
-
-    spl->c[0] = -2*durationF +   d0 + d1;
-    spl->c[1] =  3*durationF - 2*d0 - d1;
-    spl->c[2] = d0;
-    }
+  posSpline    = KbSpline(cam.trajectory_frames, cam.total_duration, cam.vob_name);
+  targetSpline = KbSpline(cam.target_frames, cam.total_duration, cam.vob_name);
   }
 
 bool CsCamera::isPlayerMovable() const {
@@ -115,8 +146,6 @@ void CsCamera::onTrigger(const TriggerEvent& evt) {
 
   active               = true;
   time                 = 0;
-  posSpline.splTime    = 0;
-  targetSpline.splTime = 0;
   godMode              = Gothic::inst().isGodMode();
   Gothic::inst().setGodMode(true);
   world.setCurrentCs(this);
@@ -164,8 +193,7 @@ Vec3 CsCamera::position() {
   if(posSpline.size()==1) {
     pos = posSpline.keyframe[0].c[3];
     } else {
-    posSpline.setSplTime(float(time)/float(duration));
-    pos = posSpline.position();
+    pos = posSpline.position(float(time)/float(duration));
     }
   return pos;
   }
@@ -176,8 +204,7 @@ PointF CsCamera::spin(Tempest::Vec3& d) {
   else if(targetSpline.size()==1)
     d = targetSpline.keyframe[0].c[3] - d;
   else if(targetSpline.size()>1) {
-    targetSpline.setSplTime(float(time)/float(duration));
-    d = targetSpline.position() - d;
+    d = targetSpline.position(float(time)/float(duration)) - d;
     }
 
   float k     = 180.f/float(M_PI);
@@ -186,32 +213,4 @@ PointF CsCamera::spin(Tempest::Vec3& d) {
   if(d.x!=0.f || d.z!=0.f)
     spinY = 90 + k * std::atan2(d.z,d.x);
   return {-spinX,spinY};
-  }
-
-void CsCamera::KbSpline::setSplTime(float time) {
-  float    t   = applyMotionScaling(time);
-  uint32_t n   = uint32_t(splTime);
-  auto     kF0 = &keyframe[n];
-  auto     kF1 = &keyframe[n+1];
-  if(t>kF1->time) {
-    splTime = std::ceil(splTime);
-    n       = uint32_t(splTime);
-    kF0     = kF1;
-    kF1     = &keyframe[n+1];
-    }
-  assert(n<size());
-  float u = (t - kF0->time) / (kF1->time - kF0->time);
-  assert(u>=0 && u<=1);
-  splTime = float(n) + u;
-  }
-
-Vec3 CsCamera::KbSpline::position() const {
-  float n;
-  float t  = std::modf(splTime,&n);
-  auto& kF = keyframe[uint32_t(n)];
-  return ((kF.c[0]*t + kF.c[1])*t + kF.c[2])*t + kF.c[3];
-  }
-
-float CsCamera::KbSpline::applyMotionScaling(float t) const {
-  return std::min(((c[0]*t + c[1])*t + c[2])*t,keyframe.back().time);
   }

--- a/game/world/triggers/cscamera.cpp
+++ b/game/world/triggers/cscamera.cpp
@@ -145,7 +145,7 @@ void CsCamera::debugDraw(DbgPainter& p) const {
   }
 
 void CsCamera::onTrigger(const TriggerEvent& evt) {
-  if(active || posSpline.size()==0)
+  if(hasTicksEnabled() || posSpline.size()==0)
     return;
 
   if(auto cs = world.currentCs())
@@ -157,22 +157,20 @@ void CsCamera::onTrigger(const TriggerEvent& evt) {
     camera.setMode(Camera::Mode::Cutscene);
     }
 
-  active      = true;
   timeTrigger = world.tickCount();
   world.setCurrentCs(this);
   enableTicks();
   }
 
 void CsCamera::onUntrigger(const TriggerEvent& evt) {
-  if(!active)
+  if(!hasTicksEnabled())
     return;
-  active = false;
   disableTicks();
+
   if(world.currentCs()!=this)
     return;
 
   world.setCurrentCs(nullptr);
-
   auto& camera = world.gameSession().camera();
   camera.setMode(Camera::Mode::Normal);
   camera.reset();

--- a/game/world/triggers/cscamera.cpp
+++ b/game/world/triggers/cscamera.cpp
@@ -56,41 +56,9 @@ CsCamera::KbSpline::KbSpline(const std::vector<std::shared_ptr<zenkit::VCameraTr
   if(keyframe.back().time!=duration) {
     Log::e("CsCamera: \"", vobName, "\" - invalid sequence duration");
     }
-
-  const float slow   = 0;
-  const float linear = duration;
-  const float fast   = 2 * duration;
-
-  const zenkit::CameraMotion mType0 = frames.front()->motion_type;
-  const zenkit::CameraMotion mType1 = frames.back() ->motion_type;
-
-  float d0 = slow;
-  float d1 = slow;
-  if(mType0!=zenkit::CameraMotion::SLOW && mType1!=zenkit::CameraMotion::SLOW) {
-    d0 = linear;
-    d1 = linear;
-    }
-  else if(mType0==zenkit::CameraMotion::SLOW && mType1!=zenkit::CameraMotion::SLOW) {
-    d0 = slow;
-    d1 = fast;
-    }
-  else if(mType0!=zenkit::CameraMotion::SLOW && mType1==zenkit::CameraMotion::SLOW) {
-    d0 = fast;
-    d1 = slow;
-    }
-
-  this->c[0] = -2*duration +   d0 + d1;
-  this->c[1] =  3*duration - 2*d0 - d1;
-  this->c[2] = d0;
-  }
-
-float CsCamera::KbSpline::applyMotionScaling(uint64_t time) const {
-  const float t = (float(time)/1000.f)/keyframe.back().time;
-  return std::min(((c[0]*t + c[1])*t + c[2])*t, keyframe.back().time);
   }
 
 Vec3 CsCamera::KbSpline::position(const uint64_t time) const {
-  // const float t = applyMotionScaling(time);
   const float t = float(time)/1000.f;
 
   //TODO: lower bound

--- a/game/world/triggers/cscamera.h
+++ b/game/world/triggers/cscamera.h
@@ -5,6 +5,7 @@
 #include "abstracttrigger.h"
 
 class World;
+class DbgPainter;
 
 class CsCamera : public AbstractTrigger {
   public:
@@ -12,10 +13,13 @@ class CsCamera : public AbstractTrigger {
 
     bool isPlayerMovable() const;
 
+    void debugDraw(DbgPainter& p) const;
+
   private:
     struct KeyFrame {
       float         time = 0;
       Tempest::Vec3 c[4] = {};
+      zenkit::CameraMotion motionType = zenkit::CameraMotion::LINEAR;
 
       auto          position(float u) const -> Tempest::Vec3;
       float         arcLength() const;
@@ -28,8 +32,8 @@ class CsCamera : public AbstractTrigger {
       float                 c[3] = {};
       std::vector<KeyFrame> keyframe;
       size_t                size() const { return keyframe.size(); }
-      auto                  position(float time) const -> Tempest::Vec3;
-      float                 applyMotionScaling(float t) const;
+      auto                  position(const uint64_t time) const -> Tempest::Vec3;
+      float                 applyMotionScaling(uint64_t t) const;
       };
 
     void onTrigger(const TriggerEvent& evt) override;
@@ -44,10 +48,9 @@ class CsCamera : public AbstractTrigger {
 
     uint64_t duration      = 0;
     uint64_t delay         = 0;
-    uint64_t time          = 0;
+    uint64_t timeTrigger   = 0;
 
     bool     active        = false;
-    bool     godMode       = false;
     bool     playerMovable = false;
     bool     autoUntrigger = false;
   };

--- a/game/world/triggers/cscamera.h
+++ b/game/world/triggers/cscamera.h
@@ -16,16 +16,20 @@ class CsCamera : public AbstractTrigger {
     struct KeyFrame {
       float         time = 0;
       Tempest::Vec3 c[4] = {};
+
+      auto          position(float u) const -> Tempest::Vec3;
+      float         arcLength() const;
       };
 
     struct KbSpline {
-      float                 c[3]     = {};
-      float                 splTime  = 0;
+      KbSpline() = default;
+      KbSpline(const std::vector<std::shared_ptr<zenkit::VCameraTrajectoryFrame>>& frames, const float duration, std::string_view vobName);
+
+      float                 c[3] = {};
       std::vector<KeyFrame> keyframe;
-      size_t size() const { return keyframe.size(); }
-      auto   position() const -> Tempest::Vec3;
-      void   setSplTime(float t);
-      float  applyMotionScaling(float t) const;
+      size_t                size() const { return keyframe.size(); }
+      auto                  position(float time) const -> Tempest::Vec3;
+      float                 applyMotionScaling(float t) const;
       };
 
     void onTrigger(const TriggerEvent& evt) override;
@@ -35,14 +39,15 @@ class CsCamera : public AbstractTrigger {
     auto position() -> Tempest::Vec3;
     auto spin(Tempest::Vec3& d) -> Tempest::PointF;
 
+    KbSpline posSpline     = {};
+    KbSpline targetSpline  = {};
+
+    uint64_t duration      = 0;
+    uint64_t delay         = 0;
+    uint64_t time          = 0;
+
     bool     active        = false;
     bool     godMode       = false;
     bool     playerMovable = false;
     bool     autoUntrigger = false;
-    float    durationF     = 0;
-    uint64_t duration      = 0;
-    uint64_t delay         = 0;
-    uint64_t time          = 0;
-    KbSpline posSpline     = {};
-    KbSpline targetSpline  = {};
   };

--- a/game/world/triggers/cscamera.h
+++ b/game/world/triggers/cscamera.h
@@ -29,11 +29,9 @@ class CsCamera : public AbstractTrigger {
       KbSpline() = default;
       KbSpline(const std::vector<std::shared_ptr<zenkit::VCameraTrajectoryFrame>>& frames, const float duration, std::string_view vobName);
 
-      float                 c[3] = {};
       std::vector<KeyFrame> keyframe;
       size_t                size() const { return keyframe.size(); }
       auto                  position(const uint64_t time) const -> Tempest::Vec3;
-      float                 applyMotionScaling(uint64_t t) const;
       };
 
     void onTrigger(const TriggerEvent& evt) override;

--- a/game/world/triggers/cscamera.h
+++ b/game/world/triggers/cscamera.h
@@ -48,7 +48,6 @@ class CsCamera : public AbstractTrigger {
     uint64_t delay         = 0;
     uint64_t timeTrigger   = 0;
 
-    bool     active        = false;
     bool     playerMovable = false;
     bool     autoUntrigger = false;
   };

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -567,6 +567,10 @@ void World::marchPoints(DbgPainter& p) const {
   wmatrix->marchPoints(p);
   }
 
+void World::marchCsCameras(DbgPainter& p) const {
+  wobj.marchCsCameras(p);
+  }
+
 AiOuputPipe *World::openDlgOuput(Npc &player, Npc &npc) {
   return game.openDlgOuput(player,npc);
   }

--- a/game/world/world.h
+++ b/game/world/world.h
@@ -142,6 +142,7 @@ class World final {
 
     void                 marchInteractives(DbgPainter& p) const;
     void                 marchPoints      (DbgPainter& p) const;
+    void                 marchCsCameras   (DbgPainter& p) const;
 
     AiOuputPipe*         openDlgOuput(Npc &player, Npc &npc);
     void                 aiOutputSound(Npc &player, std::string_view msg);

--- a/game/world/worldobjects.cpp
+++ b/game/world/worldobjects.cpp
@@ -7,6 +7,7 @@
 #include "world/objects/interactive.h"
 #include "world/objects/vob.h"
 #include "world/collisionzone.h"
+#include "world/triggers/cscamera.h"
 #include "world/triggers/pfxcontroller.h"
 #include "world/triggers/triggerworldstart.h"
 #include "world/triggers/abstracttrigger.h"
@@ -818,6 +819,13 @@ void WorldObjects::marchInteractives(DbgPainter &p) const {
 
     i->marchInteractives(p);
     }
+  }
+
+void WorldObjects::marchCsCameras(DbgPainter& p) const {
+  for(auto& i:triggers)
+    if(auto c = dynamic_cast<CsCamera*>(i)) {
+      c->debugDraw(p);
+      }
   }
 
 Interactive *WorldObjects::availableMob(const Npc &pl, std::string_view dest) {

--- a/game/world/worldobjects.h
+++ b/game/world/worldobjects.h
@@ -126,6 +126,7 @@ class WorldObjects final {
     Item*          findItem       (const Npc& pl, Item* def, const SearchOpt& opt);
 
     void           marchInteractives(DbgPainter& p) const;
+    void           marchCsCameras(DbgPainter& p) const;
 
     Interactive*   availableMob(const Npc& pl, std::string_view name);
     void           setMobRoutine(gtime time, std::string_view scheme, int32_t state);


### PR DESCRIPTION
Large refactor of CsCamera.

* Simplify code
* Most of things are now stateless
  * animation state no longer depends of `dt`
  * player 'god' state handled properly
* Added debug-draw for splines
* Remove old motion-scaling

While there is intent to make camera smooth, this are of time-demo is still an issue:
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/356bcdc3-c2e1-4376-be75-75d0389ad8e5" />


