### PR TITLE
fix(compatibility): include <unordered_map> where it is used

### DIFF
--- a/game/game/compatibility/cpu32.h
+++ b/game/game/compatibility/cpu32.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <functional>
 #include <string>
+#include <unordered_map>
 
 #include "mem32instances.h"
 

--- a/game/game/compatibility/mem32.h
+++ b/game/game/compatibility/mem32.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <functional>
 #include <type_traits>
+#include <unordered_map>
 
 #include <Tempest/Log>
 


### PR DESCRIPTION
libstdc++ includes unordered_map via functional.
libc++ does not. This causes compilation to fail on libc++ targets.