### PR TITLE
fix(compatibility): construct string_view by length, not by iterator pair

### DIFF
--- a/game/game/compatibility/directmemory.cpp
+++ b/game/game/compatibility/directmemory.cpp
@@ -1444,14 +1444,14 @@ void DirectMemory::setupWinapiFunctions() {
 
   cpu.register_stdcall(WINAPI__LOADLIBRARY, [this](ptr32_t pname) {
     auto [ptr, size] = mem32.deref(pname);
-    auto name = std::string_view(reinterpret_cast<const char*>(ptr), (size_t) size);
+    auto name = std::string_view(reinterpret_cast<const char*>(ptr), size_t(size));
     Log::d("suppress LoadLibrary: ", name);
     return 0x1;
     });
 
   cpu.register_stdcall(WINAPI__GETPROCADDRESS, [this](ptr32_t module, ptr32_t pname) {
     auto [ptr, size] = mem32.deref(pname);
-    auto name = std::string_view(reinterpret_cast<const char*>(ptr), (size_t) size);
+    auto name = std::string_view(reinterpret_cast<const char*>(ptr), size_t(size));
     Log::d("suppress GetProcAddress: ",name);
     return 0x1;
     });

--- a/game/game/compatibility/directmemory.cpp
+++ b/game/game/compatibility/directmemory.cpp
@@ -1444,14 +1444,14 @@ void DirectMemory::setupWinapiFunctions() {
 
   cpu.register_stdcall(WINAPI__LOADLIBRARY, [this](ptr32_t pname) {
     auto [ptr, size] = mem32.deref(pname);
-    auto name = std::string_view(reinterpret_cast<const char*>(ptr), reinterpret_cast<const char*>(ptr)+size);
+    auto name = std::string_view(reinterpret_cast<const char*>(ptr), (size_t) size);
     Log::d("suppress LoadLibrary: ", name);
     return 0x1;
     });
 
   cpu.register_stdcall(WINAPI__GETPROCADDRESS, [this](ptr32_t module, ptr32_t pname) {
     auto [ptr, size] = mem32.deref(pname);
-    auto name = std::string_view(reinterpret_cast<const char*>(ptr), reinterpret_cast<const char*>(ptr)+size);
+    auto name = std::string_view(reinterpret_cast<const char*>(ptr), (size_t) size);
     Log::d("suppress GetProcAddress: ",name);
     return 0x1;
     });


### PR DESCRIPTION
basic_string_view(It first, End last) is C++20 and libc++ 11 does not have it. The call fails with "no matching constructor".
The length form is C++17, exists in both libraries, and denotes the same view - ptr..ptr+size is a range of length size.