### PR TITLE
Extract gog assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,11 @@
 *.dylib
 *.dll
 
-# Executables
+# Binaries
 *.exe
 *.out
 *.app
+*.bin
 
 # IDE
 CMakeLists.txt.user*

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ OpenGothic is designed to utilize features of modern graphics hardware and APIs,
 
 #### Prerequisites
 
-Gothic 2: Night of the Raven is required as OpenGothic does not provide any built-in game assets or scripts.
+A copy of Gothic 2 is required as OpenGothic does not provide any built-in game assets or scripts. Both Gothic 2: Night of the Raven and the vanilla/classic "Gothic 2" (without the addon) are supported - use the `-g2` and `-g2c` command line flags respectively, see [Command line arguments](#command-line-arguments).
 
 Supported systems are:
 * Windows (DX12, Vulkan)
@@ -63,14 +63,23 @@ Supported systems are:
 
 ### MacOS
 1. If not already done, install Gothic 2. Instructions on how to obtain the game files can be found [here](https://macsourceports.com/faq#getgamedata). OpenGothic comes with automatic path detection if your Gothic files are in `"~/Library/Application Support/OpenGothic"`.
+
+   If you own the English GOG.com installer (`setup_*.exe` [+ `.bin`]) for Gothic 2 Gold, you can extract the classic (no addon) game data directly on macOS/Linux, without Wine, using [innoextract](https://constexpr.org/innoextract/):
+   ```bash
+   brew install innoextract
+   scripts/extract-gog-assets.sh /path/to/setup_gothic_2_*.exe
+   ```
+   This extracts the game data into `~/Library/Application Support/OpenGothic` (pass a second argument to use a different destination).
 2. Download a build from [Mac Source Ports](https://macsourceports.com/game/gothic2) and follow the installation instructions given there.
-   Alternatively, recent test builds are available from [CI](https://github.com/Try/OpenGothic/actions?query=build.yml?query=branch%3Amaster) and can be extracted into a folder of your choice. You can compile a fresh build as well.
-3. Run `Gothic2Notr.sh`
+   Alternatively, recent test builds are available from [CI](https://github.com/Try/OpenGothic/actions?query=build.yml?query=branch%3Amaster) and can be extracted into a folder of your choice. You can compile a fresh build as well, see [Build Instructions](#macos-1).
+3. Run `Gothic2Notr.sh`.
 
    If OpenGothic fails to find your Gothic 2 files, you have to explicitly specify its location via `-g` parameter.
    Change the line `exec "$DIR/Gothic2Notr" "$@"` to reflect your Gothic 2 path e.g.
 
-   `exec "$DIR/Gothic2Notr" "$@" -g "~/PlayOnLinux's virtual drives/Gothic2_gog/drive_c/Gothic II"`
+   `exec "$DIR/Gothic2Notr" "$@" -g2c -g "~/PlayOnLinux's virtual drives/Gothic2_gog/drive_c/Gothic II"`
+
+   The `-g2c` flag tells OpenGothic to expect the classic (no addon) game data extracted above.
 
 ---
 ### Modifications

--- a/scripts/extract-gog-assets.sh
+++ b/scripts/extract-gog-assets.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Extract Gothic 2 Classic (English, no addon) game data from the GOG.com
+# installer, without needing Wine. Requires innoextract:
+#   macOS: brew install innoextract
+#   Debian/Ubuntu: sudo apt install innoextract
+#   Arch: sudo pacman -S innoextract
+#
+# Usage:
+#   scripts/extract-gog-assets.sh <path-to-setup_gothic_2_*.exe> [destination-dir]
+#
+# If the installer is split into a .exe and a .bin, point this at the .exe;
+# innoextract picks up the matching .bin automatically.
+#
+# Default destination:
+#   macOS:  ~/Library/Application Support/OpenGothic  (auto-detected by OpenGothic)
+#   Other:  ~/.local/share/OpenGothic
+
+set -eu
+
+if [ "${1:-}" = "" ]; then
+  echo "usage: $0 <path-to-setup_gothic_2_*.exe> [destination-dir]" >&2
+  exit 1
+fi
+INSTALLER="$1"
+
+if [ "${2:-}" != "" ]; then
+  DEST="$2"
+elif [ "$(uname)" = "Darwin" ]; then
+  DEST="$HOME/Library/Application Support/OpenGothic"
+else
+  DEST="$HOME/.local/share/OpenGothic"
+fi
+
+if ! command -v innoextract >/dev/null 2>&1; then
+  echo "innoextract not found. Install it first (e.g. 'brew install innoextract')." >&2
+  exit 1
+fi
+
+mkdir -p "$DEST"
+
+echo "Extracting Gothic game data from '$INSTALLER' into '$DEST'..."
+innoextract -e -m -g \
+  -I "Data" -I "System/Gothic.INI" \
+  -d "$DEST" \
+  "$INSTALLER"
+
+# innoextract preserves the installer's original file casing (e.g.
+# "System/Gothic.INI"). OpenGothic looks up "system/Gothic.ini" and on a
+# case-sensitive filesystem that lookup can fail, so normalize it.
+sysdir=$(find "$DEST" -mindepth 1 -maxdepth 1 -iname 'system' -type d | head -n1)
+if [ -n "$sysdir" ] && [ "$(basename "$sysdir")" != "system" ]; then
+  mv "$sysdir" "$DEST/system"
+fi
+
+if [ -d "$DEST/system" ]; then
+  ini=$(find "$DEST/system" -mindepth 1 -maxdepth 1 -iname 'gothic.ini' -type f | head -n1)
+  if [ -n "$ini" ] && [ "$(basename "$ini")" != "Gothic.ini" ]; then
+    mv "$ini" "$DEST/system/Gothic.ini"
+  fi
+fi
+
+# innoextract also creates an empty "app/" placeholder dir - not part of the
+# actual game layout.
+rm -rf "$DEST/app"
+
+echo "Done. Game data is ready at: $DEST"
+echo "Run OpenGothic with: -g \"$DEST\" -g2c"


### PR DESCRIPTION
This PR enables extraction of Gothic 2 Vanilla Assets from **2.7 Vanilla OpenGothic 1.0.3010 GOG**
With the script, Users can extract G2 Classic Assets and use it for builds on other platforms such as macOS and Linux.
Furthermore, new versions of OpenGothic Vanilla on Windows can be created.