### PR TITLE
Delay trigger sent by mobsi interaction

### DIFF
--- a/game/world/objects/interactive.cpp
+++ b/game/world/objects/interactive.cpp
@@ -471,7 +471,7 @@ void Interactive::invokeStateFunc(Npc& npc) {
 void Interactive::emitTriggerEvent(TriggerEvent::Type type) const {
   if(triggerTarget.empty())
     return;
-  const TriggerEvent evt(triggerTarget,vobName,type);
+  const TriggerEvent evt(triggerTarget,vobName,waitAnim,type);
   world.triggerEvent(evt);
   }
 


### PR DESCRIPTION
Matches vanilla behavior where a CsCamera sequence is only started after the switch animation to next state has ended.