### PR TITLE
Change name check in waypoint search

### DIFF
--- a/game/game/gamescript.cpp
+++ b/game/game/gamescript.cpp
@@ -3014,8 +3014,10 @@ void GameScript::ai_gotowp(std::shared_ptr<zenkit::INpc> npcRef, std::string_vie
     return;
 
   auto to = world().findWayPoint(npc->position(), waypoint);
-  if(to!=nullptr)
+  if(to!=nullptr) {
     npc->aiPush(AiQueue::aiGoToPoint(*to));
+    return;
+    }
 
   // in vanilla 'ai_gotowp' sometimes is used incorrectly, so we need to check all other points
   to = world().findPoint(waypoint, false);

--- a/game/world/waymatrix.h
+++ b/game/world/waymatrix.h
@@ -45,6 +45,7 @@ class WayMatrix final {
     // Vatras requires at least 8 meters
     // Abuyin requires less than 10 meters
     // Gothic 1 range is identical
+    // Vanilla is buggy here as Vatras can't reach his praying spot from teaching location
     float                  distanceThreshold = 900.f;
 
     std::vector<WayEdge>   edges;

--- a/game/world/waypoint.cpp
+++ b/game/world/waypoint.cpp
@@ -28,25 +28,13 @@ bool WayPoint::isFreePoint() const {
   return conn.size()<1;
   }
 
-bool WayPoint::checkName(std::string_view n) const {
-  auto src = std::string_view(name);
-
-  if(src.starts_with(n))
+bool WayPoint::checkName(std::string_view n, bool inexact) const {
+  if(n.empty())
+    return false;
+  if(name==n)
     return true;
-
-  for(size_t i=0, i0=0; ; ++i) {
-    if(i==name.size() || src[i]=='_') {
-      const size_t len2 = i-i0;
-      auto sb = src.substr(i0, len2);
-      // if(sb==n)
-      if(sb.starts_with(n))
-        return true;
-      i0=i+1;
-      }
-    if(i==name.size())
-      break;
-    }
-
+  if(inexact && name.find(n)!=std::string::npos)
+    return true;
   return false;
   }
 

--- a/game/world/waypoint.h
+++ b/game/world/waypoint.h
@@ -22,7 +22,7 @@ class WayPoint final {
     bool isFreePoint() const;
 
     uint32_t useCounter() const { return useCount; }
-    bool checkName(std::string_view name) const;
+    bool checkName(std::string_view name, bool inexact = true) const;
 
     Tempest::Vec3 position() const;
 

--- a/game/world/world.cpp
+++ b/game/world/world.cpp
@@ -884,7 +884,7 @@ const WayPoint* World::findWayPoint(const Tempest::Vec3& pos, std::string_view n
   return wmatrix->findWayPoint(pos,[name](const WayPoint& wp) -> bool {
     if(wp.isLocked())
       return false;
-    if(!wp.checkName(name))
+    if(!wp.checkName(name,false))
       return false;
     return true;
     });


### PR DESCRIPTION
Byproduct of https://github.com/Try/OpenGothic/pull/831. Npcs would go to closest waypoint even if that had empty name.

Testing showed `AI_GoToPoint` wants exact name match but `AI_GoToFp` only does a loose check. Even single characters like "_" or "S" made the npc go to a freepoint if its name contained them.

Added a comment to range threshold indicating vanilla value is buggy (found in https://github.com/Try/OpenGothic/pull/790#issuecomment-3140773921) and early return in `AI_GoToPoint` to avoid two commands being sent to ai queue..


