### PR TITLE
Restore Ikarus runtime bindings after loading a save

### DIFF
--- a/common/game/gamescript.h
+++ b/common/game/gamescript.h
@@ -75,6 +75,8 @@ class GameScript final {
     void         savePerc(Serialize& fout);
     void         loadPerc(Serialize& fin);
 
+    bool         usesMemoryExtensions() const { return dma!=nullptr; }
+
     inline auto& getVm() { return vm; }
     auto         questLog() const -> const QuestLog&;
 

--- a/common/game/gamesession.cpp
+++ b/common/game/gamesession.cpp
@@ -165,6 +165,11 @@ GameSession::GameSession(Serialize &fin) {
   if(auto hero = wrld->player())
     vm->setInstanceNPC("HERO",*hero);
 
+  // Saved variables do not restore Ikarus's transient parser and engine bindings.
+  // Reconnect those without replaying gameplay initialization or resetting NPC routines.
+  if(vm->usesMemoryExtensions())
+    vm->getVm().call_function("MEM_InitAll");
+
   fin.setEntry("game/camera");
   cam->load(fin,wrld->player());
   Gothic::inst().setLoadingProgress(96);


### PR DESCRIPTION
Loading a save restores script variables but leaves Ikarus's transient parser and engine bindings uninitialized.

Reproduced with Archolos: dialogue and facial-animation calls work in a new game, then fail after saving and reloading with `MEM_GetFuncID: Unresolvable request` and an out-of-bounds access to `MOB_CREATEITEMS.PAR1`.

Call `MEM_InitAll` after restoring variables and `HERO`, only for scripts using Ikarus. This does not rerun gameplay initialization, reset NPC routines, or change the save format.

Verified on Windows using the same save and `AI_ResetFaceAni` call before and after the fix. The call failed before and completed without those errors afterward. Windows and Android ARM64 release builds passed on the development branch before extracting this fix.