### PR TITLE
fix(sound): memset sizes the silence buffer with the wrong element type

### DIFF
--- a/game/gamemusic.cpp
+++ b/game/gamemusic.cpp
@@ -105,7 +105,7 @@ struct GameMusic::OpenGothicMusicProvider : GameMusic::MusicProvider {
 
   void renderSound(int16_t *out, size_t n) override {
     if(!isEnabled()) {
-      std::memset(out, 0, n * sizeof(int16_t) * 2);
+      std::memset(out, 0, n * sizeof(out[0]) * 2);
       return;
       }
     updateTheme();
@@ -239,7 +239,7 @@ struct GameMusic::GothicKitMusicProvider : GameMusic::MusicProvider {
 
   void renderSound(int16_t *out, size_t n) override {
     if(!isEnabled()) {
-      std::memset(out, 0, n * sizeof(int16_t) * 2);
+      std::memset(out, 0, n * sizeof(out[0]) * 2);
       return;
       }
     updateTheme();

--- a/game/gamemusic.cpp
+++ b/game/gamemusic.cpp
@@ -105,7 +105,7 @@ struct GameMusic::OpenGothicMusicProvider : GameMusic::MusicProvider {
 
   void renderSound(int16_t *out, size_t n) override {
     if(!isEnabled()) {
-      std::memset(out, 0, n * sizeof(int32_t) * 2);
+      std::memset(out, 0, n * sizeof(int16_t) * 2);
       return;
       }
     updateTheme();
@@ -239,7 +239,7 @@ struct GameMusic::GothicKitMusicProvider : GameMusic::MusicProvider {
 
   void renderSound(int16_t *out, size_t n) override {
     if(!isEnabled()) {
-      std::memset(out, 0, n * sizeof(int32_t) * 2);
+      std::memset(out, 0, n * sizeof(int16_t) * 2);
       return;
       }
     updateTheme();


### PR DESCRIPTION
The element size is settled by the format.
 Tempest declares: alBufferCallbackDirectSOFT is given AL_FORMAT_STEREO16 or AL_FORMAT_MONO16.