### PR TITLE
fix: removed unused Read::from

### DIFF
--- a/game/resources.cpp
+++ b/game/resources.cpp
@@ -155,7 +155,6 @@ void Resources::loadVdfs(const std::vector<std::u16string>& modvdfs, bool modFil
 
   for(auto& i:archives) {
     try {
-      auto in = zenkit::Read::from(i.name);
 #ifdef __IOS__
       // causes OOM on iPhone7
       if(i.name.find(u"Speech")!=std::string::npos)


### PR DESCRIPTION
`in` is never used, and `mount_disk` on the next line opens the same path anyway.

It costs a full read of every archive, discarded. In a Gothic 2 NotR installation that is 2.51 GiB, read and thrown away on every start. I only noticed this because PS4 was hanging when executing this call.