### PR TITLE
Fix Gothic 1 underwater diving

### DIFF
--- a/game/camera.cpp
+++ b/game/camera.cpp
@@ -755,16 +755,15 @@ void Camera::tick(uint64_t dt) {
     auto  pl     = isFree() ? nullptr : world->player();
     auto& physic = *world->physic();
 
-    if(pl!=nullptr && pl->isSwim()) {
-      inWater = (angles.x < -8.f);
+    if(pl!=nullptr && (pl->isSwim() || pl->isDive())) {
+      inWater = pl->isDive();
       }
     else if(pl!=nullptr && (pl->isInAir() || pl->isJump()) && !pl->isDead()) {
       // NOTE: not quite correct
       inWater = physic.cameraRay(inter.target, origin).waterCol % 2;
       }
     else {
-      // NOTE: find a way to avoid persistent tracking
-      inWater = inWater ^ (physic.cameraRay(prev, origin).waterCol % 2);
+      inWater = physic.cameraRay(inter.target, origin).waterCol % 2;
       }
     }
   }

--- a/game/game/movealgo.cpp
+++ b/game/game/movealgo.cpp
@@ -819,6 +819,9 @@ void MoveAlgo::setState(State f) {
   if((f==Dive) && !(flags==Dive)) {
     npc.setDirectionY(-40);
     }
+  else if(flags==Dive && f!=Dive) {
+    npc.setDirectionY(0);
+    }
   if((f==Dive) != (flags==Dive)) {
     diveStart = npc.world().tickCount();
     }
@@ -1081,4 +1084,3 @@ std::string_view MoveAlgo::portalName() {
 std::string_view MoveAlgo::formerPortalName() {
   return formerPortal;
   }
-

--- a/game/graphics/renderer.cpp
+++ b/game/graphics/renderer.cpp
@@ -1591,6 +1591,10 @@ void Renderer::drawGWater(Encoder<CommandBuffer>& cmd, WorldView& view) {
   static bool water = true;
   if(!water)
     return;
+  if(auto camera = Gothic::inst().camera()) {
+    if(camera->isInWater())
+      return;
+    }
 
   cmd.setFramebuffer({{sceneLinear, Tempest::Preserve, Tempest::Preserve},
                       {gbufDiffuse, Vec4(0,0,0,0),     Tempest::Preserve},
@@ -1622,8 +1626,16 @@ void Renderer::drawReflections(Encoder<CommandBuffer>& cmd, const WorldView& wvi
   }
 
 void Renderer::drawUnderwater(Encoder<CommandBuffer>& cmd, const WorldView& wview) {
+  static const auto underwaterFrames = Resources::loadTextureAnim("UNDERWATER_A0.TGA");
+  const auto* underwater = &Resources::fallbackBlack();
+  if(!underwaterFrames.empty()) {
+    const auto now = Gothic::inst().world()!=nullptr ? Gothic::inst().world()->tickCount() : 0;
+    underwater = underwaterFrames[(now/120)%underwaterFrames.size()];
+    }
+
   cmd.setBinding(0, wview.sceneGlobals().uboGlobal[SceneGlobals::V_Main]);
   cmd.setBinding(1, zbuffer);
+  cmd.setBinding(2, *underwater, Sampler::bilinear(ClampMode::MirroredRepeat));
 
   cmd.setPipeline(shaders.underwaterT);
   cmd.draw(nullptr, 0, 3);
@@ -2309,4 +2321,3 @@ Size Renderer::internalResolution() const {
     return Size(int(3*swapchain.w()/4), int(3*swapchain.h()/4));
   return Size(int(swapchain.w()/2), int(swapchain.h()/2));
   }
-

--- a/game/mainwindow.cpp
+++ b/game/mainwindow.cpp
@@ -969,7 +969,7 @@ void MainWindow::tickCamera(uint64_t dt) {
       auto spin = camera.spin();
       if(pl->interactive()==nullptr && !pl->isDown())
         spin.y = pl->rotation();
-      if(pl->isDive() && !camera.isMarvin())
+      if(Gothic::inst().version().game!=1 && pl->isDive() && !camera.isMarvin())
         spin.x = -pl->rotationY();
       camera.setSpin(spin);
       camera.setTarget(pos);
@@ -1007,7 +1007,7 @@ Camera::Mode MainWindow::solveCameraMode() const {
     if(pl->isDead())
       return Camera::Death;
     if(pl->isDive())
-      return Camera::Dive;
+      return Gothic::inst().version().game==1 ? Camera::Swim : Camera::Dive;
     if(pl->isSwim())
       return Camera::Swim;
     if(pl->isFallingDeep())

--- a/shader/water/underwater.frag
+++ b/shader/water/underwater.frag
@@ -11,14 +11,57 @@ layout(binding = 0, std140) uniform UboScene {
   SceneDesc scene;
   };
 layout(binding = 1) uniform sampler2D zbuffer;
+layout(binding = 2) uniform sampler2D underwater;
+
+float hash21(vec2 p) {
+  p = fract(p*vec2(123.34,456.21));
+  p += dot(p,p+45.32);
+  return fract(p.x*p.y);
+  }
+
+float noise(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  vec2 u = f*f*(3.0-2.0*f);
+  return mix(mix(hash21(i+vec2(0,0)), hash21(i+vec2(1,0)), u.x),
+             mix(hash21(i+vec2(0,1)), hash21(i+vec2(1,1)), u.x), u.y);
+  }
+
+vec2 barrelUv(vec2 uv) {
+  vec2 p = uv*2.0-1.0;
+  float r2 = dot(p,p);
+  p *= 1.0 + r2*0.035;
+  return p*0.5+0.5;
+  }
+
+float caustics(vec2 uv, float t) {
+  vec2 p = uv*vec2(9.0,5.0);
+  float a = noise(p + vec2(t*0.65, t*0.21));
+  float b = noise(p*1.7 + vec2(-t*0.31, t*0.57));
+  float c = abs(a-b);
+  return smoothstep(0.34, 0.03, c) * 0.55;
+  }
+
+vec3 underwaterOverlay(vec2 uv, float t) {
+  vec2 wobble = vec2(noise(uv*5.0 + t), noise(uv*5.0 - t))*0.008;
+  vec2 uv0 = barrelUv(uv + wobble + vec2(t*0.025, -t*0.011));
+  vec2 uv1 = barrelUv(uv*1.43 - wobble + vec2(-t*0.017, t*0.031));
+
+  vec3 a = texture(underwater, uv0).rgb;
+  vec3 b = texture(underwater, uv1).rgb;
+  vec3 m = max(a,b*0.75);
+  return smoothstep(vec3(0.22), vec3(0.86), m);
+  }
 
 // fixme: copy-paste
 vec4 waterScatter(vec3 back, vec3 normal, const float len) {
-  const float depth         = len / 5000.0; // 50 meters
-  const vec3  transmittance = exp(-depth * vec3(4,2,1) * 1.25);
+  const float depth         = len / 7200.0;
+  const vec3  waterFloor    = vec3(0.10, 0.24, 0.42);
+  const vec3  transmittance = max(exp(-depth * vec3(4.2, 2.05, 0.62)), waterFloor);
 #if defined(SCATTERING)
   const float f       = fresnel(scene.sunDir,normal,IorWater);
-  const vec3  scatter = f * scene.sunColor * (1-exp(-len/20000.0)) * scene.exposure;
+  const vec3  scatter = vec3(0.004, 0.020, 0.032) * (1.0-exp(-len/8500.0)) +
+                        f * scene.sunColor * (1.0-exp(-len/22000.0)) * scene.exposure * 0.018;
   return vec4(scatter*transmittance, 1);
 #else
   return vec4(transmittance, 1);
@@ -31,12 +74,31 @@ vec3 unproject(vec4 screen) {
   }
 
 void main() {
-  const vec2  fragCoord = (gl_FragCoord.xy*scene.screenResInv)*2.0-vec2(1.0);
+  const vec2  uv        = gl_FragCoord.xy*scene.screenResInv;
+  const vec2  fragCoord = uv*2.0-vec2(1.0);
   const float depth     = texelFetch(zbuffer,  ivec2(gl_FragCoord.xy), 0).r;
 
   const vec3  camPos    = unproject(vec4(0,0,0, 1.0));
   const vec3  wPos      = unproject(vec4(fragCoord.x, fragCoord.y, depth, 1.0));
 
-  const float len = length(wPos-camPos);
-  outColor = waterScatter(vec3(1),vec3(0,1,0),len);
+  const float len = depth>=0.999999 ? 7000.0 : min(length(wPos-camPos), 18000.0);
+  vec4 color = waterScatter(vec3(1),vec3(0,1,0),len);
+  float t = float(scene.tickCount32) * 0.001;
+  float depth01 = clamp(len/9000.0, 0.0, 1.0);
+  float vignette = smoothstep(1.35, 0.26, length(uv*2.0-1.0));
+  vec3 overlay = underwaterOverlay(uv, t);
+  float cst = caustics(uv + overlay.xy*0.018, t);
+
+#if defined(SCATTERING)
+  color.rgb += overlay*vec3(0.0015,0.010,0.016);
+  color.rgb += cst*vec3(0.0015,0.010,0.014)*(1.0-depth01*0.7);
+#else
+  vec3 deepBlue = vec3(0.015, 0.14, 0.28);
+  vec3 textureShade = vec3(1.0) - overlay*vec3(0.12,0.09,0.04) - cst*vec3(0.03,0.02,0.01);
+  color.rgb = mix(color.rgb, deepBlue, depth01*0.18);
+  color.rgb *= textureShade;
+  color.rgb *= mix(0.55, 1.0, vignette);
+  color.rgb = clamp(color.rgb, vec3(0.055,0.16,0.28), vec3(0.86,0.92,1.0));
+#endif
+  outColor = color;
   }


### PR DESCRIPTION
Right now diving in Gothic 1 fully breaks the game and the screen goes black. Even going back up breaks it and the screen is still black.

Fixed it by:
- handling Gothic 1 diving with the swim camera instead of the Gothic 2 dive camera
- stopping the camera from following dive pitch in Gothic 1
- making underwater detection use the actual dive/swim state instead of getting stuck from previous camera checks
- resetting vertical dive movement when leaving dive mode
- not drawing the water surface while the camera is underwater
- adding the proper underwater overlay/texture pass so underwater view renders normally instead of blacking out

Basically, G1 and G2 handle diving differently, but we were treating G1 like G2. This PR separates that behavior and makes underwater movement/rendering work again in G1. 

Before:


https://github.com/user-attachments/assets/b27f1516-faa6-439d-9ee7-4f7493444f38


After:


https://github.com/user-attachments/assets/1ef6d7d5-1329-4e7b-ba11-e0d65b3efb8d

