### PR TITLE
fix compilation on gcc 16

### DIFF
--- a/game/dmusic/soundfont.h
+++ b/game/dmusic/soundfont.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+#include <cstdint>
 
 namespace Dx8 {
 


### PR DESCRIPTION
In the last 2 weeks I have upgraded Fedora which brought a newer GCC with it.

Avoids a set failures like this one:
```
In file included from /home/black_fox/src/OpenGothic/game/dmusic/wave.cpp:1:
/home/black_fox/src/OpenGothic/game/dmusic/soundfont.h:26:9: error: ‘uint8_t’ does not name a type
   26 |         uint8_t                   note=0;
      |         ^~~~~~~
/home/black_fox/src/OpenGothic/game/dmusic/soundfont.h:5:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
    4 | #include <vector>
  +++ |+#include <cstdint>
    5 | 
/home/black_fox/src/OpenGothic/game/dmusic/soundfont.h:37:42: error: ‘uint32_t’ has not been declared
   37 |     SoundFont(std::shared_ptr<Data> &sh, uint32_t dwPatch);
      |                                          ^~~~~~~~
/home/black_fox/src/OpenGothic/game/dmusic/soundfont.h:37:42: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/black_fox/src/OpenGothic/game/dmusic/soundfont.h:47:24: error: ‘uint8_t’ has not been declared
   47 |     Ticket      noteOn(uint8_t note, uint8_t velosity);
      |                        ^~~~~~~
/home/black_fox/src/OpenGothic/game/dmusic/soundfont.h:47:24: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/black_fox/src/OpenGothic/game/dmusic/soundfont.h:47:38: error: ‘uint8_t’ has not been declared
   47 |     Ticket      noteOn(uint8_t note, uint8_t velosity);
      |                                      ^~~~~~~
/home/black_fox/src/OpenGothic/game/dmusic/soundfont.h:47:38: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
```