### PR TITLE
Handle DirectMusic loader creation failures safely

### DIFF
--- a/common/resources.cpp
+++ b/common/resources.cpp
@@ -98,9 +98,10 @@ Resources::Resources(Tempest::Device &device)
   DmResult rv = DmLoader_create(&dmLoader, DmLoader_DOWNLOAD);
   if(rv != DmResult_SUCCESS) {
     Log::e("Failed to created DmLoader object. Out of memory?");
+    dmLoader = nullptr;
     }
-
-  DmLoader_addResolver(dmLoader, [](void* ctx, char const* name, size_t* len) -> void* {
+  else {
+    DmLoader_addResolver(dmLoader, [](void* ctx, char const* name, size_t* len) -> void* {
       auto* slf = reinterpret_cast<Resources*>(ctx);
       auto* node = slf->gothicAssets.find(name);
 
@@ -118,7 +119,8 @@ Resources::Resources(Tempest::Device &device)
       reader->read(bytes, *len);
 
       return bytes;
-  }, this);
+    }, this);
+    }
   }
 
 void Resources::mountWork(const std::filesystem::path& path) {


### PR DESCRIPTION
When DirectMusic loader initialization fails, `DmLoader_create` can free its allocation while leaving the output pointer non-null. OpenGothic then passes that dangling pointer to `DmLoader_addResolver` and later `DmLoader_release`.

Clear the pointer on failure and register the resolver only after successful initialization. This prevents use-after-free during startup and shutdown.

Found while investigating a Gothic 1 crash on Quit: loader initialization failed, and shutdown crashed while destroying the VFS tree. The change eliminated that native crash in the Android build. It affects shared resource initialization and requires no Android code.
