### PR TITLE
Fix compilation error

### DIFF
--- a/game/graphics/mesh/submesh/packedmesh.cpp
+++ b/game/graphics/mesh/submesh/packedmesh.cpp
@@ -883,7 +883,9 @@ void PackedMesh::packCWBVH8(const zenkit::Mesh& mesh) {
 
   std::vector<UVec4> nodes(sizeof(CWBVH8)/sizeof(UVec4));
   auto root = packCWBVH8(mesh, nodes, frag.data(), frag.size());
-  std::memcpy(nodes.data(), &root, sizeof(root));
+  static_assert(sizeof(CWBVH8) == sizeof(UVec4) * 5);
+  auto* dest = reinterpret_cast<CWBVH8*>(nodes.data());
+  *dest = root;
 
   //TODO: ensure, that first node is a box node
   bvh8Nodes = std::move(nodes);


### PR DESCRIPTION
Fixes build error https://ci.appveyor.com/project/Try/opengothic/builds/53389475/job/7adrowelsxjeg9tj#L1695

```
/home/appveyor/projects/opengothic/game/graphics/mesh/submesh/packedmesh.cpp: In member function ‘void PackedMesh::packCWBVH8(const zenkit::Mesh&)’:
/home/appveyor/projects/opengothic/game/graphics/mesh/submesh/packedmesh.cpp:886:14: error: ‘void* memcpy(void*, const void*, size_t)’ copying an object of non-trivial type ‘class Tempest::BasicPoint<unsigned int, 4>’ from an array of ‘struct PackedMesh::CWBVH8’ [-Werror=class-memaccess]
  886 |   std::memcpy(nodes.data(), &root, sizeof(root));
      |   ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/appveyor/projects/opengothic/lib/Tempest/Engine/include/Tempest/Vec:1,
```