### PR TITLE
Relax a condition for mover speed calculation

### DIFF
--- a/game/world/triggers/movetrigger.cpp
+++ b/game/world/triggers/movetrigger.cpp
@@ -42,8 +42,15 @@ MoveTrigger::MoveTrigger(Vob* parent, World& world, const zenkit::VMover& mover,
     float len   = Vec3(dx,dy,dz).length();
 
     if(speed>0) {
+      /*
+       * Distance between keyframe positions doesn't have to be exactly zero to use rotation speed,
+       * it seem there is some small threshold.
+       * Otherwise the boat close to Lares in L'Hiver mod would jump between two keyframes.
+       */
+      static const float rotationThreshold = 0.01f;
+
       uint64_t ticks = 0;
-      if(len>0.01f)
+      if(len>rotationThreshold)
         ticks = uint64_t(len/speed); else
         ticks = uint64_t((angle/360.f) * 1000.f/scaleRotSpeed(speed));
       keyframes[i].ticks = std::max<uint64_t>(1,ticks);


### PR DESCRIPTION
Distance between keyframe positions doesn't have to be exactly zero to use rotation speed, it seem there is some small threshold. Otherwise the boat close to Lares in L'Hiver mod would jump between two keyframes.

In general boats in L'Hiver require lower speeds than mover speed value suggests whereas in non-moded game higher values are needed. There's even one going completely haywire. I have no solution for this and leave it as is for now.