### PR TITLE
Fix fleeing for G1 npcs

### DIFF
--- a/game/world/objects/npc.cpp
+++ b/game/world/objects/npc.cpp
@@ -2172,7 +2172,7 @@ void Npc::tick(uint64_t dt) {
     }
 
   if(waitTime>=owner.tickCount() || aniWaitTime>=owner.tickCount() || outWaitTime>owner.tickCount()) {
-    if(!isPlayer() && faiWaitTime<owner.tickCount())
+    if(!isPlayer() && go2.flag!=GT_Flee && faiWaitTime<owner.tickCount())
       adjustAttackRotation(dt);
     mvAlgo.tick(dt,MoveAlgo::WaitMove);
     return;


### PR DESCRIPTION
G1 script makes npcs flee if the their health drops below a certain percentage in a fight. As in many ZS loop functions there's a AI_Wait call in ZS_Flee.

The Engine is calling `Npc::adjustAttackRotation` function everytime a npc has to wait.
```C++
  if(waitTime>=owner.tickCount() || aniWaitTime>=owner.tickCount() || outWaitTime>owner.tickCount()) {
    if(!isPlayer() && faiWaitTime<owner.tickCount())
      adjustAttackRotation(dt);
```
 Because fleeing npcs have a target and a drawn weapon a rotation is executed. The rotation added from AI_Flee is overwritten and the npc follows the player instead of running away.

This is fixed by adding a check if npc is attacking to `Npc::adjustAttackRotation`. I used the same check as in `Npc::implAttack`. I’m not sure if there is a difference to `isAttack()` here.

fixes https://github.com/Try/OpenGothic/issues/638