### PR TITLE
downscale preview image for faster save

### DIFF
--- a/game/game/gamesession.cpp
+++ b/game/game/gamesession.cpp
@@ -196,8 +196,8 @@ void GameSession::save(Serialize &fout, std::string_view name, const Pixmap& scr
     fout.write(i.name);
   }
 
-  fout.setEntry("preview.png");
-  fout.write(screen);
+  fout.setEntry("preview.jpg");
+  fout.write(std::tie(screen,"jpg"));
 
   fout.setEntry("game/session");
   fout.write(ticks,wrldTime,wrldTimePart,wrld->name());

--- a/game/game/serialize.cpp
+++ b/game/game/serialize.cpp
@@ -273,10 +273,14 @@ void Serialize::implRead(SaveGameHeader& p) {
   }
 
 void Serialize::implWrite(const Tempest::Pixmap& p) {
+  implWrite(p, "png");
+  }
+
+void Serialize::implWrite(const Tempest::Pixmap& p, const char* ext) {
   std::vector<uint8_t> tmp;
   tmp.reserve(4*1024*1024);
   Tempest::MemWriter w{tmp};
-  p.save(w);
+  p.save(w, ext);
   writeBytes(tmp.data(),tmp.size());
   }
 

--- a/game/game/serialize.h
+++ b/game/game/serialize.h
@@ -250,6 +250,9 @@ class Serialize {
     void implRead (SaveGameHeader&       p);
 
     void implWrite(const Tempest::Pixmap& p);
+    void implWrite(const Tempest::Pixmap& p, const char* ext);
+    template<class Ext>
+    void implWrite(std::tuple<const Tempest::Pixmap&, Ext> p) { implWrite(std::get<0>(p), std::get<1>(p)); }
     void implRead (Tempest::Pixmap&       p);
 
     void implWrite(const zenkit::INpc& h);

--- a/game/graphics/shaders.cpp
+++ b/game/graphics/shaders.cpp
@@ -42,7 +42,8 @@ Shaders& Shaders::inst() {
   }
 
 void Shaders::compileKeyShaders() {
-  bink = postEffect("bink");
+  bink      = postEffect("bink");
+  downscale = postEffect("downscale");
   }
 
 void Shaders::compileShaders() {
@@ -50,13 +51,13 @@ void Shaders::compileShaders() {
 
   const bool meshlets = Gothic::options().doMeshShading;
 
-  copyBuf = computeShader("copy.comp.sprv");
-  copyImg = computeShader("copy_img.comp.sprv");
-  copy    = postEffect("copy");
+  copyBuf   = computeShader("copy.comp.sprv");
+  copyImg   = computeShader("copy_img.comp.sprv");
+  copy      = postEffect("copy");
 
-  patch   = computeShader("patch.comp.sprv");
+  patch     = computeShader("patch.comp.sprv");
 
-  stash   = postEffect("stash");
+  stash     = postEffect("stash");
 
   clusterInit         = computeShader("cluster_init.comp.sprv");
   clusterPatch        = computeShader("cluster_patch.comp.sprv");

--- a/game/graphics/shaders.h
+++ b/game/graphics/shaders.h
@@ -35,7 +35,7 @@ class Shaders {
     Tempest::ComputePipeline copyBuf;
     Tempest::ComputePipeline copyImg;
     Tempest::ComputePipeline patch;
-    Tempest::RenderPipeline  copy;
+    Tempest::RenderPipeline  copy, downscale;
     Tempest::RenderPipeline  stash;
     Tempest::RenderPipeline  bink;
 

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -28,38 +28,6 @@
 
 using namespace Tempest;
 
-namespace {
-  Pixmap downscaleSavePreviewPixmap(Pixmap src) {
-    if(src.isEmpty())
-      return src;
-
-    constexpr uint32_t kThumbW = 1024;
-    const uint32_t w = src.w(), h = src.h();
-    if(w <= kThumbW)
-      return src;
-
-    const uint32_t nh = std::max(1u, uint32_t((size_t(h) * kThumbW) / w));
-    const size_t bpp = src.bpp();
-
-    Pixmap out(kThumbW, nh, src.format());
-    const uint8_t* s = static_cast<const uint8_t*>(src.data());
-    uint8_t* d = static_cast<uint8_t*>(out.data());
-    
-    // Copy source pixel map to reduced pixel map using Nearest-Neighbor interpolation
-    for(uint32_t y=0; y<nh; ++y) {
-      const uint32_t sy = uint32_t((size_t(y)*h) / nh);
-      const uint8_t* srcRow = s + (size_t(sy) * w * bpp);
-      uint8_t* destRow = d + (size_t(y) * kThumbW * bpp);
-        
-      for(uint32_t x=0; x<kThumbW; ++x) {
-        const uint32_t sx = uint32_t((size_t(x)*w) / kThumbW);
-        memcpy(destRow + x*bpp, srcRow + sx*bpp, bpp);
-        }
-      }
-    return out;
-    }
-  }
-
 MainWindow::MainWindow(Device& device)
   : Window(Maximized),device(device),swapchain(device,hwnd()),
     atlas(device),renderer(swapchain),
@@ -1095,15 +1063,40 @@ void MainWindow::loadGame(std::string_view slot) {
   }
 
 void MainWindow::saveGame(std::string_view slot, std::string_view name) {
-  auto tex = renderer.screenshoot(cmdId);
-
-  // reduce size of the save entry preview screenshot for faster save & load
-  auto pm  = downscaleSavePreviewPixmap(device.readPixels(textureCast<const Texture2d&>(tex)));
-
   if(dialogs.isActive())
     return;
   if(auto w = Gothic::inst().world(); w!=nullptr && w->currentCs()!=nullptr)
     return;
+
+  auto tex  = renderer.screenshoot(cmdId);
+  auto lres = Attachment();
+
+  static int32_t kThumbW = 800;
+  const  int32_t kThumbH = tex.w()>0 ? int32_t((tex.h() * kThumbW) / tex.w()) : 0;
+  if(kThumbW>0 && kThumbH>0 && kThumbW<tex.w() && kThumbH<tex.h()) {
+    lres = device.attachment(Tempest::TextureFormat::RGBA8, uint32_t(kThumbW), uint32_t(kThumbH));
+    }
+
+  if(!lres.isEmpty()) {
+    // reduce size of the save entry preview screenshot for faster save & load
+    CommandBuffer cmd;
+    {
+    auto enc = cmd.startEncoding(device);
+    if(!lres.isEmpty()) {
+      enc.setDebugMarker("Downscale screenhoot");
+      enc.setFramebuffer({{lres, Vec4(), Tempest::Preserve}});
+      enc.setPushData(IVec2(lres.w(), lres.h()));
+      enc.setBinding(0, tex, Sampler::nearest());
+      enc.setPipeline(Shaders::inst().downscale);
+      enc.draw(nullptr, 0, 3);
+      }
+    }
+    auto sync = device.submit(cmd);
+    sync.wait();
+    }
+
+  auto& thumb = lres.isEmpty() ? tex : lres;
+  auto  pm    = device.readPixels(textureCast<const Texture2d&>(thumb));
 
   Gothic::inst().startSave(std::move(textureCast<Texture2d&>(tex)),[slot=std::string(slot),name=std::string(name),pm](std::unique_ptr<GameSession>&& game){
     if(!game)

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -28,6 +28,34 @@
 
 using namespace Tempest;
 
+namespace {
+  Pixmap downscaleSavePreviewPixmap(Pixmap src) {
+    if(src.isEmpty() || src.format()!=TextureFormat::RGBA8)
+      return src;
+    constexpr uint32_t kThumbW = 640, kThumbH = 480;
+    const uint32_t w = src.w(), h = src.h();
+    
+    if(w<=kThumbW || h<=kThumbH)
+      return src;
+
+    Pixmap out(kThumbW, kThumbH, TextureFormat::RGBA8);
+    const auto* s = static_cast<const uint32_t*>(src.data());
+    auto* d = static_cast<uint32_t*>(out.data());
+    
+    // Copy source pixel map to reduced pixel map using Nearest-Neighbor interpolation
+    for(uint32_t y=0; y<kThumbH; ++y) {
+      const uint32_t sy = std::min(h-1u, uint32_t((size_t(y)*h)/kThumbH));
+      const uint32_t rowOffset = sy * w;
+      
+      for(uint32_t x=0; x<kThumbW; ++x) {
+        const uint32_t sx = std::min(w-1u, uint32_t((size_t(x)*w)/kThumbW));
+        d[y * kThumbW + x] = s[rowOffset + sx];
+        }
+      }
+    return out;
+    }
+  }
+
 MainWindow::MainWindow(Device& device)
   : Window(Maximized),device(device),swapchain(device,hwnd()),
     atlas(device),renderer(swapchain),
@@ -1062,7 +1090,9 @@ void MainWindow::loadGame(std::string_view slot) {
 
 void MainWindow::saveGame(std::string_view slot, std::string_view name) {
   auto tex = renderer.screenshoot(cmdId);
-  auto pm  = device.readPixels(textureCast<const Texture2d&>(tex));
+
+  // reduce size of the save entry preview screenshot for faster save & load
+  auto pm  = downscaleSavePreviewPixmap(device.readPixels(textureCast<const Texture2d&>(tex)));
 
   if(dialogs.isActive())
     return;

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -1082,14 +1082,12 @@ void MainWindow::saveGame(std::string_view slot, std::string_view name) {
     CommandBuffer cmd;
     {
     auto enc = cmd.startEncoding(device);
-    if(!lres.isEmpty()) {
-      enc.setDebugMarker("Downscale screenhoot");
-      enc.setFramebuffer({{lres, Vec4(), Tempest::Preserve}});
-      enc.setPushData(IVec2(lres.w(), lres.h()));
-      enc.setBinding(0, tex, Sampler::nearest());
-      enc.setPipeline(Shaders::inst().downscale);
-      enc.draw(nullptr, 0, 3);
-      }
+    enc.setDebugMarker("Downscale screenhoot");
+    enc.setFramebuffer({{lres, Vec4(), Tempest::Preserve}});
+    enc.setPushData(IVec2(lres.w(), lres.h()));
+    enc.setBinding(0, tex, Sampler::nearest());
+    enc.setPipeline(Shaders::inst().downscale);
+    enc.draw(nullptr, 0, 3);
     }
     auto sync = device.submit(cmd);
     sync.wait();

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -30,26 +30,30 @@ using namespace Tempest;
 
 namespace {
   Pixmap downscaleSavePreviewPixmap(Pixmap src) {
-    if(src.isEmpty() || src.format()!=TextureFormat::RGBA8)
-      return src;
-    constexpr uint32_t kThumbW = 640, kThumbH = 480;
-    const uint32_t w = src.w(), h = src.h();
-    
-    if(w<=kThumbW || h<=kThumbH)
+    if(src.isEmpty())
       return src;
 
-    Pixmap out(kThumbW, kThumbH, TextureFormat::RGBA8);
-    const auto* s = static_cast<const uint32_t*>(src.data());
-    auto* d = static_cast<uint32_t*>(out.data());
+    constexpr uint32_t kThumbW = 1024;
+    const uint32_t w = src.w(), h = src.h();
+    if(w <= kThumbW)
+      return src;
+
+    const uint32_t nh = std::max(1u, uint32_t((size_t(h) * kThumbW) / w));
+    const size_t bpp = src.bpp();
+
+    Pixmap out(kThumbW, nh, src.format());
+    const uint8_t* s = static_cast<const uint8_t*>(src.data());
+    uint8_t* d = static_cast<uint8_t*>(out.data());
     
     // Copy source pixel map to reduced pixel map using Nearest-Neighbor interpolation
-    for(uint32_t y=0; y<kThumbH; ++y) {
-      const uint32_t sy = std::min(h-1u, uint32_t((size_t(y)*h)/kThumbH));
-      const uint32_t rowOffset = sy * w;
-      
+    for(uint32_t y=0; y<nh; ++y) {
+      const uint32_t sy = uint32_t((size_t(y)*h) / nh);
+      const uint8_t* srcRow = s + (size_t(sy) * w * bpp);
+      uint8_t* destRow = d + (size_t(y) * kThumbW * bpp);
+        
       for(uint32_t x=0; x<kThumbW; ++x) {
-        const uint32_t sx = std::min(w-1u, uint32_t((size_t(x)*w)/kThumbW));
-        d[y * kThumbW + x] = s[rowOffset + sx];
+        const uint32_t sx = uint32_t((size_t(x)*w) / kThumbW);
+        memcpy(destRow + x*bpp, srcRow + sx*bpp, bpp);
         }
       }
     return out;

--- a/game/ui/gamemenu.cpp
+++ b/game/ui/gamemenu.cpp
@@ -1012,6 +1012,8 @@ void GameMenu::updateSavTitle(GameMenu::Item& sel) {
       reader.read(sel.savPriview); // legacy
     else if(reader.setEntry("preview.png"))
       reader.read(sel.savPriview);
+    else if(reader.setEntry("preview.jpg"))
+      reader.read(sel.savPriview);
     }
   catch(std::bad_alloc&) {
     return;

--- a/shader/CMakeLists.txt
+++ b/shader/CMakeLists.txt
@@ -197,6 +197,7 @@ add_shader(item.frag                 inventory/item.frag)
 
 add_shader(stash.frag                stash.frag)
 add_shader(bink.frag                 bink/bink.frag)
+add_shader(downscale.frag            downscale.frag)
 
 add_shader(direct_light.frag         lighting/direct_light.frag)
 add_shader(direct_light_sh.frag      lighting/direct_light.frag -DSHADOW_MAP)

--- a/shader/downscale.frag
+++ b/shader/downscale.frag
@@ -1,0 +1,22 @@
+#version 450
+
+layout(binding  = 0) uniform sampler2D src;
+layout(location = 0) out vec4 outColor;
+
+layout(push_constant, std140) uniform Push {
+  ivec2 dstSize;
+  };
+
+void main() {
+  ivec2 srcSize = textureSize(src, 0);
+
+  ivec2 tl = (ivec2(gl_FragCoord.xy+ivec2(0))*srcSize)/dstSize;
+  ivec2 br = (ivec2(gl_FragCoord.xy+ivec2(1))*srcSize)/dstSize;
+
+  vec4  color = vec4(0);
+  for(int i=tl.x; i<br.x; ++i)
+    for(int r=tl.y; r<br.y; ++r) {
+      color += texelFetch(src, ivec2(i,r), 0);
+      }
+  outColor = color/((br.x-tl.x)*(br.y-tl.y));
+  }


### PR DESCRIPTION
Hi folks,
I really like what you did here with this game porting! amazing work!
While playing it on my macos I noticed the save was taking quite a while. about 7 seconds each time. which was an issue for me since I save quite a lot..
I took a glimpse at the code this morning and after some testing I believe I found the culprit. It looks like the image preview saved in a saving slot is what causes this, as I'm running on a high resolution (3008*1692) and this creates a large pixel buffer taking about 30mb. So I went ahead and reduced the resolution size (to 640x480) to see if this will solve it and I think it did. The save is much faster now and it also got the load/save screen to load faster as the images it contains are smaller. To test this I replaced my existing saves by loading and re-saving them with the updated code.
I suppose this will affect those who run the game on high resolutions.
Feel free to review or use this PR as you see fit.
Regards, jairus.